### PR TITLE
feat(runtime): add fail-closed Firecracker runtime driver skeleton

### DIFF
--- a/api/v1alpha2/sandboxpool_types.go
+++ b/api/v1alpha2/sandboxpool_types.go
@@ -7,7 +7,7 @@ import (
 )
 
 // RuntimeName is the canonical runtime profile selected by a SandboxPool.
-// +kubebuilder:validation:Enum=container;gvisor;kata-qemu;kata-clh;kata-fc;kata-dragonball;boxlite
+// +kubebuilder:validation:Enum=container;gvisor;kata-qemu;kata-clh;kata-fc;kata-dragonball;boxlite;firecracker
 type RuntimeName string
 
 const (
@@ -25,6 +25,8 @@ const (
 	RuntimeKataDragonball RuntimeName = "kata-dragonball"
 	// RuntimeBoxLite uses the BoxLite microVM runtime driver.
 	RuntimeBoxLite RuntimeName = "boxlite"
+	// RuntimeFirecracker uses the direct Firecracker microVM runtime driver.
+	RuntimeFirecracker RuntimeName = "firecracker"
 )
 
 // SandboxResourceProfile defines the fixed resource limit for every Sandbox in

--- a/api/v1alpha2/validation.go
+++ b/api/v1alpha2/validation.go
@@ -24,7 +24,7 @@ var sha256Pattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
 // IsRuntimeName reports whether name identifies a built-in runtime profile.
 func IsRuntimeName(name RuntimeName) bool {
 	switch name {
-	case RuntimeContainer, RuntimeGVisor, RuntimeKataQemu, RuntimeKataClh, RuntimeKataFc, RuntimeKataDragonball, RuntimeBoxLite:
+	case RuntimeContainer, RuntimeGVisor, RuntimeKataQemu, RuntimeKataClh, RuntimeKataFc, RuntimeKataDragonball, RuntimeBoxLite, RuntimeFirecracker:
 		return true
 	default:
 		return false

--- a/api/v1alpha2/validation_test.go
+++ b/api/v1alpha2/validation_test.go
@@ -10,6 +10,7 @@ import (
 func TestValidateRuntime(t *testing.T) {
 	require.NoError(t, (&SandboxPoolSpec{Runtime: RuntimeKataFc}).ValidateRuntime())
 	require.NoError(t, (&SandboxPoolSpec{Runtime: RuntimeKataDragonball}).ValidateRuntime())
+	require.NoError(t, (&SandboxPoolSpec{Runtime: RuntimeFirecracker}).ValidateRuntime())
 	require.Error(t, (&SandboxPoolSpec{}).ValidateRuntime())
 	require.Error(t, (&SandboxPoolSpec{Runtime: RuntimeName("unknown")}).ValidateRuntime())
 }

--- a/config/crd/sandbox.fast.io_sandboxpools.yaml
+++ b/config/crd/sandbox.fast.io_sandboxpools.yaml
@@ -240,6 +240,7 @@ spec:
                 - kata-fc
                 - kata-dragonball
                 - boxlite
+                - firecracker
                 type: string
                 x-kubernetes-validations:
                 - message: runtime is immutable

--- a/internal/catalog/runtime/builtin.go
+++ b/internal/catalog/runtime/builtin.go
@@ -73,6 +73,30 @@ func builtinProfiles() map[apiv1alpha2.RuntimeName]RuntimeProfile {
 			NetworkMode:        NetworkModeBoxLite,
 			InfraDeliveryModes: []InfraDeliveryMode{InfraDeliveryTemplateBake, InfraDeliveryPreinstalled, InfraDeliveryArtifactVolume},
 		},
+		apiv1alpha2.RuntimeFirecracker: withResidualProcess(
+			RuntimeProfile{
+				Name: apiv1alpha2.RuntimeFirecracker, Version: builtinProfileVersion, Driver: DriverKindFirecracker,
+				Firecracker: &FirecrackerConfig{
+					BinaryPath: "/usr/local/bin/firecracker", KernelPath: "/opt/fast-sandbox/firecracker/vmlinux.bin",
+					RootfsPath: "/var/lib/fast-sandbox/firecracker/rootfs", StateRoot: "/var/lib/fast-sandbox/firecracker",
+					DefaultVCPUs: 1, DefaultMemory: "512Mi", BootTimeoutSeconds: 30,
+				},
+				Deployment: DeploymentRequirements{
+					Privileged: true, RequiresKVM: true, Overhead: overhead("250m", "256Mi"),
+					HostPaths: append([]HostPathRequirement{
+						{Name: "dev-kvm", HostPath: "/dev/kvm", MountPath: "/dev/kvm", Type: corev1.HostPathCharDev},
+						{Name: "firecracker-bin", HostPath: "/usr/local/bin/firecracker", MountPath: "/usr/local/bin/firecracker", Type: corev1.HostPathFile, ReadOnly: true},
+						{Name: "firecracker-kernel", HostPath: "/opt/fast-sandbox/firecracker/vmlinux.bin", MountPath: "/opt/fast-sandbox/firecracker/vmlinux.bin", Type: corev1.HostPathFile, ReadOnly: true},
+						{Name: "firecracker-rootfs", HostPath: "/var/lib/fast-sandbox/firecracker/rootfs", MountPath: "/var/lib/fast-sandbox/firecracker/rootfs", Type: corev1.HostPathDirectoryOrCreate},
+						{Name: "firecracker-state", HostPath: "/var/lib/fast-sandbox/firecracker", MountPath: "/var/lib/fast-sandbox/firecracker", Type: corev1.HostPathDirectoryOrCreate},
+					}, linuxNetworkPaths...),
+				},
+				Capabilities:       Capabilities{DefaultState: CapabilityUnsupported, SupportsNetwork: true, SupportsRecovery: true, Reason: "FirecrackerDriverUnimplemented"},
+				NetworkMode:        NetworkModeGuestNetNS,
+				InfraDeliveryModes: []InfraDeliveryMode{InfraDeliveryTemplateBake, InfraDeliveryPreinstalled, InfraDeliveryGuestCopy},
+			},
+			ResidualProcessFirecracker,
+		),
 	}
 }
 

--- a/internal/catalog/runtime/catalog.go
+++ b/internal/catalog/runtime/catalog.go
@@ -21,6 +21,7 @@ type DriverKind string
 const (
 	DriverKindContainerd DriverKind = "containerd"
 	DriverKindBoxLite    DriverKind = "boxlite"
+	DriverKindFirecracker DriverKind = "firecracker"
 )
 
 type NetworkMode string
@@ -86,6 +87,20 @@ type BoxLiteConfig struct {
 	DefaultMemory   string `json:"defaultMemory"`
 }
 
+// FirecrackerConfig carries the platform-owned paths and defaults for the
+// direct Firecracker runtime driver. The driver boots one Firecracker
+// microVM on demand for every Sandbox create request; nothing is pre-warmed.
+type FirecrackerConfig struct {
+	BinaryPath      string `json:"binaryPath"`
+	JailerPath      string `json:"jailerPath,omitempty"`
+	KernelPath      string `json:"kernelPath"`
+	RootfsPath      string `json:"rootfsPath"`
+	StateRoot       string `json:"stateRoot"`
+	DefaultVCPUs    int32  `json:"defaultVCPUs"`
+	DefaultMemory   string `json:"defaultMemory"`
+	BootTimeoutSeconds int32 `json:"bootTimeoutSeconds"`
+}
+
 type HostPathRequirement struct {
 	Name             string                      `json:"name"`
 	HostPath         string                      `json:"hostPath"`
@@ -123,6 +138,7 @@ type RuntimeDefinition struct {
 	Driver             DriverKind              `json:"driver"`
 	Containerd         *ContainerdConfig       `json:"containerd,omitempty"`
 	BoxLite            *BoxLiteConfig          `json:"boxlite,omitempty"`
+	Firecracker        *FirecrackerConfig      `json:"firecracker,omitempty"`
 	Deployment         DeploymentRequirements  `json:"deployment"`
 	Capabilities       Capabilities            `json:"capabilities"`
 	NetworkMode        NetworkMode             `json:"networkMode"`
@@ -236,6 +252,10 @@ func cloneProfile(profile RuntimeProfile) RuntimeProfile {
 	if profile.BoxLite != nil {
 		value := *profile.BoxLite
 		clone.BoxLite = &value
+	}
+	if profile.Firecracker != nil {
+		value := *profile.Firecracker
+		clone.Firecracker = &value
 	}
 	clone.Deployment.NodeSelector = cloneStringMap(profile.Deployment.NodeSelector)
 	clone.Deployment.HostPaths = append([]HostPathRequirement(nil), profile.Deployment.HostPaths...)

--- a/internal/catalog/runtime/catalog_test.go
+++ b/internal/catalog/runtime/catalog_test.go
@@ -16,6 +16,7 @@ func TestBuiltinCatalogProfiles(t *testing.T) {
 	expectedNames := []apiv1alpha2.RuntimeName{
 		apiv1alpha2.RuntimeBoxLite,
 		apiv1alpha2.RuntimeContainer,
+		apiv1alpha2.RuntimeFirecracker,
 		apiv1alpha2.RuntimeGVisor,
 		apiv1alpha2.RuntimeKataClh,
 		apiv1alpha2.RuntimeKataDragonball,
@@ -62,6 +63,20 @@ func TestBuiltinCatalogProfiles(t *testing.T) {
 	require.Equal(t, "/opt/kata/runtime-rs/bin/containerd-shim-kata-v2", dragonball.Containerd.RuntimePath)
 	require.Contains(t, dragonball.Containerd.ConfigPath, "configuration-dragonball.toml")
 
+	firecracker, err := catalog.Resolve(apiv1alpha2.RuntimeFirecracker)
+	require.NoError(t, err)
+	require.Equal(t, DriverKindFirecracker, firecracker.Driver)
+	require.Equal(t, CapabilityUnsupported, firecracker.Capabilities.DefaultState)
+	require.Equal(t, "FirecrackerDriverUnimplemented", firecracker.Capabilities.Reason)
+	require.Equal(t, ResidualProcessFirecracker, firecracker.ResidualProcess)
+	require.True(t, firecracker.Deployment.RequiresKVM)
+	require.True(t, hasHostPath(firecracker.Deployment.HostPaths, "/dev/kvm"))
+	require.True(t, hasHostPath(firecracker.Deployment.HostPaths, "/usr/local/bin/firecracker"))
+	require.Equal(t, "/usr/local/bin/firecracker", firecracker.Firecracker.BinaryPath)
+	require.Equal(t, "/opt/fast-sandbox/firecracker/vmlinux.bin", firecracker.Firecracker.KernelPath)
+	require.Equal(t, int32(1), firecracker.Firecracker.DefaultVCPUs)
+	require.Equal(t, "512Mi", firecracker.Firecracker.DefaultMemory)
+
 	for _, name := range []apiv1alpha2.RuntimeName{apiv1alpha2.RuntimeKataQemu, apiv1alpha2.RuntimeKataClh, apiv1alpha2.RuntimeKataDragonball} {
 		kataProfile, resolveErr := catalog.Resolve(name)
 		require.NoError(t, resolveErr)
@@ -93,6 +108,7 @@ func TestRuntimeProfilesUsingFastletNetworkHaveRequiredMounts(t *testing.T) {
 		apiv1alpha2.RuntimeKataClh,
 		apiv1alpha2.RuntimeKataDragonball,
 		apiv1alpha2.RuntimeKataFc,
+		apiv1alpha2.RuntimeFirecracker,
 	} {
 		profile, err := catalog.Resolve(name)
 		require.NoError(t, err)

--- a/internal/runtime/factory/capability.go
+++ b/internal/runtime/factory/capability.go
@@ -82,6 +82,22 @@ func (p *HostCapabilityProber) Probe(_ context.Context, profile runtimecatalog.R
 			break
 		}
 		p.requirePath(&report, profile.BoxLite.ControlSocket, "BoxLiteSidecarUnavailable")
+	case runtimecatalog.DriverKindFirecracker:
+		if profile.Firecracker == nil {
+			p.missing(&report, "firecracker runtime configuration", "RuntimeProfileInvalid")
+			break
+		}
+		if profile.Firecracker.BinaryPath == "" || profile.Firecracker.KernelPath == "" || profile.Firecracker.RootfsPath == "" || profile.Firecracker.StateRoot == "" {
+			p.missing(&report, "firecracker runtime paths", "RuntimeProfileInvalid")
+			break
+		}
+		if profile.Firecracker.DefaultVCPUs < 1 || profile.Firecracker.DefaultMemory == "" || profile.Firecracker.BootTimeoutSeconds < 1 {
+			p.missing(&report, "firecracker boot profile", "RuntimeProfileInvalid")
+			break
+		}
+		p.requirePath(&report, profile.Firecracker.BinaryPath, "RuntimeBinaryUnavailable")
+		p.requirePath(&report, profile.Firecracker.KernelPath, "RuntimeKernelUnavailable")
+		p.requirePath(&report, profile.Firecracker.StateRoot, "RuntimeStateRootUnavailable")
 	default:
 		p.missing(&report, string(profile.Driver), "RuntimeDriverUnsupported")
 	}

--- a/internal/runtime/factory/capability_test.go
+++ b/internal/runtime/factory/capability_test.go
@@ -11,6 +11,7 @@ import (
 	runtimecatalog "fast-sandbox/internal/catalog/runtime"
 	boxlitedriver "fast-sandbox/internal/runtime/boxlite/driver"
 	"fast-sandbox/internal/runtime/containerd"
+	firecrackerdriver "fast-sandbox/internal/runtime/firecracker"
 
 	"github.com/stretchr/testify/require"
 )
@@ -35,6 +36,12 @@ func TestHostCapabilityProberFailsClosed(t *testing.T) {
 	require.Equal(t, runtimecatalog.CapabilityUnsupported, report.State)
 	require.Equal(t, "BoxLiteResourceEnforcementIncomplete", report.Reason)
 
+	firecracker, err := catalog.Resolve(apiv1alpha2.RuntimeFirecracker)
+	require.NoError(t, err)
+	report = NewHostCapabilityProber().Probe(context.Background(), firecracker, "")
+	require.Equal(t, runtimecatalog.CapabilityUnsupported, report.State)
+	require.Equal(t, "FirecrackerDriverUnimplemented", report.Reason)
+
 	kata, err := catalog.Resolve(apiv1alpha2.RuntimeKataQemu)
 	require.NoError(t, err)
 	prober := NewHostCapabilityProber()
@@ -54,6 +61,26 @@ func TestHostCapabilityProberAcceptsConfiguredFirecrackerProfile(t *testing.T) {
 	report := prober.Probe(context.Background(), profile, "/run/containerd/containerd.sock")
 	require.Equal(t, runtimecatalog.CapabilityAvailable, report.State)
 	require.Empty(t, report.Missing)
+}
+
+func TestHostCapabilityProberFirecrackerDriverGate(t *testing.T) {
+	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
+	require.NoError(t, err)
+	prober := NewHostCapabilityProber()
+	prober.stat = func(string) (os.FileInfo, error) { return fakeFileInfo{}, nil }
+	report := prober.Probe(context.Background(), profile, "")
+	require.Equal(t, runtimecatalog.CapabilityUnsupported, report.State)
+	require.Equal(t, "FirecrackerDriverUnimplemented", report.Reason)
+
+	profile.Capabilities.DefaultState = runtimecatalog.CapabilityConfigured
+	report = prober.Probe(context.Background(), profile, "")
+	require.Equal(t, runtimecatalog.CapabilityAvailable, report.State)
+	require.Empty(t, report.Missing)
+
+	profile.Firecracker.BootTimeoutSeconds = 0
+	report = prober.Probe(context.Background(), profile, "")
+	require.Equal(t, runtimecatalog.CapabilityDegraded, report.State)
+	require.Equal(t, "RuntimeProfileInvalid", report.Reason)
 }
 
 func TestHostCapabilityProberRequiresFastSandboxCLHCgroupMode(t *testing.T) {
@@ -99,4 +126,10 @@ func TestBuildRuntimeDriverSelection(t *testing.T) {
 	driver, err = buildDriver(boxlite)
 	require.NoError(t, err)
 	require.IsType(t, &boxlitedriver.Driver{}, driver)
+
+	firecracker, err := catalog.Resolve(apiv1alpha2.RuntimeFirecracker)
+	require.NoError(t, err)
+	driver, err = buildDriver(firecracker)
+	require.NoError(t, err)
+	require.IsType(t, &firecrackerdriver.Driver{}, driver)
 }

--- a/internal/runtime/factory/factory.go
+++ b/internal/runtime/factory/factory.go
@@ -8,6 +8,7 @@ import (
 	runtimecatalog "fast-sandbox/internal/catalog/runtime"
 	boxlitedriver "fast-sandbox/internal/runtime/boxlite/driver"
 	"fast-sandbox/internal/runtime/containerd"
+	firecrackerdriver "fast-sandbox/internal/runtime/firecracker"
 )
 
 type Factory struct {
@@ -69,6 +70,8 @@ func buildDriver(profile runtimecatalog.RuntimeProfile) (RuntimeDriver, error) {
 		return containerd.New(profile)
 	case runtimecatalog.DriverKindBoxLite:
 		return boxlitedriver.New(profile)
+	case runtimecatalog.DriverKindFirecracker:
+		return firecrackerdriver.New(profile)
 	default:
 		return nil, fmt.Errorf("%w: driver kind %q", ErrUnsupportedRuntime, profile.Driver)
 	}

--- a/internal/runtime/firecracker/contract.go
+++ b/internal/runtime/firecracker/contract.go
@@ -1,0 +1,17 @@
+package firecracker
+
+import runtimecontract "fast-sandbox/internal/runtime/contract"
+
+type SandboxMetadata = runtimecontract.Metadata
+type CapabilityReport = runtimecontract.CapabilityReport
+type RuntimeDriver = runtimecontract.Driver
+type RuntimeArtifactCache = runtimecontract.ArtifactCache
+type RuntimeResourceRecoverer = runtimecontract.ResourceRecoverer
+type AccessDescriptorProvider = runtimecontract.AccessDescriptorProvider
+
+var (
+	ErrInvalidConfig      = runtimecontract.ErrInvalidConfig
+	ErrNetworkUnavailable = runtimecontract.ErrNetworkUnavailable
+)
+
+var validateExistingRuntimeProfile = runtimecontract.ValidateProfile

--- a/internal/runtime/firecracker/doc.go
+++ b/internal/runtime/firecracker/doc.go
@@ -1,0 +1,16 @@
+// Package firecracker implements the direct Firecracker runtime driver for
+// Fastlet. It is the runtime-neutral Driver contract implementation behind
+// the built-in "firecracker" SandboxPool runtime.
+//
+// The driver boots one Firecracker microVM on demand for every Sandbox create
+// request: nothing is pre-warmed and no sidecar daemon stays resident.
+// Firecracker is launched as a plain child process with an immutable
+// per-Sandbox identity, which matches the NodeJanitor residual-process
+// cleanup contract (ResidualProcessFirecracker, binary "firecracker" and
+// "--id" matching).
+//
+// The built-in profile currently fails closed with
+// CapabilityUnsupported/FirecrackerDriverUnimplemented. The lifecycle
+// implementation lands behind this gate; until the profile gate is enabled,
+// the HostCapabilityProber rejects the runtime before any driver is built.
+package firecracker

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -1,0 +1,143 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	runtimecatalog "fast-sandbox/internal/catalog/runtime"
+	dataplane "fast-sandbox/internal/dataplane/contract"
+	fastletapi "fast-sandbox/internal/protocol/fastlet"
+)
+
+// reasonUnimplemented is the capability gate reason that keeps the driver
+// fail-closed until the Firecracker VM lifecycle implementation lands.
+const reasonUnimplemented = "FirecrackerDriverUnimplemented"
+
+// errLifecycleUnimplemented is returned by every VM lifecycle operation while
+// the driver is still a framework-only skeleton.
+var errLifecycleUnimplemented = errors.New("firecracker runtime driver lifecycle is not implemented")
+
+// Driver is the on-demand Firecracker microVM runtime driver. One Firecracker
+// process is launched per Sandbox create request with an immutable identity;
+// no VM or sidecar is pre-warmed. The VM lifecycle implementation is pending
+// behind the FirecrackerDriverUnimplemented capability gate.
+type Driver struct {
+	mu          sync.RWMutex
+	profile     runtimecatalog.RuntimeProfile
+	config      runtimecatalog.FirecrackerConfig
+	namespace   string
+	initialized bool
+}
+
+// New validates that the resolved runtime profile carries the private
+// Firecracker configuration and returns the driver skeleton.
+func New(profile runtimecatalog.RuntimeProfile) (*Driver, error) {
+	if profile.Firecracker == nil {
+		return nil, fmt.Errorf("firecracker runtime profile %q has no private configuration", profile.Name)
+	}
+	return &Driver{profile: profile, config: *profile.Firecracker}, nil
+}
+
+// Initialize validates the Firecracker boot configuration. The concrete boot
+// preparation (kernel/rootfs readiness, API socket placement) is part of the
+// lifecycle implementation.
+func (d *Driver) Initialize(_ context.Context, _ string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.initialized {
+		return nil
+	}
+	if err := validateConfig(d.config); err != nil {
+		return err
+	}
+	d.initialized = true
+	return nil
+}
+
+func validateConfig(config runtimecatalog.FirecrackerConfig) error {
+	if config.BinaryPath == "" || config.KernelPath == "" || config.RootfsPath == "" || config.StateRoot == "" {
+		return fmt.Errorf("%w: firecracker binary, kernel, rootfs, and state root are required", ErrInvalidConfig)
+	}
+	if config.DefaultVCPUs < 1 || config.DefaultMemory == "" || config.BootTimeoutSeconds < 1 {
+		return fmt.Errorf("%w: firecracker boot profile requires vCPUs, memory, and boot timeout", ErrInvalidConfig)
+	}
+	return nil
+}
+
+// SetNamespace records the Fastlet namespace that owns the managed Sandboxes.
+func (d *Driver) SetNamespace(namespace string) {
+	d.mu.Lock()
+	d.namespace = namespace
+	d.mu.Unlock()
+}
+
+// ProbeCapabilities fails closed until the lifecycle implementation reports a
+// concrete runtime capability report.
+func (d *Driver) ProbeCapabilities(_ context.Context) CapabilityReport {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return CapabilityReport{
+		Runtime: d.profile.Name, ProfileHash: d.profile.ProfileHash,
+		State: runtimecatalog.CapabilityUnsupported, Reason: reasonUnimplemented,
+		Message: "firecracker runtime driver lifecycle is not implemented yet",
+	}
+}
+
+// EnsureSandbox boots one Firecracker microVM on demand for the Sandbox. The
+// boot implementation is pending.
+func (d *Driver) EnsureSandbox(_ context.Context, _ *fastletapi.SandboxSpec) (*SandboxMetadata, error) {
+	return nil, errLifecycleUnimplemented
+}
+
+// InspectSandbox reports the metadata of a managed Firecracker microVM.
+func (d *Driver) InspectSandbox(_ context.Context, _ string) (*SandboxMetadata, error) {
+	return nil, errLifecycleUnimplemented
+}
+
+// DeleteSandbox stops and removes the Firecracker microVM of the Sandbox.
+func (d *Driver) DeleteSandbox(_ context.Context, _ string) error {
+	return errLifecycleUnimplemented
+}
+
+// ListManagedSandboxes lists the Sandboxes owned by this Fastlet.
+func (d *Driver) ListManagedSandboxes(_ context.Context) ([]*SandboxMetadata, error) {
+	return nil, errLifecycleUnimplemented
+}
+
+// RecoverRuntimeResources reattaches Fastlet to VMs that survived a Fastlet
+// restart.
+func (d *Driver) RecoverRuntimeResources(_ context.Context, _ []*SandboxMetadata) error {
+	return errLifecycleUnimplemented
+}
+
+// GetAccessDescriptor returns the data-plane access descriptor for a Sandbox.
+func (d *Driver) GetAccessDescriptor(_ string) (dataplane.AccessDescriptor, error) {
+	return dataplane.AccessDescriptor{}, fmt.Errorf("%w: firecracker access descriptors are not implemented", ErrNetworkUnavailable)
+}
+
+// ListImages lists the images cached by the Firecracker artifact cache.
+func (d *Driver) ListImages(_ context.Context) ([]string, error) {
+	return nil, errLifecycleUnimplemented
+}
+
+// PullImage caches an image for later Firecracker rootfs preparation.
+func (d *Driver) PullImage(_ context.Context, _ string) error {
+	return errLifecycleUnimplemented
+}
+
+// Close resets the driver state.
+func (d *Driver) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.initialized = false
+	return nil
+}
+
+var (
+	_ RuntimeDriver            = (*Driver)(nil)
+	_ RuntimeArtifactCache     = (*Driver)(nil)
+	_ RuntimeResourceRecoverer = (*Driver)(nil)
+	_ AccessDescriptorProvider = (*Driver)(nil)
+)

--- a/internal/runtime/firecracker/driver_test.go
+++ b/internal/runtime/firecracker/driver_test.go
@@ -1,0 +1,88 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apiv1alpha2 "fast-sandbox/api/v1alpha2"
+	runtimecatalog "fast-sandbox/internal/catalog/runtime"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRequiresProfileConfig(t *testing.T) {
+	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
+	require.NoError(t, err)
+	require.NotNil(t, profile.Firecracker)
+
+	profile.Firecracker = nil
+	_, err = New(profile)
+	require.Error(t, err)
+}
+
+func TestInitializeValidatesBootConfig(t *testing.T) {
+	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
+	require.NoError(t, err)
+
+	driver, err := New(profile)
+	require.NoError(t, err)
+	require.NoError(t, driver.Initialize(context.Background(), ""))
+	require.NoError(t, driver.Initialize(context.Background(), ""))
+
+	broken, err := New(profile)
+	require.NoError(t, err)
+	broken.config.BinaryPath = ""
+	require.ErrorIs(t, broken.Initialize(context.Background(), ""), ErrInvalidConfig)
+
+	invalid, err := New(profile)
+	require.NoError(t, err)
+	invalid.config.BootTimeoutSeconds = 0
+	require.ErrorIs(t, invalid.Initialize(context.Background(), ""), ErrInvalidConfig)
+}
+
+func TestProbeCapabilitiesFailsClosed(t *testing.T) {
+	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
+	require.NoError(t, err)
+	driver, err := New(profile)
+	require.NoError(t, err)
+
+	report := driver.ProbeCapabilities(context.Background())
+	require.Equal(t, runtimecatalog.CapabilityUnsupported, report.State)
+	require.Equal(t, "FirecrackerDriverUnimplemented", report.Reason)
+	require.False(t, report.Ready())
+}
+
+func TestLifecycleOperationsFailClosed(t *testing.T) {
+	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
+	require.NoError(t, err)
+	driver, err := New(profile)
+	require.NoError(t, err)
+	require.NoError(t, driver.Initialize(context.Background(), ""))
+
+	ctx := context.Background()
+	_, err = driver.EnsureSandbox(ctx, nil)
+	require.True(t, errors.Is(err, errLifecycleUnimplemented))
+	_, err = driver.InspectSandbox(ctx, "sandbox-1")
+	require.True(t, errors.Is(err, errLifecycleUnimplemented))
+	require.True(t, errors.Is(driver.DeleteSandbox(ctx, "sandbox-1"), errLifecycleUnimplemented))
+	_, err = driver.ListManagedSandboxes(ctx)
+	require.True(t, errors.Is(err, errLifecycleUnimplemented))
+	require.True(t, errors.Is(driver.RecoverRuntimeResources(ctx, nil), errLifecycleUnimplemented))
+	_, err = driver.GetAccessDescriptor("sandbox-1")
+	require.True(t, errors.Is(err, ErrNetworkUnavailable))
+	_, err = driver.ListImages(ctx)
+	require.True(t, errors.Is(err, errLifecycleUnimplemented))
+	require.True(t, errors.Is(driver.PullImage(ctx, "example.com/image:latest"), errLifecycleUnimplemented))
+}
+
+func TestCloseResetsDriver(t *testing.T) {
+	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
+	require.NoError(t, err)
+	driver, err := New(profile)
+	require.NoError(t, err)
+	require.NoError(t, driver.Initialize(context.Background(), ""))
+
+	require.NoError(t, driver.Close())
+	require.NoError(t, driver.Initialize(context.Background(), ""))
+}


### PR DESCRIPTION
## Summary

Registers the direct Firecracker microVM runtime as a built-in SandboxPool runtime (`firecracker`). This PR is the **framework layer only** — the VM lifecycle implementation lands in a follow-up behind a fail-closed capability gate.

## Changes

- **api/v1alpha2**: add `RuntimeFirecracker` + kubebuilder enum + `IsRuntimeName` (CRD yaml updated)
- **catalog**: `DriverKindFirecracker`, `FirecrackerConfig` (on-demand boot: no sidecar, no pre-warm), built-in profile with `CapabilityUnsupported/FirecrackerDriverUnimplemented` gate (mirrors the boxlite fail-closed pattern), `NetworkModeGuestNetNS`, `ResidualProcessFirecracker` (NodeJanitor `--id` cleanup contract already exists)
- **factory**: `buildDriver` registration + host capability probe (binary/kernel/state root paths; short-circuited while the gate is closed)
- **internal/runtime/firecracker**: new Driver skeleton implementing the full `contract.Driver` contract (+ ArtifactCache / ResourceRecoverer / AccessDescriptorProvider assertions); lifecycle ops return `errLifecycleUnimplemented`

## Design notes

- One Firecracker process per Sandbox create request; nothing is pre-warmed
- Fastlet netns is turned into the guest NIC (`NetworkModeGuestNetNS`)
- Residual process cleanup reuses the existing NodeJanitor Firecracker matcher (binary `firecracker` + `--id` ≤ 32 chars)
- Fails closed: the prober rejects the runtime before a driver is built until the implementation flips the profile gate

## Testing

- `go build ./...` clean
- `go test` green for api/v1alpha2, catalog, factory, firecracker
- `go vet` clean
- 3 unrelated test failures (boxlite-runtime UDS, fastletproxy, infra symlink) confirmed pre-existing on master (macOS environment)

Follow-up: VM lifecycle implementation in `EnsureSandbox` (boot via Firecracker API socket under `StateRoot`, `--id` = truncated Sandbox ID).