### PR TITLE
firecracker driver lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,7 @@ e2e:
 				gvisor) flags="-run ^TestGVisor" ;; \
 				kata) flags="-p 1 -failfast -run ^TestKata" ;; \
 				boxlite) flags="-run ^TestRuntimeValidationUnsupportedBoxLite$$" ;; \
+				firecracker) flags="-run ^TestRuntimeValidationUnsupportedFirecracker$$" ;; \
 				*) echo "unknown runtime gate RUNTIME=$(RUNTIME)" >&2; exit 2 ;; \
 			esac ;; \
 		*) \

--- a/build/Dockerfile.fastlet
+++ b/build/Dockerfile.fastlet
@@ -10,7 +10,7 @@ FROM golang:1.25-alpine
 # EXPOSE 2345
 
 WORKDIR /workspace
-RUN apk add --no-cache iproute2 iptables
+RUN apk add --no-cache iproute2 iptables e2fsprogs
 COPY .build/linux-amd64/fastlet .
 COPY .build/linux-amd64/sandbox-init /opt/fast-sandbox/bin/sandbox-init
 COPY .build/linux-amd64/sandbox-tunnel /opt/fast-sandbox/bin/sandbox-tunnel

--- a/cmd/fastlet/main.go
+++ b/cmd/fastlet/main.go
@@ -107,7 +107,7 @@ func main() {
 		configurable.SetRegistryProvider(registryProvider)
 	}
 	if runtimeProfile.UsesFastletNetNS() {
-		networkManager, err := newNetworkManager(capacityFromEnvironment(), podUID)
+		networkManager, err := newNetworkManager(capacityFromEnvironment(), podUID, runtimeProfile.NetworkMode)
 		if err != nil {
 			klog.ErrorS(err, "Failed to configure Fastlet-owned network")
 			os.Exit(1)
@@ -171,7 +171,7 @@ func main() {
 	}
 }
 
-func newNetworkManager(capacity int, podUID string) (*fastletnetwork.Manager, error) {
+func newNetworkManager(capacity int, podUID string, networkMode runtimecatalog.NetworkMode) (*fastletnetwork.Manager, error) {
 	config := fastletnetwork.DefaultConfig(capacity, podUID)
 	config.PodName = os.Getenv("POD_NAME")
 	config.PodNamespace = os.Getenv("NAMESPACE")
@@ -187,7 +187,11 @@ func newNetworkManager(capacity int, podUID string) (*fastletnetwork.Manager, er
 	}
 	config.MTU = mtu
 	store := fastletnetwork.NewFileStateStore(filepath.Join(config.StateRoot, podUID))
-	return fastletnetwork.NewManager(config, fastletnetwork.NewLinuxNetNSDriver(fastletnetwork.LinuxDriverConfig{}), store)
+	var driver fastletnetwork.Driver = fastletnetwork.NewLinuxNetNSDriver(fastletnetwork.LinuxDriverConfig{})
+	if networkMode == runtimecatalog.NetworkModeFirecracker {
+		driver = fastletnetwork.NewGuestVMNetNSDriver(fastletnetwork.LinuxDriverConfig{})
+	}
+	return fastletnetwork.NewManager(config, driver, store)
 }
 
 type networkConfigurable interface {

--- a/docs/design/overlaybd-on-demand-loading.md
+++ b/docs/design/overlaybd-on-demand-loading.md
@@ -1,0 +1,90 @@
+# OverlayBD 按需加载消费侧设计
+
+> 文档类型：设计
+>
+> 日期：2026-08-24
+>
+> 范围：SandboxTemplate（OSEP-0023）产物（OverlayBD LSMT commit layer）的**消费侧**——
+> 在节点上把 layer 挂成块设备并按需从远端加载。生产侧（转换/打包）见 OSEP-0023。
+
+## 1. 背景与目标
+
+SandboxTemplate 的 `package` 阶段把 `rootfs.ext4` 与 `memory.snap` 转换为
+OverlayBD LSMT commit layer（`layer.lsmt`，索引 + 数据段，uncompressed）。
+转换只是"准备好了数据面"，真正实现按需加载需要消费侧两块能力：
+
+1. **OverlayBD 运行时设备挂载**：把 layer 挂成只读块设备，Firecracker 的
+   virtio-blk / file-backed memory 指向它；
+2. **远端 range read**：guest 读 block → 设备 miss → 按 digest+offset 从
+   远端（S3/OSS/Registry）拉数据段，落本地 bounded cache。
+
+本设计给出组件清单、来源与抽取边界。参考实现为
+[kvcache-ai/AgentENV](https://github.com/kvcache-ai/AgentENV)（MIT，
+生产运行于大规模 agent 环境：150 万镜像按需加载、ublk 设备、
+快照 <100ms、共享宿主 page cache）。
+
+## 2. 按需加载链路
+
+```
+guest 读 block
+  → virtio-blk / file-backed memory
+  → ublk 设备（OverlaybdTarget）
+  → overlaybd ImageFile（上游库：layer 索引 + 本地 block cache）
+  → cache miss → 远端 repo range read（digest+offset）
+  → 数据段落 cache → 返回
+```
+
+eager 的只有 manifest / vmstate（小）；rootfs 与 memory 的大数据段全部 lazy。
+缓存层次：guest page cache → OverlayBD block cache → 节点共享只读设备
+（多 sandbox 共享同一 layer 设备与宿主 page cache）→ S3/OSS/Registry。
+
+## 3. 组件清单与来源
+
+| 层 | 组件 | 来源 | 说明 |
+|----|------|------|------|
+| 上游库 | `containerd/overlaybd`（`ImageFile` / `ImageService`） | **直接依赖** | range read、层读取、本地 block cache 都在这里实现；AgentENV 同样直接使用 |
+| 设备挂载 | `storage/ublk` crate（tokio + io_uring ublk server）+ `overlaybd_target.rs`（`UVMUblkTarget` impl） | **直接依赖（MIT）或参考重写** | AgentENV 已解耦为独立 workspace member，仅依赖 overlaybd + tokio/io_uring；`OverlaybdTarget` 把块 I/O 转成 `ImageFile` 读 |
+| 服务化 | `storage/ublk-daemon`（RPC 创建/删除设备） | 参考 | runtime-agent 内做设备生命周期管理 |
+| 缓存编排 | `src/image/cache/*`（graph/gc/store/service + 并发锁） | 参考结构 | bounded cache、容量治理、GC |
+| 快照存储 | `src/snapshot/repository/backends/oss`（`object-store-operator`） | 参考 | S3 兼容客户端（含凭证刷新）；overlaybd repo 统一 `s3://` scheme |
+| 远端 repo | overlaybd global config | 配置 | 指向 S3/OSS/Registry，按 range 访问 |
+
+**不采用的组件（AgentENV 平台面）**：orchestrator / scheduler / gateway /
+API / 租户 / 密钥管理 / envd / warm-pool / uffd-core（E2B 备选路径）。
+这些与 OpenSandbox 控制面构成双控制面，不在数据面抽取范围。
+
+## 4. 抽取边界
+
+- **必须自研**：runtime-agent 的设备编排（对应 ublk-daemon 职责）、缓存
+  容量管理（参考 `src/image/cache`）、快照对接（复用 OpenSandbox
+  `SnapshotService` 语义）、manifest/layer 引用与 GC。
+- **可直接依赖**：overlaybd 上游库、AgentENV `storage/ublk`（MIT，cargo
+  依赖即可；若 license/维护策略不允许，参考其 ~400 行 `overlaybd_target.rs`
+  重写成本可控）。
+- **固定版本**：overlaybd、ublk 相关 crate 按 commit 锁定，独立 E2E 保障
+  升级可验证。
+
+## 5. 落地路径与验收
+
+```
+runtime-agent
+  ├─ 依赖：containerd/overlaybd + storage/ublk
+  ├─ 自研：设备编排、缓存管理、快照对接
+  └─ repo 配置：s3://（S3/OSS/registry 兼容）
+```
+
+验收（对应按需加载方案 Phase 0）：
+
+- 空缓存恢复 4 GiB memory + 9 GiB rootfs；
+- MinIO/对象存储观测只有 Range Read，下载字节显著小于 logical size；
+- memory/rootfs LSMT layer 与源文件 byte-for-byte 一致；
+- 多 sandbox 共享只读设备，宿主 page cache 复用；
+- 远端故障注入：无 silent corruption、已缓存 VM 可继续、未缓存块明确
+  失败而非 stall 伪装正常。
+
+## 6. 与 SandboxTemplate 的衔接
+
+SandboxTemplate `package` 阶段产物（`layer.lsmt`）即 overlaybd `ImageFile`
+直接消费的 commit layer——模板负责"造"，runtime-agent + storage/ublk 负责
+"用"，两端在 overlaybd 格式上闭合。产物 manifest（digest、logicalSize、
+layers）即消费侧缓存 key 与校验依据。

--- a/docs/design/sandboxtemplate-golden-image-builds.md
+++ b/docs/design/sandboxtemplate-golden-image-builds.md
@@ -1,0 +1,453 @@
+# SandboxTemplate: Declarative Golden-Image Builds for Firecracker
+
+> 文档类型：设计提案
+>
+> 日期：2026-08-24
+>
+> 说明：本提案的权威版本位于 OpenSandbox 仓库的 OSEP 流程；此副本供 fast-sandbox
+> 消费侧（driver / runtime-agent）与转换侧（osb template CLI）对齐使用。
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Requirements](#requirements)
+- [Proposal](#proposal)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+- [Test Plan](#test-plan)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Infrastructure Needed](#infrastructure-needed)
+- [Upgrade & Migration Strategy](#upgrade--migration-strategy)
+<!-- /toc -->
+
+## Summary
+
+Firecracker does not consume OCI images directly. Today the conversion of an
+OCI image into a Firecracker rootfs, the injection of the OpenSandbox runtime
+(execd), and — for snapshot and lazy-loading scenarios — the packaging into
+OverlayBD layers, are ad-hoc, hand-written pipeline steps with no shared
+contract.
+
+This OSEP introduces **SandboxTemplate**, a declarative
+`sandbox.opensandbox.io/v1alpha1` resource that describes a golden-image build:
+source OCI image, execd injection, guest init selection, readiness semantics,
+and output artifacts. A single schema is consumed in two phases:
+
+1. **Phase 1**: an `osb image` subcommand in the OpenSandbox CLI executes the
+   template locally (converting, snapshotting, packaging, publishing).
+2. **Phase 2**: a Kubernetes controller reconciles `SandboxTemplate` objects
+   by driving the same build as a Kubernetes Job, so golden images are built,
+   versioned, and published by the cluster.
+
+## Motivation
+
+Sandboxes backed by Firecracker need a bootable rootfs. The OpenSandbox
+runtime stack also requires execd and bootstrap files inside the guest, and
+fast startup paths want full snapshots or OverlayBD lazy-loading layers.
+
+None of that has a first-class description today:
+
+- The conversion input (which OCI image), the injected runtime bits, the
+  guest PID 1, and the readiness definition are scattered across build
+  scripts and CI parameters.
+- There is no shared, versionable artifact contract: consumers cannot tell
+  from a build output which source image, kernel, execd, or init it embeds,
+  nor how it was validated.
+- Building images inside CI is not reproducible or reviewable the way a
+  declarative resource is; there is no way for a cluster to request a
+  rebuild when a template changes.
+
+A declarative template fixes all three: the **template** is the contract a
+user writes, the **manifest** is the contract a runtime consumes, and the
+**executor** (CLI or controller) is interchangeable.
+
+### Goals
+
+- Define a `SandboxTemplate` CRD (spec + status) covering the full golden
+  image build: source, injection, init, readiness, output.
+- Define a content-addressed artifact **manifest** (digest, machine, files,
+  validation record) produced by every build.
+- Phase 1: `osb image` CLI subcommands that consume the same schema locally
+  — build, template init, validation, publish.
+- Phase 2: a controller that reconciles `SandboxTemplate` into Kubernetes
+  Jobs, records build results in `status`, and publishes artifacts.
+- Keep the two executors behaviorally identical through a shared build
+  engine and shared schema validation.
+
+### Non-Goals
+
+- Not a general-purpose OCI-to-VM converter; scope is Firecracker golden
+  images for OpenSandbox.
+- No runtime behavior change in the drivers that consume the artifacts; this
+  OSEP only changes how the artifacts are produced (the existing
+  content-addressed rootfs cache contract in the fast-sandbox Firecracker
+  driver is the Phase 1 consumer, see [Runtime consumption](#runtime-consumption)).
+- Sandbox API surface is unchanged: the per-sandbox init override is carried
+  by the existing `CreateSandboxRequest.entrypoint` (argv list) — in free-init
+  mode the request entrypoint becomes the guest PID 1, in managed mode it
+  replaces the business command executed under the injected guest init.
+- Not covering pause/resume or snapshot restore orchestration at runtime.
+- Phase 2 does not include multi-tenancy, quotas, or scheduling policy for
+  build Jobs beyond basic resource requests.
+
+## Requirements
+
+- The schema must be a Kubernetes-native CRD (`sandbox.opensandbox.io/v1alpha1`)
+  following the existing conventions in `kubernetes/apis/sandbox/v1alpha1`.
+- The same YAML document must be consumable by the CLI (Phase 1) and by the
+  controller (Phase 2) with identical validation.
+- Artifacts must be content-addressed (digest over the produced files and
+  manifest) so consumers can verify integrity and share cached blobs.
+- The build must support three artifact tiers with strict inclusion:
+  `ext4` (converted rootfs only) → `snapshot` (+ full snapshot) →
+  `overlaybd` (+ LSMT layers).
+- The guest init must be selectable per template (injected PID 1, or the
+  image's own init) and overridable per sandbox at runtime. The override is
+  carried by the existing `CreateSandboxRequest.entrypoint` field — no new
+  sandbox API surface.
+- Readiness must be defined per template: custom probe first, execd `/ping`
+  by default, time-based warmup plus image healthcheck as fallback.
+- Every produced format must pass a boot validation gate; for `ext4` this is
+  a boot-only validation (start, reach readiness, stop) without retaining
+  snapshot artifacts.
+- The manifest must record the snapshot compatibility tuple (kernel digest,
+  host kernel, CPU model, Firecracker version) so consumers can select a
+  compatible restore node.
+
+## Proposal
+
+Introduce a `SandboxTemplate` custom resource:
+
+```yaml
+apiVersion: sandbox.opensandbox.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: ai-office-sandbox
+spec:
+  image: registry.example.com/sandbox:v1.0.21
+  entrypoint:                              # empty: defaults to ["tail","-f","/dev/null"]
+    - /opt/gem/run.sh
+  execd: registry.example.com/execd:v1.0.21
+  kernel: vmlinux-6.1.177
+  machine:
+    vcpu: "4"                        # Kubernetes resource quantity
+    memory: "8Gi"                    # e.g. 512Mi / 2Gi / 8Gi
+  init: /usr/local/sbin/guest-init    # empty: no injection
+  envs:                             # merged into /etc/sandbox-init.env
+    - name: FOO
+      value: bar
+  readiness:
+    probe: tcp://127.0.0.1:44772             # custom first
+    warmupSeconds: 60                        # fallback baseline
+    healthCheck: ""                           # empty: image CMD-SHELL
+  output:
+    rootfsSize: "30Gi"
+    format: overlaybd                        # ext4 | snapshot | overlaybd
+    publish: s3://bucket/sandbox-images/     # optional, digest-addressed
+    prime:                                 # optional seed-node prime
+      nodeSelector:                          # best-effort, never blocks the build
+        node-role.open-sandbox.io/agent: "true"
+```
+
+The build pipeline has three stages, selected by `output.format`:
+
+1. **convert** — materialize the OCI layers directly into a sparse ext4
+   image (e.g. with the `oci2rootfs` tool), repair with `e2fsck`, then
+   loop-mount briefly to inject execd/bootstrap/prepare/bwrap, the optional
+   guest init, and `/etc/sandbox-init.env` (OCI `Config.Env` merged with
+   `spec.envs`).
+2. **validate-boot** — boot the rootfs on a KVM host with the embedded
+   kernel and wait for guest readiness. For `ext4` this is the terminal
+   validation gate (start, reach readiness, stop; no snapshot artifacts are
+   retained). For `snapshot`/`overlaybd` it continues into the snapshot
+   stage.
+3. **snapshot** — pause the validated guest and create a full snapshot
+   (`vmstate.snap` + `memory.snap`); restore once for validation.
+4. **package** — convert `rootfs.ext4` and `memory.snap` into independent
+   OverlayBD LSMT commit layers (windowed import, zero-run elision, seal,
+   byte-for-byte verification).
+
+Every build emits a content-addressed `manifest.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "sourceImage": "registry.example.com/sandbox:v1.0.21",
+  "sourceImageDigest": "sha256:...",
+  "execd": "registry.example.com/execd:v1.0.21",
+  "kernel": {
+    "name": "vmlinux-6.1.177",
+    "digest": "sha256:..."
+  },
+  "machine": { "vcpu": "4", "memory": "8Gi" },          // parsed into vcpuCount/memoryMiB by the engine
+  "compatibility": {
+    "firecrackerVersion": "v1.16.1",
+    "architecture": "x86_64",
+    "cpuModel": "Intel(R) Xeon(R) Platinum 8163 CPU @ 2.50GHz",
+    "hostKernel": "5.10.134-18.al8.x86_64"
+  },
+  "entrypoint": ["tail", "-f", "/dev/null"],
+  "init": "/usr/local/sbin/guest-init",            // empty: no injection
+  "envs": [{"name": "FOO", "value": "bar"}],            // effective envs (OCI Config.Env + spec.envs)
+  "files": { "rootfs": {"sha256": "...", "sizeBytes": 32212254720}, ... },
+  "validation": { "booted": true, "restored": true, "iterations": 3, "timing": {...} }
+}
+```
+
+### Notes/Constraints/Caveats
+
+- **Runtime consumer**: the Phase 1 consumer of the `ext4` artifact is the
+  Firecracker runtime driver in the fast-sandbox project, which already
+  maintains the content-addressed cache
+  (`<StateRoot>/images/<sha256(imageRef)>/rootfs.img`) and pulls artifacts
+  by digest. The template's `publish` target becomes the pull source; the
+  artifact contract (digest + manifest) is defined here and consumed there.
+- **Seed prime is best-effort**: `output.prime` optionally selects seed
+  nodes (by label selector) whose agent warms the local cache after a
+  successful build, so P2P spread and cold-start storms start from warm
+  seeds. Prime never blocks or fails the build; unreachable nodes are
+  skipped and the object store remains the authoritative source.
+- **execd injection boundary**: only the execd binary and fixed bootstrap
+  skeleton are build-time injected. Per-sandbox configuration (infra.json,
+  identity, component env) remains runtime-generated, written into the
+  instance layer — the build cannot know the sandbox identity.
+- **init modes**: injected guest init (managed mode, execd started by PID 1),
+  or no injection (image's own init; execd startup is then the image's
+  responsibility). A per-sandbox override takes precedence over the template
+  value and is carried by `CreateSandboxRequest.entrypoint`: in free-init
+  mode the request entrypoint becomes the guest PID 1 (`init=` argv); in
+  managed mode it replaces the business command executed under the injected
+  guest init, which stays the PID 1.
+- **entrypoint semantics**: `spec.entrypoint` is an argv list with a fixed
+  default of `["tail", "-f", "/dev/null"]` when empty — the sandbox stays
+  alive as an environment and work is driven through execd or the SDK. An
+  explicit value fully replaces the default with intact argument boundaries.
+- **Readiness precedence**: custom `probe` (`tcp://` or `cmd://`) → execd
+  `/ping` (default) → `warmupSeconds` + `healthCheck` (fallback, e.g. when
+  execd is not injected; empty healthcheck uses the image `CMD-SHELL`).
+- **Format tiers are inclusive**: `overlaybd` implies `snapshot` implies
+  `ext4`; a single value selects the pipeline depth.
+- **Guest network**: the snapshot stage deliberately does not configure
+  external connectivity so live connections are not captured in the
+  snapshot. Snapshotting workloads with active connections is out of scope.
+- **Source image compatibility**: the converter applies layer ordering,
+  compression, hard links, and whiteouts, but may skip device nodes and
+  timestamps/xattrs; the boot (and restore, for snapshot formats)
+  validation is a mandatory compatibility gate for the selected source
+  image.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Converter fidelity (whiteout leftovers, missing device nodes) | `e2fsck -fy` repair + read-only re-check + mandatory boot validation per build (restore validation for snapshot formats) |
+| Snapshot captures an unready or half-initialized guest | Readiness gate before snapshot; warmup baseline; application-specific readiness preferred |
+| Snapshot portability (kernel/CPU features) | Manifest records the compatibility tuple (kernel digest, host kernel, CPU model, Firecracker version); consumers match it against node labels before restore |
+| Artifact tampering or corruption in transit | Content-addressed manifest + `SHA256SUMS`; consumers verify digests |
+| Two executors drift (CLI vs controller) | Shared build engine library + shared schema validation; both consume the same template |
+| Build resource spikes (30 GiB rootfs, snapshot memory) | Phased disk usage (archive → layout → rootfs only), page-cache dropping during import, configurable machine size |
+
+## Design Details
+
+### CRD schema
+
+`SandboxTemplate` lives in `kubernetes/apis/sandbox/v1alpha1`
+(`sandboxtemplate_types.go`), same group and kubebuilder conventions as
+`BatchSandbox`.
+
+```go
+type SandboxTemplateSpec struct {
+    Image       string            `json:"image"`                 // required
+    // Argv list; empty defaults to ["tail","-f","/dev/null"].
+    Entrypoint  []string          `json:"entrypoint,omitempty"`
+    Execd       string            `json:"execd,omitempty"`
+    Kernel      string            `json:"kernel"`                // required
+    // Init is the injected PID 1 path inside the rootfs; empty means
+    // no injection (the kernel default or the image's own init applies).
+    Init        string            `json:"init,omitempty"`
+    // Envs is injected as /etc/sandbox-init.env, merged with the
+    // OCI Config.Env.
+    Envs []corev1.EnvVar     `json:"envs,omitempty"`
+    Machine     MachineSpec       `json:"machine"`
+    Readiness   ReadinessSpec     `json:"readiness"`
+    Output      OutputSpec        `json:"output"`
+}
+
+type MachineSpec struct {
+    // Kubernetes resource quantity (e.g. "1", "4000m").
+    // +kubebuilder:default="1"
+    VCPU string `json:"vcpu"`
+    // Kubernetes resource quantity (e.g. "512Mi", "2Gi", "8Gi").
+    // +kubebuilder:default="2Gi"
+    Memory string `json:"memory"`
+}
+
+type ReadinessSpec struct {
+    // tcp://host:port or cmd://<command>; empty falls back to execd /ping.
+    Probe         string `json:"probe,omitempty"`
+    // +kubebuilder:default=60
+    WarmupSeconds int32  `json:"warmupSeconds"`
+    // Empty uses the source image CMD-SHELL healthcheck.
+    HealthCheck   string `json:"healthCheck,omitempty"`
+}
+
+// +kubebuilder:validation:Enum=ext4;snapshot;overlaybd
+// +kubebuilder:default=ext4
+type ArtifactFormat string
+
+type OutputSpec struct {
+    // Kubernetes resource quantity (e.g. "10Gi", "30Gi").
+    // +kubebuilder:default="30Gi"
+    RootfsSize string          `json:"rootfsSize"`
+    Format        ArtifactFormat `json:"format"`
+    Publish       string         `json:"publish,omitempty"`
+    // Prime optionally selects seed nodes (by label selector) whose agent
+    // warms the local cache after a successful build. Always best-effort:
+    // it never blocks or fails the build, and the object store stays the
+    // authoritative source.
+    // +optional
+    Prime *PrimeSpec `json:"prime,omitempty"`
+}
+
+type PrimeSpec struct {
+    // +kubebuilder:validation:MinProperties=1
+    NodeSelector map[string]string `json:"nodeSelector"`
+}
+
+type SandboxTemplateStatus struct {
+    // +kubebuilder:validation:Enum=Pending;Building;Succeeded;Failed
+    Phase             SandboxTemplatePhase  `json:"phase,omitempty"`
+    Conditions        []SandboxTemplateCondition `json:"conditions,omitempty"`
+    ArtifactDigest    string                `json:"artifactDigest,omitempty"`
+    ManifestRef       string                `json:"manifestRef,omitempty"`
+    LastBuildTime     *metav1.Time          `json:"lastBuildTime,omitempty"`
+    ObservedGeneration int64                `json:"observedGeneration,omitempty"`
+}
+```
+
+### Build engine
+
+The stages (convert / validate-boot / snapshot / package) are implemented as
+a shared library (`components/internal` or a dedicated package) invoked by
+both executors. External tools are dependencies, not embedded logic:
+`oci2rootfs` (or an equivalent layer-applier), `firecracker`, `e2fsprogs`,
+and the OverlayBD toolchain. The engine emits the manifest and `SHA256SUMS`.
+Every format runs the validate-boot gate; only `snapshot`/`overlaybd`
+continue into snapshot and package.
+
+### Phase 1 — `osb image` CLI
+
+```
+osb image template init -n <name>            # generate a template skeleton
+osb image template validate -f template.yaml # schema + reference checks
+osb image build -f template.yaml             # run the full build locally
+osb image build -f template.yaml --set image=...:v1.0.22   # overrides
+```
+
+The CLI shares the schema validation and the engine with the controller.
+Local execution requires a KVM-capable host for `snapshot`/`overlaybd`
+formats.
+
+### Phase 2 — controller
+
+A controller watches `SandboxTemplate`:
+
+```
+reconcile(template):
+  validate spec
+  → create a Kubernetes Job (builder image, spec → env/args, format
+    decides pipeline depth; /dev/kvm device for snapshot/overlaybd)
+  → wait for completion → read manifest (digest verified)
+  → publish to spec.output.publish (digest-addressed)
+  → if output.prime set: notify the agent pods on matching seed nodes
+    (best-effort; failures are logged, never failing the build) so they
+    warm their local caches for P2P spread
+  → update status {phase, artifactDigest, manifestRef, lastBuildTime,
+    observedGeneration}
+```
+
+Generation tracking drives rebuilds on template changes; failed builds set
+`phase: Failed` with conditions.
+
+### Runtime consumption
+
+The produced artifacts are consumed by the Firecracker runtime driver:
+
+- `ext4`: the existing content-addressed cache
+  (`<StateRoot>/images/<sha256(imageRef)>/rootfs.img`) — the template's
+  `publish` target becomes the source for on-demand pull with digest
+  verification.
+- `snapshot`: restore path for fast startup.
+- `overlaybd`: root drive / memory backend backed by LSMT layers (runtime
+  support lands separately).
+
+The per-sandbox `init` override resolves as:
+`CreateSandboxRequest.entrypoint > template manifest.init > kernel default`.
+
+## Test Plan
+
+- **Unit**: schema validation (field combos, format tiers, readiness
+  precedence), manifest digest computation, engine stage wiring.
+- **Integration (CLI)**: build each format tier against a small fixture OCI
+  image; assert manifest fields, file digests, and `e2fsck` clean state.
+- **E2E**: boot the produced `ext4` rootfs in a Firecracker microVM and run
+  the execd smoke path; restore a produced snapshot and assert guest
+  readiness; byte-for-byte verify OverlayBD layers against sources.
+- **Controller (Phase 2, Kind)**: apply a `SandboxTemplate`, assert the Job
+  is created, status transitions Pending → Building → Succeeded, manifest
+  digest recorded, and a spec change triggers a rebuild.
+- **Negative**: converter-unsupported images fail the boot/restore
+  validation gate; digest mismatch fails publication; unreadable template
+  fails validation before any Job is created.
+
+## Drawbacks
+
+- A new CRD and a new build pipeline are a real investment; for teams that
+  only need plain rootfs images the `ext4` tier plus CLI may be sufficient
+  and the controller is extra machinery.
+- Template-driven builds are only as good as their validation: a template
+  whose readiness gate is misconfigured can produce "healthy" snapshots that
+  are not actually ready. The readiness semantics mitigate but do not
+  eliminate this.
+- Golden-image builds shift flexibility from runtime to build time:
+  per-sandbox variance is constrained to what the template declares
+  (init override, envs, entrypoint).
+
+## Alternatives
+
+- **Keep ad-hoc CI scripts**: no shared contract, no reviewability, no
+  cluster-driven rebuilds — rejected as the status quo this OSEP replaces.
+- **CLI only, no CRD**: simpler, but the schema would be a plain YAML
+  convention with no cluster representation; the controller phase would
+  require inventing the schema later. CRD-first keeps one contract.
+- **CRD only, no CLI**: complicates local iteration and debugging; a
+  template build should be runnable on a workstation before being driven by
+  the cluster.
+- **Single monolithic binary performing conversion**: couples the build to
+  embedded logic; delegating to focused external tools (layer applier,
+  OverlayBD toolchain) keeps each piece maintainable and verifiable.
+- **General OCI-to-VM converter**: out of scope; the template is
+  Firecracker/OpenSandbox-specific.
+
+## Infrastructure Needed
+
+- A KVM-capable build environment for `snapshot`/`overlaybd` formats
+  (CI runners or dedicated build nodes with `/dev/kvm`).
+- A digest-addressed object store for artifact publication
+  (`spec.output.publish`), e.g. S3/OSS-compatible storage.
+- The upstream toolchain pinned by digest: layer applier, Firecracker
+  release, embedded guest kernel, OverlayBD import tool.
+
+## Upgrade & Migration Strategy
+
+- Additive: the new CRD and CLI subcommands do not change existing sandbox
+  or runtime behavior.
+- Existing ad-hoc builders can migrate incrementally by expressing their
+  steps as a `SandboxTemplate` and switching to `osb image build` (Phase 1)
+  before adopting the controller (Phase 2).
+- Runtime consumption of the new artifacts is optional per format: `ext4`
+  artifacts remain the default until snapshot/overlaybd runtime support
+  lands.

--- a/docs/guides/firecracker-runtime-e2e.md
+++ b/docs/guides/firecracker-runtime-e2e.md
@@ -1,0 +1,111 @@
+# Firecracker runtime driver E2E environment
+
+Reference environment and expected behavior for running the real Firecracker
+runtime driver E2E (`scripts/firecracker-e2e.sh`). Use this document when
+reproducing the suite on a fresh host, comparing results, or triaging
+failures.
+
+## Host environment
+
+| Item | Value |
+|------|-------|
+| Machine | Dedicated bare-metal server (cloud-hosted), `/dev/kvm` passed through |
+| CPU | 2 x Intel Xeon Platinum 8163 @ 2.50GHz, 96 logical CPUs (24 cores x 2 sockets x 2 threads), 2 NUMA nodes |
+| Memory | 504 GiB total, no swap |
+| OS | Alibaba Cloud Linux 3 (Soaring Falcon), kernel 5.10.134-18.al8.x86_64 |
+| KVM | `/dev/kvm` and `/dev/net/tun` available (VT-x) |
+| Hostname | `agent-sandbox033067064046.sg52` (internal ALITest network) |
+| Workdir | `/home/gaoran/fast-sandbox` (git clone, branch `feature/firecracker-driver-lifecycle`) |
+| Runner | root (login directly as root; the script re-invokes itself with `sudo` only when not root) |
+
+The host also carries other networking (docker0, `tap-external-sk`,
+`slot0XXX` ENI-style interfaces) that coexists with the E2E bridge; the suite
+only touches resources it creates (`fsb*` netns, `fc*`/`fh*` devices, the
+`fsb0` bridge, one MASQUERADE rule) and restores them on exit.
+
+## VM baseline
+
+| Item | Value |
+|------|-------|
+| Firecracker | v1.16.1, vanilla upstream release binary |
+| Kernel | `vmlinux.bin`, 4.14.174 (firecracker quickstart image) |
+| Rootfs | `bionic.rootfs.ext4`, Ubuntu 18.04.5 LTS minimized, ~300 MiB |
+| Guest spec | 1 vCPU, 512 MiB, static network via kernel `ip=` boot arg |
+
+Artifacts are downloaded on first run:
+
+- `https://github.com/firecracker-microvm/firecracker/releases/download/v1.16.1/firecracker-v1.16.1-x86_64.tgz`
+- `https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin`
+- `https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/rootfs/bionic.rootfs.ext4`
+
+## StateRoot and reflink
+
+The driver StateRoot lives on a reflink-capable filesystem so per-Sandbox
+rootfs copies are CoW instead of paying the full dirty writeback:
+
+- Loop-backed sparse xfs image (default 64 GiB) mounted at
+  `/var/lib/fast-sandbox` (see `scripts/firecracker-xfs-stateroot.sh`, size
+  selectable; `--grow <size>` extends it online)
+- E2E runs with `FC_STATE_ROOT=/var/lib/fast-sandbox/e2e`
+- Instance rootfs copies use `cp --reflink=always` (plain copy fallback);
+  reflink is verified by the xfs script before use
+
+## Network topology
+
+- Shared bridge `fsb0` in the host netns: `172.30.0.1/24`
+- Each slot gets its own netns (`fsb<64 hex>`): veth `eth0` owns the slot IP
+  (172.30.0.2 onwards), default route via the bridge gateway
+- A host-side tap (`fc<13 hex>`) per slot is attached to the bridge; the VM
+  runs in the host netns and attaches to its tap
+- The guest owns the next address (slot IP + 1), configured statically via
+  the kernel `ip=` boot arg (dotted-quad netmask)
+- Host `PREROUTING` DNAT maps the slot IP to the guest IP; `FORWARD` ACCEPT
+  rules allow ingress/egress; the slot netns MASQUERADEs egress
+- Sandbox-to-sandbox isolation: the slot netns rejects direct traffic to the
+  private CIDR (except the gateway)
+
+## E2E suites
+
+All four cases run under the `firecracker` build tag in one script
+invocation (`-run '^TestFirecrackerDriverE2E'`):
+
+| Test | What it verifies |
+|------|------------------|
+| `TestFirecrackerDriverE2E` | Full lifecycle with real Infra Components delivery (loop-mount GuestCopy of sandbox-init + execd), guest files asserted with debugfs, real guest reachability |
+| `TestFirecrackerDriverE2ENoInfra` | Same lifecycle without infra delivery |
+| `TestFirecrackerDriverE2EConcurrent` | 5 pre-provisioned slots, 5 VMs booted concurrently; per-sandbox trace correlation, distinct processes, guest reachability for every instance |
+| `TestFirecrackerDriverE2EImageGC` | Independent LFU image-cache GC: unreferenced low-frequency image evicted, live Sandbox pins its image, deletion releases it |
+
+## Observed performance
+
+Steady state (reflink StateRoot, warm cache):
+
+| Case | Total | Phase breakdown |
+|------|-------|-----------------|
+| Single VM with infra | ~317 ms | acquire ~30 µs, rootfs ~1 ms, infra ~200 ms, launch ~100 ms, configure ~1 ms, boot ~10 ms |
+| Single VM without infra | ~113 ms | infra 0, rest identical |
+| 5 VMs concurrently | ~470-515 ms | 5 x infra ~280-400 ms in parallel, launch ~100 ms each |
+
+Notes:
+
+- `launch` (~100 ms) is the firecracker process spawn constant; `boot`
+  (~10 ms) is the VM reaching `Running` (1 state poll)
+- Without reflink (ext4 StateRoot) a create costs ~3.0 s (first-fsync dirty
+  writeback); with xfs reflink it drops to ~282 ms (rootfs copy ~1 ms)
+- The suite has been run back-to-back many times with all green; stale
+  netns/taps from interrupted runs are purged by the script at start and on
+  exit, and the host neighbour cache is flushed before guest probes so
+  repeated runs do not interfere
+
+## Running
+
+```bash
+cd /home/gaoran/fast-sandbox
+git pull origin feature/firecracker-driver-lifecycle
+FC_STATE_ROOT=/var/lib/fast-sandbox/e2e ./scripts/firecracker-e2e.sh
+```
+
+Overrides: `FC_VERSION`, `FC_BINARY`, `FC_KERNEL`, `FC_ROOTFS`,
+`FC_STATE_ROOT`, `WORK`. `--cleanup` removes leftovers of an interrupted run.
+Host resources created by a run (bridge, MASQUERADE, ip_forward, netns, taps)
+are restored automatically on exit.

--- a/internal/catalog/runtime/builtin.go
+++ b/internal/catalog/runtime/builtin.go
@@ -85,6 +85,7 @@ func builtinProfiles() map[apiv1alpha2.RuntimeName]RuntimeProfile {
 					Privileged: true, RequiresKVM: true, Overhead: overhead("250m", "256Mi"),
 					HostPaths: append([]HostPathRequirement{
 						{Name: "dev-kvm", HostPath: "/dev/kvm", MountPath: "/dev/kvm", Type: corev1.HostPathCharDev},
+						{Name: "dev-net-tun", HostPath: "/dev/net/tun", MountPath: "/dev/net/tun", Type: corev1.HostPathCharDev},
 						{Name: "firecracker-bin", HostPath: "/usr/local/bin/firecracker", MountPath: "/usr/local/bin/firecracker", Type: corev1.HostPathFile, ReadOnly: true},
 						{Name: "firecracker-kernel", HostPath: "/opt/fast-sandbox/firecracker/vmlinux.bin", MountPath: "/opt/fast-sandbox/firecracker/vmlinux.bin", Type: corev1.HostPathFile, ReadOnly: true},
 						{Name: "firecracker-rootfs", HostPath: "/var/lib/fast-sandbox/firecracker/rootfs", MountPath: "/var/lib/fast-sandbox/firecracker/rootfs", Type: corev1.HostPathDirectoryOrCreate},
@@ -92,7 +93,7 @@ func builtinProfiles() map[apiv1alpha2.RuntimeName]RuntimeProfile {
 					}, linuxNetworkPaths...),
 				},
 				Capabilities:       Capabilities{DefaultState: CapabilityUnsupported, SupportsNetwork: true, SupportsRecovery: true, Reason: "FirecrackerDriverUnimplemented"},
-				NetworkMode:        NetworkModeGuestNetNS,
+				NetworkMode:        NetworkModeFirecracker,
 				InfraDeliveryModes: []InfraDeliveryMode{InfraDeliveryTemplateBake, InfraDeliveryPreinstalled, InfraDeliveryGuestCopy},
 			},
 			ResidualProcessFirecracker,

--- a/internal/catalog/runtime/catalog.go
+++ b/internal/catalog/runtime/catalog.go
@@ -19,17 +19,18 @@ import (
 type DriverKind string
 
 const (
-	DriverKindContainerd DriverKind = "containerd"
-	DriverKindBoxLite    DriverKind = "boxlite"
+	DriverKindContainerd  DriverKind = "containerd"
+	DriverKindBoxLite     DriverKind = "boxlite"
 	DriverKindFirecracker DriverKind = "firecracker"
 )
 
 type NetworkMode string
 
 const (
-	NetworkModeLinuxNetNS NetworkMode = "linux-netns"
-	NetworkModeGuestNetNS NetworkMode = "guest-netns"
-	NetworkModeBoxLite    NetworkMode = "boxlite-gvproxy"
+	NetworkModeLinuxNetNS  NetworkMode = "linux-netns"
+	NetworkModeGuestNetNS  NetworkMode = "guest-netns"
+	NetworkModeBoxLite     NetworkMode = "boxlite-gvproxy"
+	NetworkModeFirecracker NetworkMode = "firecracker-tap"
 )
 
 const DefaultContainerdNamespace = "k8s.io"
@@ -91,14 +92,18 @@ type BoxLiteConfig struct {
 // direct Firecracker runtime driver. The driver boots one Firecracker
 // microVM on demand for every Sandbox create request; nothing is pre-warmed.
 type FirecrackerConfig struct {
-	BinaryPath      string `json:"binaryPath"`
-	JailerPath      string `json:"jailerPath,omitempty"`
-	KernelPath      string `json:"kernelPath"`
-	RootfsPath      string `json:"rootfsPath"`
-	StateRoot       string `json:"stateRoot"`
-	DefaultVCPUs    int32  `json:"defaultVCPUs"`
-	DefaultMemory   string `json:"defaultMemory"`
-	BootTimeoutSeconds int32 `json:"bootTimeoutSeconds"`
+	BinaryPath         string `json:"binaryPath"`
+	JailerPath         string `json:"jailerPath,omitempty"`
+	KernelPath         string `json:"kernelPath"`
+	RootfsPath         string `json:"rootfsPath"`
+	StateRoot          string `json:"stateRoot"`
+	DefaultVCPUs       int32  `json:"defaultVCPUs"`
+	DefaultMemory      string `json:"defaultMemory"`
+	BootTimeoutSeconds int32  `json:"bootTimeoutSeconds"`
+	// BootArgs is the optional base guest kernel command line. The guest
+	// network ip= argument is appended per Sandbox; an empty value selects
+	// the driver default.
+	BootArgs string `json:"bootArgs,omitempty"`
 }
 
 type HostPathRequirement struct {
@@ -153,9 +158,11 @@ type RuntimeProfile = RuntimeDefinition
 
 // UsesFastletNetNS reports whether the runtime consumes a Fastlet-owned Linux
 // network namespace. GuestNetNS runtimes turn that namespace into a guest NIC,
-// but retain the same slot lifecycle and DirectIP access contract.
+// but retain the same slot lifecycle and DirectIP access contract. The
+// firecracker-tap mode uses the slot for IP and access-descriptor allocation
+// and prepares its tap inside the slot lifecycle.
 func (p RuntimeProfile) UsesFastletNetNS() bool {
-	return p.NetworkMode == NetworkModeLinuxNetNS || p.NetworkMode == NetworkModeGuestNetNS
+	return p.NetworkMode == NetworkModeLinuxNetNS || p.NetworkMode == NetworkModeGuestNetNS || p.NetworkMode == NetworkModeFirecracker
 }
 
 // ContainerdNamespace returns the namespace used by runtime and artifact

--- a/internal/catalog/runtime/catalog_test.go
+++ b/internal/catalog/runtime/catalog_test.go
@@ -71,6 +71,7 @@ func TestBuiltinCatalogProfiles(t *testing.T) {
 	require.Equal(t, ResidualProcessFirecracker, firecracker.ResidualProcess)
 	require.True(t, firecracker.Deployment.RequiresKVM)
 	require.True(t, hasHostPath(firecracker.Deployment.HostPaths, "/dev/kvm"))
+	require.True(t, hasHostPath(firecracker.Deployment.HostPaths, "/dev/net/tun"))
 	require.True(t, hasHostPath(firecracker.Deployment.HostPaths, "/usr/local/bin/firecracker"))
 	require.Equal(t, "/usr/local/bin/firecracker", firecracker.Firecracker.BinaryPath)
 	require.Equal(t, "/opt/fast-sandbox/firecracker/vmlinux.bin", firecracker.Firecracker.KernelPath)

--- a/internal/fastlet/network/guest_vm_linux_driver.go
+++ b/internal/fastlet/network/guest_vm_linux_driver.go
@@ -1,0 +1,137 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+)
+
+// GuestVMNetNSDriver extends LinuxNetNSDriver with a host-side tap and DNAT
+// rules for guest-VM runtimes (Firecracker). The tap lives in the Fastlet
+// (firecracker) network namespace and is bridged to the shared bridge; the
+// pod-side slot IP is DNATed to the guest address at the host so Ingress
+// keeps dialing the pod IP and reply traffic is reverse-NATed by the host
+// conntrack. Container runtimes keep using LinuxNetNSDriver and never see
+// the tap or the rules.
+type GuestVMNetNSDriver struct {
+	LinuxNetNSDriver
+}
+
+// NewGuestVMNetNSDriver wraps a LinuxNetNSDriver with the guest-VM additions.
+func NewGuestVMNetNSDriver(config LinuxDriverConfig) *GuestVMNetNSDriver {
+	return &GuestVMNetNSDriver{LinuxNetNSDriver: *NewLinuxNetNSDriver(config)}
+}
+
+// Prepare runs the standard Linux preparation, then creates the host-side
+// tap on the shared bridge and installs the pod-IP DNAT and forward rules.
+func (d *GuestVMNetNSDriver) Prepare(ctx context.Context, slot *Slot) error {
+	if err := d.LinuxNetNSDriver.Prepare(ctx, slot); err != nil {
+		return err
+	}
+	guestIP, err := GuestVMIP(slot)
+	if err != nil {
+		return err
+	}
+	commands := [][]string{
+		{"tuntap", "add", "dev", slot.GuestTap, "mode", "tap"},
+		{"link", "set", slot.GuestTap, "master", slot.Bridge},
+		{"link", "set", slot.GuestTap, "mtu", fmt.Sprint(slot.MTU)},
+		{"link", "set", slot.GuestTap, "up"},
+	}
+	for _, arguments := range commands {
+		if _, err := d.runner.Run(ctx, "ip", arguments...); err != nil {
+			return fmt.Errorf("prepare guest tap %s: %w", slot.GuestTap, err)
+		}
+	}
+	rules := [][]string{
+		{"-t", "nat", "-A", "PREROUTING", "-d", slot.IP + "/32", "-j", "DNAT", "--to-destination", guestIP},
+		{"-A", "FORWARD", "-d", guestIP + "/32", "-j", "ACCEPT"},
+		{"-A", "FORWARD", "-s", guestIP + "/32", "-j", "ACCEPT"},
+	}
+	for _, arguments := range rules {
+		check := append([]string(nil), arguments...)
+		for index, argument := range check {
+			if argument == "-A" {
+				check[index] = "-C"
+				break
+			}
+		}
+		if _, err := d.runner.Run(ctx, "iptables", check...); err != nil {
+			if _, err := d.runner.Run(ctx, "iptables", arguments...); err != nil {
+				return fmt.Errorf("prepare guest DNAT rules: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// Validate extends the Linux validation with a guest tap existence check.
+func (d *GuestVMNetNSDriver) Validate(ctx context.Context, slot *Slot) error {
+	if err := d.LinuxNetNSDriver.Validate(ctx, slot); err != nil {
+		return err
+	}
+	if slot.GuestTap == "" {
+		return fmt.Errorf("guest-VM slot has no tap name")
+	}
+	if _, err := d.runner.Run(ctx, "ip", "link", "show", "dev", slot.GuestTap); err != nil {
+		return fmt.Errorf("guest tap %s: %w", slot.GuestTap, err)
+	}
+	return nil
+}
+
+// Destroy removes the guest tap and rules, then runs the Linux destruction.
+func (d *GuestVMNetNSDriver) Destroy(ctx context.Context, slot *Slot) error {
+	if slot == nil {
+		return nil
+	}
+	var result error
+	if slot.GuestTap != "" {
+		if _, err := d.runner.Run(ctx, "ip", "link", "del", slot.GuestTap); err != nil && !isMissingNetworkResource(err) {
+			result = fmt.Errorf("delete guest tap %s: %w", slot.GuestTap, err)
+		}
+	}
+	if guestIP, err := GuestVMIP(slot); err == nil {
+		rules := [][]string{
+			{"-t", "nat", "-D", "PREROUTING", "-d", slot.IP + "/32", "-j", "DNAT", "--to-destination", guestIP},
+			{"-D", "FORWARD", "-d", guestIP + "/32", "-j", "ACCEPT"},
+			{"-D", "FORWARD", "-s", guestIP + "/32", "-j", "ACCEPT"},
+		}
+		for _, arguments := range rules {
+			_, _ = d.runner.Run(ctx, "iptables", arguments...)
+		}
+	}
+	if err := d.LinuxNetNSDriver.Destroy(ctx, slot); err != nil {
+		result = errorsJoin(result, err)
+	}
+	return result
+}
+
+// GuestVMIP returns the guest address directly after the slot IP.
+func GuestVMIP(slot *Slot) (string, error) {
+	if slot == nil || slot.IP == "" || slot.PrivateCIDR == "" {
+		return "", fmt.Errorf("slot IP and private CIDR are required")
+	}
+	address, err := netip.ParseAddr(slot.IP)
+	if err != nil || !address.Is4() {
+		return "", fmt.Errorf("invalid slot IP %q", slot.IP)
+	}
+	prefix, err := netip.ParsePrefix(slot.PrivateCIDR)
+	if err != nil || !prefix.Contains(address) {
+		return "", fmt.Errorf("slot IP %q is outside private CIDR %q", slot.IP, slot.PrivateCIDR)
+	}
+	guest := address.Next()
+	if !prefix.Contains(guest) {
+		return "", fmt.Errorf("no guest address after %q in %q", slot.IP, slot.PrivateCIDR)
+	}
+	return guest.String(), nil
+}
+
+func errorsJoin(left, right error) error {
+	if left == nil {
+		return right
+	}
+	if right == nil {
+		return left
+	}
+	return fmt.Errorf("%v; %v", left, right)
+}

--- a/internal/fastlet/network/guest_vm_linux_driver_test.go
+++ b/internal/fastlet/network/guest_vm_linux_driver_test.go
@@ -1,0 +1,87 @@
+package network
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGuestVMIP(t *testing.T) {
+	slot := &Slot{IP: "10.17.0.2", PrivateCIDR: "10.17.0.0/16"}
+	guest, err := GuestVMIP(slot)
+	require.NoError(t, err)
+	require.Equal(t, "10.17.0.3", guest)
+
+	_, err = GuestVMIP(&Slot{IP: "not-an-ip", PrivateCIDR: "10.17.0.0/16"})
+	require.Error(t, err)
+	_, err = GuestVMIP(&Slot{IP: "192.168.1.5", PrivateCIDR: "10.17.0.0/16"})
+	require.Error(t, err)
+	_, err = GuestVMIP(&Slot{IP: "10.17.0.7", PrivateCIDR: "10.17.0.0/29"})
+	require.Error(t, err)
+	_, err = GuestVMIP(nil)
+	require.Error(t, err)
+}
+
+func TestGuestVMNetNSDriverPrepare(t *testing.T) {
+	root := t.TempDir()
+	runner := &recordingRunner{}
+	driver := NewGuestVMNetNSDriver(LinuxDriverConfig{Runner: runner, ResolverPath: "/etc/resolv.conf"})
+	slot := &Slot{
+		NetNSName: "ns-1", NetNSPath: root + "/netns/ns-1", HostNetNSPath: root + "/host-netns/ns-1",
+		HostVeth: "fh-1", PeerVeth: "fp-1", Bridge: "fsb0",
+		Address: "10.17.0.2/16", IP: "10.17.0.2", Gateway: "10.17.0.1",
+		PrivateCIDR: "10.17.0.0/16", DNSPath: root + "/dns", MTU: 1400,
+		GuestTap: "fc-abc123",
+	}
+	require.NoError(t, driver.Prepare(context.Background(), slot))
+
+	joined := strings.Join(runner.commands, "\n")
+	require.Contains(t, joined, "ip tuntap add dev fc-abc123 mode tap")
+	require.Contains(t, joined, "ip link set fc-abc123 master fsb0")
+	require.Contains(t, joined, "ip link set fc-abc123 mtu 1400")
+	require.Contains(t, joined, "ip link set fc-abc123 up")
+	// The nat -C check fails in the harness, so the -A fallback runs.
+	require.Contains(t, joined, "iptables -t nat -A PREROUTING -d 10.17.0.2/32 -j DNAT --to-destination 10.17.0.3")
+	// The FORWARD -C check succeeds in the harness, so no duplicate rules.
+	require.NotContains(t, joined, "iptables -A FORWARD")
+}
+
+func TestGuestVMNetNSDriverDestroy(t *testing.T) {
+	runner := &recordingRunner{}
+	driver := NewGuestVMNetNSDriver(LinuxDriverConfig{Runner: runner, ResolverPath: "/etc/resolv.conf"})
+	slot := &Slot{
+		NetNSName: "ns-1", HostVeth: "fh-1",
+		Address: "10.17.0.2/16", IP: "10.17.0.2", PrivateCIDR: "10.17.0.0/16",
+		GuestTap: "fc-abc123",
+	}
+	require.NoError(t, driver.Destroy(context.Background(), slot))
+
+	joined := strings.Join(runner.commands, "\n")
+	require.Contains(t, joined, "ip link del fc-abc123")
+	require.Contains(t, joined, "iptables -t nat -D PREROUTING -d 10.17.0.2/32 -j DNAT --to-destination 10.17.0.3")
+	require.Contains(t, joined, "ip netns delete ns-1")
+}
+
+func TestGuestVMNetNSDriverValidate(t *testing.T) {
+	root := t.TempDir()
+	netnsPath := root + "/ns-1"
+	dnsPath := root + "/resolv.conf"
+	require.NoError(t, os.WriteFile(dnsPath, []byte("nameserver 10.96.0.10\n"), 0o644))
+	require.NoError(t, os.MkdirAll(netnsPath, 0o755))
+	runner := &recordingRunner{}
+	driver := NewGuestVMNetNSDriver(LinuxDriverConfig{Runner: runner, ResolverPath: "/etc/resolv.conf"})
+	slot := &Slot{
+		NetNSName: "ns-1", NetNSPath: netnsPath, HostNetNSPath: root + "/host-ns-1",
+		HostVeth: "fh-1", PeerVeth: "fp-1", Bridge: "fsb0",
+		Address: "10.17.0.2/16", IP: "10.17.0.2", Gateway: "10.17.0.1",
+		PrivateCIDR: "10.17.0.0/16", DNSPath: dnsPath, MTU: 1400,
+		GuestTap: "fc-abc123",
+	}
+	require.NoError(t, driver.Validate(context.Background(), slot))
+
+	slot.GuestTap = ""
+	require.Error(t, driver.Validate(context.Background(), slot))
+}

--- a/internal/fastlet/network/linux_driver.go
+++ b/internal/fastlet/network/linux_driver.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type CommandRunner interface {
@@ -157,7 +158,7 @@ func (d *LinuxNetNSDriver) Destroy(ctx context.Context, slot *Slot) error {
 	}
 	var result error
 	if slot.NetNSName != "" {
-		if _, err := d.runner.Run(ctx, d.ipCommand, "netns", "delete", slot.NetNSName); err != nil && !isMissingNetworkResource(err) {
+		if err := deleteNetNSWithRetry(ctx, d.runner, d.ipCommand, slot.NetNSName); err != nil && !isMissingNetworkResource(err) {
 			result = errors.Join(result, err)
 		}
 	}
@@ -244,4 +245,22 @@ func isMissingNetworkResource(err error) bool {
 	message := strings.ToLower(err.Error())
 	return strings.Contains(message, "cannot find device") || strings.Contains(message, "no such file") ||
 		strings.Contains(message, "no such device") || strings.Contains(message, "cannot open network namespace")
+}
+
+// deleteNetNSWithRetry removes a slot network namespace. The deletion races
+// a VMM that is still exiting and returns EBUSY, which would otherwise leak
+// the namespace (and its private addresses) onto the shared bridge.
+func deleteNetNSWithRetry(ctx context.Context, runner CommandRunner, ipCommand, name string) error {
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		if _, err = runner.Run(ctx, ipCommand, "netns", "delete", name); err == nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	return err
 }

--- a/internal/fastlet/network/manager.go
+++ b/internal/fastlet/network/manager.go
@@ -348,7 +348,8 @@ func (m *Manager) prepareOne(ctx context.Context) error {
 		NetNSName: netnsName, NetNSPath: filepath.Join(m.config.NetNSRoot, netnsName),
 		HostNetNSPath: filepath.Join(m.config.HostNetNSRoot, netnsName),
 		HostVeth:      hostVeth, PeerVeth: peerVeth, Bridge: m.config.Bridge,
-		Address: address, IP: ip, Gateway: m.ipam.Gateway(), PrivateCIDR: m.ipam.CIDR(),
+		GuestTap: resourceName("fc", m.config.PodUID, id, 15),
+		Address:  address, IP: ip, Gateway: m.ipam.Gateway(), PrivateCIDR: m.ipam.CIDR(),
 		DNSPath: filepath.Join(m.config.StateRoot, m.config.PodUID, id+".resolv.conf"),
 		MTU:     m.config.MTU, EgressDevice: m.config.EgressDevice, CreatedAt: m.config.Now(),
 	}

--- a/internal/fastlet/network/types.go
+++ b/internal/fastlet/network/types.go
@@ -59,29 +59,33 @@ type AccessDescriptor = dataplane.AccessDescriptor
 // HostNetNSPath is consumed by host containerd; NetNSPath is the path visible
 // inside the Fastlet container for lifecycle operations.
 type Slot struct {
-	Version        int              `json:"version"`
-	ID             string           `json:"id"`
-	OwnerPodUID    string           `json:"ownerPodUid"`
-	OwnerPodName   string           `json:"ownerPodName,omitempty"`
-	OwnerNamespace string           `json:"ownerNamespace,omitempty"`
-	Phase          SlotPhase        `json:"phase"`
-	Owner          Owner            `json:"owner,omitempty"`
-	NetNSName      string           `json:"netnsName"`
-	NetNSPath      string           `json:"netnsPath"`
-	HostNetNSPath  string           `json:"hostNetnsPath"`
-	HostVeth       string           `json:"hostVeth"`
-	PeerVeth       string           `json:"peerVeth"`
-	Bridge         string           `json:"bridge"`
-	Address        string           `json:"address"`
-	IP             string           `json:"ip"`
-	Gateway        string           `json:"gateway"`
-	PrivateCIDR    string           `json:"privateCidr"`
-	DNSPath        string           `json:"dnsPath"`
-	MTU            int              `json:"mtu"`
-	EgressDevice   string           `json:"egressDevice"`
-	Access         AccessDescriptor `json:"access"`
-	CreatedAt      time.Time        `json:"createdAt"`
-	BoundAt        *time.Time       `json:"boundAt,omitempty"`
+	Version        int       `json:"version"`
+	ID             string    `json:"id"`
+	OwnerPodUID    string    `json:"ownerPodUid"`
+	OwnerPodName   string    `json:"ownerPodName,omitempty"`
+	OwnerNamespace string    `json:"ownerNamespace,omitempty"`
+	Phase          SlotPhase `json:"phase"`
+	Owner          Owner     `json:"owner,omitempty"`
+	NetNSName      string    `json:"netnsName"`
+	NetNSPath      string    `json:"netnsPath"`
+	HostNetNSPath  string    `json:"hostNetnsPath"`
+	HostVeth       string    `json:"hostVeth"`
+	PeerVeth       string    `json:"peerVeth"`
+	Bridge         string    `json:"bridge"`
+	// GuestTap is the host-side tap device for guest-VM runtimes (Firecracker).
+	// It is prepared by GuestVMNetNSDriver and consumed by the runtime driver
+	// as the VM's host_dev_name; container runtimes leave it unused.
+	GuestTap     string           `json:"guestTap,omitempty"`
+	Address      string           `json:"address"`
+	IP           string           `json:"ip"`
+	Gateway      string           `json:"gateway"`
+	PrivateCIDR  string           `json:"privateCidr"`
+	DNSPath      string           `json:"dnsPath"`
+	MTU          int              `json:"mtu"`
+	EgressDevice string           `json:"egressDevice"`
+	Access       AccessDescriptor `json:"access"`
+	CreatedAt    time.Time        `json:"createdAt"`
+	BoundAt      *time.Time       `json:"boundAt,omitempty"`
 }
 
 type Driver interface {

--- a/internal/runtime/firecracker/client.go
+++ b/internal/runtime/firecracker/client.go
@@ -1,0 +1,190 @@
+package firecracker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// maxResponseBytes bounds Firecracker API responses read by the driver.
+const maxResponseBytes = 4 << 20
+
+// MachineConfigRequest mirrors PUT /machine-config.
+type MachineConfigRequest struct {
+	VCPUs       int    `json:"vcpu_count"`
+	MemSizeMiB  int    `json:"mem_size_mib"`
+	HtEnabled   bool   `json:"ht_enabled,omitempty"`
+	CPUTemplate string `json:"cpu_template,omitempty"`
+}
+
+// BootSourceRequest mirrors PUT /boot-source.
+type BootSourceRequest struct {
+	KernelImagePath string `json:"kernel_image_path"`
+	BootArgs        string `json:"boot_args,omitempty"`
+	InitrdPath      string `json:"initrd_path,omitempty"`
+}
+
+// DriveRequest mirrors PUT /drives/{drive_id}.
+type DriveRequest struct {
+	DriveID      string `json:"drive_id"`
+	PathOnHost   string `json:"path_on_host"`
+	IsRootDevice bool   `json:"is_root_device"`
+	IsReadOnly   bool   `json:"is_read_only,omitempty"`
+	CacheType    string `json:"cache_type,omitempty"`
+}
+
+// NetworkInterfaceRequest mirrors PUT /network-interfaces/{iface_id}.
+type NetworkInterfaceRequest struct {
+	IfaceID     string `json:"iface_id"`
+	HostDevName string `json:"host_dev_name"`
+	GuestMAC    string `json:"guest_mac,omitempty"`
+}
+
+type actionRequest struct {
+	ActionType string `json:"action_type"`
+}
+
+type versionResponse struct {
+	Version string `json:"version"`
+}
+
+type instanceInfoResponse struct {
+	State string `json:"state"`
+}
+
+// Client is a thin Firecracker REST API client over the per-Sandbox Unix
+// socket. It deliberately covers only the lifecycle surface consumed by the
+// runtime driver; snapshot and metrics endpoints are out of scope.
+type Client struct {
+	httpClient *http.Client
+}
+
+// NewClient dials the Firecracker API at socketPath (host filesystem path).
+func NewClient(socketPath string) *Client {
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+		},
+		ForceAttemptHTTP2: false,
+		IdleConnTimeout:   30 * time.Second,
+	}
+	return &Client{httpClient: &http.Client{Transport: transport}}
+}
+
+// Close releases the connection pool.
+func (c *Client) Close() {
+	if c.httpClient != nil {
+		c.httpClient.CloseIdleConnections()
+	}
+}
+
+// Version reports the Firecracker version served on the socket.
+func (c *Client) Version(ctx context.Context) (string, error) {
+	var response versionResponse
+	if err := c.do(ctx, http.MethodGet, "/version", nil, &response); err != nil {
+		return "", err
+	}
+	return response.Version, nil
+}
+
+// ConfigureMachine applies the vCPU/memory machine configuration.
+func (c *Client) ConfigureMachine(ctx context.Context, request MachineConfigRequest) error {
+	return c.do(ctx, http.MethodPut, "/machine-config", request, nil)
+}
+
+// ConfigureBootSource sets the kernel image and boot arguments.
+func (c *Client) ConfigureBootSource(ctx context.Context, request BootSourceRequest) error {
+	return c.do(ctx, http.MethodPut, "/boot-source", request, nil)
+}
+
+// AttachDrive registers a virtio-blk device.
+func (c *Client) AttachDrive(ctx context.Context, request DriveRequest) error {
+	return c.do(ctx, http.MethodPut, "/drives/"+pathEscape(request.DriveID), request, nil)
+}
+
+// AttachNetworkInterface registers a virtio-net device backed by host_dev_name.
+func (c *Client) AttachNetworkInterface(ctx context.Context, request NetworkInterfaceRequest) error {
+	return c.do(ctx, http.MethodPut, "/network-interfaces/"+pathEscape(request.IfaceID), request, nil)
+}
+
+// Start boots the microVM (InstanceStart action).
+func (c *Client) Start(ctx context.Context) error {
+	return c.do(ctx, http.MethodPut, "/actions", actionRequest{ActionType: "InstanceStart"}, nil)
+}
+
+// VMState returns the current machine state (NotStarted, Running, Paused).
+// Firecracker v1.x serves instance info at GET /; older API versions used
+// GET /vm.
+func (c *Client) VMState(ctx context.Context) (string, error) {
+	var response instanceInfoResponse
+	if err := c.do(ctx, http.MethodGet, "/", nil, &response); err != nil {
+		return "", err
+	}
+	return response.State, nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, input, output any) error {
+	var body io.Reader
+	if input != nil {
+		payload, err := json.Marshal(input)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(payload)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, "http://firecracker"+path, body)
+	if err != nil {
+		return err
+	}
+	if input != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	limited := io.LimitReader(response.Body, maxResponseBytes)
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		payload, readErr := io.ReadAll(limited)
+		if readErr != nil {
+			return fmt.Errorf("firecracker %s %s failed with %s: %w", method, path, response.Status, readErr)
+		}
+		return fmt.Errorf("firecracker %s %s failed with %s: %s", method, path, response.Status, bytes.TrimSpace(payload))
+	}
+	if output == nil {
+		return nil
+	}
+	if err := json.NewDecoder(limited).Decode(output); err != nil {
+		return fmt.Errorf("decode firecracker response: %w", err)
+	}
+	return nil
+}
+
+func pathEscape(value string) string {
+	// Drive and interface IDs are DNS-safe identifiers generated by the
+	// driver; Firecracker only accepts a restricted set, so escaping is a
+	// guard rather than a lookup.
+	var escaped bytes.Buffer
+	for _, character := range value {
+		if isSafePathCharacter(character) {
+			escaped.WriteRune(character)
+			continue
+		}
+		fmt.Fprintf(&escaped, "%%%02X", character)
+	}
+	return escaped.String()
+}
+
+func isSafePathCharacter(character rune) bool {
+	return (character >= 'a' && character <= 'z') ||
+		(character >= 'A' && character <= 'Z') ||
+		(character >= '0' && character <= '9') ||
+		character == '-' || character == '_' || character == '.'
+}

--- a/internal/runtime/firecracker/client_test.go
+++ b/internal/runtime/firecracker/client_test.go
@@ -1,0 +1,104 @@
+package firecracker
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// startFakeFirecracker serves a scripted API on a Unix socket and returns the
+// socket path plus the handler that recorded calls. The socket lives under a
+// short directory because macOS rejects Unix socket paths over 104 bytes.
+func startFakeFirecracker(t *testing.T, handler http.HandlerFunc) string {
+	t.Helper()
+	socketDir, err := os.MkdirTemp("", "fcapi")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "api.sock")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	server := &http.Server{Handler: handler}
+	t.Cleanup(func() { _ = server.Close() })
+	go func() { _ = server.Serve(listener) }()
+	return socketPath
+}
+
+func TestClientVersion(t *testing.T) {
+	socketPath := startFakeFirecracker(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/version", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"1.15.1"}`))
+	})
+	client := NewClient(socketPath)
+	t.Cleanup(client.Close)
+
+	version, err := client.Version(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "1.15.1", version)
+}
+
+func TestClientLifecycleCalls(t *testing.T) {
+	var calls []string
+	socketPath := startFakeFirecracker(t, func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		switch r.URL.Path {
+		case "/machine-config", "/boot-source", "/drives/root", "/network-interfaces/eth0", "/actions":
+			w.WriteHeader(http.StatusNoContent)
+		case "/":
+			_, _ = w.Write([]byte(`{"state":"Running"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	client := NewClient(socketPath)
+	t.Cleanup(client.Close)
+	ctx := context.Background()
+
+	require.NoError(t, client.ConfigureMachine(ctx, MachineConfigRequest{VCPUs: 2, MemSizeMiB: 512}))
+	require.NoError(t, client.ConfigureBootSource(ctx, BootSourceRequest{KernelImagePath: "/opt/firecracker/vmlinux.bin", BootArgs: "console=ttyS0"}))
+	require.NoError(t, client.AttachDrive(ctx, DriveRequest{DriveID: "root", PathOnHost: "/rootfs.img", IsRootDevice: true, IsReadOnly: false}))
+	require.NoError(t, client.AttachNetworkInterface(ctx, NetworkInterfaceRequest{IfaceID: "eth0", HostDevName: "fc-tap", GuestMAC: "02:00:00:00:00:01"}))
+	require.NoError(t, client.Start(ctx))
+	state, err := client.VMState(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Running", state)
+
+	require.Equal(t, []string{
+		"PUT /machine-config", "PUT /boot-source", "PUT /drives/root", "PUT /network-interfaces/eth0",
+		"PUT /actions", "GET /",
+	}, calls)
+}
+
+func TestClientMapsErrors(t *testing.T) {
+	socketPath := startFakeFirecracker(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid machine configuration"}`))
+	})
+	client := NewClient(socketPath)
+	t.Cleanup(client.Close)
+
+	err := client.ConfigureMachine(context.Background(), MachineConfigRequest{VCPUs: 0})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid machine configuration")
+}
+
+func TestClientNotReady(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "missing.sock")
+	client := NewClient(socketPath)
+	t.Cleanup(client.Close)
+
+	_, err := client.Version(context.Background())
+	require.Error(t, err)
+	_, err = os.Stat(socketPath)
+	require.Error(t, err)
+}
+
+func TestPathEscape(t *testing.T) {
+	require.Equal(t, "root", pathEscape("root"))
+	require.Equal(t, "a%2Fb", pathEscape("a/b"))
+}

--- a/internal/runtime/firecracker/contract.go
+++ b/internal/runtime/firecracker/contract.go
@@ -10,8 +10,11 @@ type RuntimeResourceRecoverer = runtimecontract.ResourceRecoverer
 type AccessDescriptorProvider = runtimecontract.AccessDescriptorProvider
 
 var (
-	ErrInvalidConfig      = runtimecontract.ErrInvalidConfig
-	ErrNetworkUnavailable = runtimecontract.ErrNetworkUnavailable
+	ErrInvalidConfig         = runtimecontract.ErrInvalidConfig
+	ErrNetworkUnavailable    = runtimecontract.ErrNetworkUnavailable
+	ErrSandboxNotFound       = runtimecontract.ErrSandboxNotFound
+	ErrRuntimeNotInitialized = runtimecontract.ErrRuntimeNotInitialized
+	ErrInfraUnavailable      = runtimecontract.ErrInfraUnavailable
 )
 
 var validateExistingRuntimeProfile = runtimecontract.ValidateProfile

--- a/internal/runtime/firecracker/doc.go
+++ b/internal/runtime/firecracker/doc.go
@@ -1,16 +1,17 @@
 // Package firecracker implements the direct Firecracker runtime driver for
-// Fastlet. It is the runtime-neutral Driver contract implementation behind
-// the built-in "firecracker" SandboxPool runtime.
+// Fastlet: one microVM booted on demand per Sandbox create request, launched
+// as a plain child process with an immutable per-Sandbox identity (matching
+// the NodeJanitor residual-process contract: binary "firecracker" + "--id").
 //
-// The driver boots one Firecracker microVM on demand for every Sandbox create
-// request: nothing is pre-warmed and no sidecar daemon stays resident.
-// Firecracker is launched as a plain child process with an immutable
-// per-Sandbox identity, which matches the NodeJanitor residual-process
-// cleanup contract (ResidualProcessFirecracker, binary "firecracker" and
-// "--id" matching).
+// Networking comes from the pre-provisioned Fastlet slot: the slot carries
+// the pod-side IP and the guest tap prepared by GuestVMNetNSDriver, so a
+// create performs no ip/iptables commands. The guest owns the address after
+// the slot IP (DNATed at the host) and is configured via the kernel ip=
+// boot argument. Rootfs comes from the content-addressed cache (copied per
+// instance), and durable state in StateRoot/sandboxes/<id>/meta.json anchors
+// idempotent create, delete, and Fastlet-restart recovery.
 //
-// The built-in profile currently fails closed with
-// CapabilityUnsupported/FirecrackerDriverUnimplemented. The lifecycle
-// implementation lands behind this gate; until the profile gate is enabled,
-// the HostCapabilityProber rejects the runtime before any driver is built.
+// The built-in profile fails closed (CapabilityUnsupported) until the KVM
+// E2E suite passes; the HostCapabilityProber rejects the runtime before any
+// driver is built while the gate is closed.
 package firecracker

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -4,56 +4,186 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
+	"net/netip"
+	"os"
+	"path/filepath"
 	"sync"
+	"syscall"
+	"time"
 
 	runtimecatalog "fast-sandbox/internal/catalog/runtime"
 	dataplane "fast-sandbox/internal/dataplane/contract"
+	fastletinfra "fast-sandbox/internal/fastlet/infra"
+	fastletnetwork "fast-sandbox/internal/fastlet/network"
+	infracontract "fast-sandbox/internal/infra/contract"
+	"fast-sandbox/internal/observability"
 	fastletapi "fast-sandbox/internal/protocol/fastlet"
+	runtimecontract "fast-sandbox/internal/runtime/contract"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
 )
 
-// reasonUnimplemented is the capability gate reason that keeps the driver
-// fail-closed until the Firecracker VM lifecycle implementation lands.
-const reasonUnimplemented = "FirecrackerDriverUnimplemented"
+// bootPollInterval is the VM state polling interval after InstanceStart.
+const bootPollInterval = 250 * time.Millisecond
 
-// errLifecycleUnimplemented is returned by every VM lifecycle operation while
-// the driver is still a framework-only skeleton.
-var errLifecycleUnimplemented = errors.New("firecracker runtime driver lifecycle is not implemented")
+// defaultBootArgs is the minimal Firecracker guest kernel command line. The
+// guest network ip= argument is appended per Sandbox by buildBootArgs.
+const defaultBootArgs = "console=ttyS0 reboot=k panic=1 pci=off"
 
-// Driver is the on-demand Firecracker microVM runtime driver. One Firecracker
-// process is launched per Sandbox create request with an immutable identity;
-// no VM or sidecar is pre-warmed. The VM lifecycle implementation is pending
-// behind the FirecrackerDriverUnimplemented capability gate.
+// Driver boots one Firecracker microVM on demand per Sandbox create request.
+// The VM runs in the Fastlet Pod; nothing is pre-warmed.
 type Driver struct {
-	mu          sync.RWMutex
-	profile     runtimecatalog.RuntimeProfile
-	config      runtimecatalog.FirecrackerConfig
-	namespace   string
-	initialized bool
+	mu             sync.RWMutex
+	profile        runtimecatalog.RuntimeProfile
+	config         runtimecatalog.FirecrackerConfig
+	namespace      string
+	initialized    bool
+	runner         fastletnetwork.CommandRunner
+	launcher       ProcessRunner
+	newClient      func(socketPath string) *Client
+	stat           func(string) (os.FileInfo, error)
+	killProcess    func(pid int) error
+	probeProcess   func(pid int) error
+	waitSocket     func(ctx context.Context, socketPath string, timeout time.Duration) error
+	networkManager *fastletnetwork.Manager
+	infraMgr       *fastletinfra.Manager
+	prepareInfra   func(ctx context.Context, spec *fastletapi.SandboxSpec) (fastletinfra.PreparedInstance, error)
+	processes      map[string]Process
+	// imageGCInterval is the period of the independent cache GC loop; it is a
+	// field (not a constant) so tests can shorten it.
+	imageGCInterval time.Duration
+	// imageCacheLimitBytes is the cache size the GC enforces by evicting
+	// unreferenced images in least-frequently-used order.
+	imageCacheLimitBytes int64
+	gcStop               chan struct{}
+	gcTrigger            chan struct{}
+	// imageUseCount records how often each cached image was pulled or booted,
+	// in memory: the GC evicts by this instead of filesystem timestamps.
+	// Guarded by mu.
+	imageUseCount map[string]int64
 }
 
-// New validates that the resolved runtime profile carries the private
-// Firecracker configuration and returns the driver skeleton.
+// defaultImageGCInterval bounds the image cache by usage without coupling GC
+// to Sandbox lifecycle events.
+const defaultImageGCInterval = time.Hour
+
+// New validates the runtime profile configuration and returns the driver.
 func New(profile runtimecatalog.RuntimeProfile) (*Driver, error) {
 	if profile.Firecracker == nil {
 		return nil, fmt.Errorf("firecracker runtime profile %q has no private configuration", profile.Name)
 	}
-	return &Driver{profile: profile, config: *profile.Firecracker}, nil
+	return &Driver{
+		profile: profile, config: *profile.Firecracker,
+		runner: fastletnetwork.ExecRunner{}, launcher: ExecProcessRunner{},
+		newClient: NewClient, stat: os.Stat, killProcess: killPID, probeProcess: pidAlive,
+		waitSocket: waitForAPISocket, processes: make(map[string]Process),
+		imageGCInterval:      defaultImageGCInterval,
+		imageCacheLimitBytes: defaultImageCacheLimitBytes,
+	}, nil
 }
 
-// Initialize validates the Firecracker boot configuration. The concrete boot
-// preparation (kernel/rootfs readiness, API socket placement) is part of the
-// lifecycle implementation.
+// Initialize validates the boot configuration, prepares the StateRoot, and
+// starts the independent image cache GC loop.
 func (d *Driver) Initialize(_ context.Context, _ string) error {
 	d.mu.Lock()
-	defer d.mu.Unlock()
 	if d.initialized {
+		d.mu.Unlock()
 		return nil
 	}
 	if err := validateConfig(d.config); err != nil {
+		d.mu.Unlock()
 		return err
 	}
+	if err := os.MkdirAll(d.config.StateRoot, 0o750); err != nil {
+		d.mu.Unlock()
+		return fmt.Errorf("prepare Firecracker StateRoot: %w", err)
+	}
 	d.initialized = true
+	interval := d.imageGCInterval
+	d.gcStop = make(chan struct{})
+	d.gcTrigger = make(chan struct{}, 1)
+	stop := d.gcStop
+	// Cache entries already present at startup start with one recorded use so
+	// the LFU eviction does not single them out before any pull or boot.
+	d.imageUseCount = make(map[string]int64)
+	if cached, err := listCachedImages(d.config.StateRoot); err == nil {
+		for _, digest := range cached {
+			d.imageUseCount[digest] = 1
+		}
+	}
+	d.mu.Unlock()
+	go d.imageGCLoop(interval, stop)
 	return nil
+}
+
+// touchImage records a use of a cached image for the LFU eviction order. It
+// is called when an image is pulled or booted.
+func (d *Driver) touchImage(image string) {
+	d.mu.Lock()
+	if d.imageUseCount != nil {
+		d.imageUseCount[imageKey(image)]++
+	}
+	d.mu.Unlock()
+}
+
+// TriggerImageGC requests an out-of-band collection from the independent GC
+// loop. It is non-blocking; a collection already in flight coalesces the
+// request. The loop remains independent of Sandbox lifecycle events.
+func (d *Driver) TriggerImageGC() {
+	d.mu.RLock()
+	trigger := d.gcTrigger
+	d.mu.RUnlock()
+	if trigger == nil {
+		return
+	}
+	select {
+	case trigger <- struct{}{}:
+	default:
+	}
+}
+
+// imageGCLoop periodically collects unreferenced cached images. It runs
+// independently of Sandbox lifecycle events and stops when Close closes the
+// stop channel.
+func (d *Driver) imageGCLoop(interval time.Duration, stop <-chan struct{}) {
+	d.gcImageCache()
+	for {
+		d.mu.RLock()
+		trigger := d.gcTrigger
+		d.mu.RUnlock()
+		select {
+		case <-stop:
+			return
+		case <-trigger:
+			d.gcImageCache()
+		case <-time.After(interval):
+			d.gcImageCache()
+		}
+	}
+}
+
+// gcImageCache drops cached rootfs images that no managed Sandbox references
+// and that have been idle beyond the grace period. Failures are logged and
+// never fail the surrounding operation.
+func (d *Driver) gcImageCache() {
+	d.mu.RLock()
+	stateRoot := d.config.StateRoot
+	useCount := d.imageUseCount
+	limitBytes := d.imageCacheLimitBytes
+	d.mu.RUnlock()
+	if limitBytes <= 0 {
+		limitBytes = defaultImageCacheLimitBytes
+	}
+	removed, err := garbageCollectImages(stateRoot, limitBytes, useCount)
+	if err != nil {
+		klog.V(2).InfoS("firecracker image cache GC skipped", "err", err)
+		return
+	}
+	if len(removed) > 0 {
+		klog.InfoS("firecracker image cache GC removed unreferenced images", "digests", removed)
+	}
 }
 
 func validateConfig(config runtimecatalog.FirecrackerConfig) error {
@@ -73,71 +203,707 @@ func (d *Driver) SetNamespace(namespace string) {
 	d.mu.Unlock()
 }
 
-// ProbeCapabilities fails closed until the lifecycle implementation reports a
-// concrete runtime capability report.
+// SetNetworkManager wires the Fastlet-owned slot manager. Each slot carries
+// the pod-side IP and the guest tap prepared by GuestVMNetNSDriver.
+func (d *Driver) SetNetworkManager(manager *fastletnetwork.Manager) {
+	d.mu.Lock()
+	d.networkManager = manager
+	d.mu.Unlock()
+}
+
+// SetInfraManager wires the prepared Infra Component plan. Artifacts are
+// copied into the per-instance guest rootfs before boot (GuestCopy delivery).
+func (d *Driver) SetInfraManager(manager *fastletinfra.Manager) {
+	d.mu.Lock()
+	d.infraMgr = manager
+	d.prepareInfra = manager.PrepareInstance
+	d.mu.Unlock()
+}
+
+// ProbeCapabilities reports host dependencies (KVM, tap device, binary,
+// kernel). The profile gate keeps the runtime fail-closed until the KVM E2E
+// suite passes.
 func (d *Driver) ProbeCapabilities(_ context.Context) CapabilityReport {
 	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return CapabilityReport{
-		Runtime: d.profile.Name, ProfileHash: d.profile.ProfileHash,
-		State: runtimecatalog.CapabilityUnsupported, Reason: reasonUnimplemented,
-		Message: "firecracker runtime driver lifecycle is not implemented yet",
+	profile := d.profile
+	config := d.config
+	stat := d.stat
+	d.mu.RUnlock()
+
+	report := CapabilityReport{Runtime: profile.Name, ProfileHash: profile.ProfileHash, State: runtimecatalog.CapabilityReady}
+	if profile.Capabilities.DefaultState == runtimecatalog.CapabilityUnsupported {
+		report.State = runtimecatalog.CapabilityUnsupported
+		report.Reason = profile.Capabilities.Reason
+		report.Message = "firecracker runtime profile is registered but its production capability gate is not enabled"
+		return report
 	}
+	checks := []struct {
+		path   string
+		reason string
+	}{
+		{"/dev/kvm", "KVMUnavailable"},
+		{"/dev/net/tun", "TapDeviceUnavailable"},
+		{config.BinaryPath, "RuntimeBinaryUnavailable"},
+		{config.KernelPath, "RuntimeKernelUnavailable"},
+	}
+	for _, check := range checks {
+		if _, err := stat(check.path); err != nil {
+			report.Missing = append(report.Missing, check.path)
+			if report.Reason == "" {
+				report.Reason = check.reason
+			}
+		}
+	}
+	if len(report.Missing) > 0 {
+		report.State = runtimecatalog.CapabilityDegraded
+		report.Message = fmt.Sprintf("firecracker runtime dependencies are unavailable: %v", report.Missing)
+		return report
+	}
+	report.Reason = "RuntimeDriverReady"
+	report.Message = "firecracker runtime host dependencies are ready"
+	return report
 }
 
-// EnsureSandbox boots one Firecracker microVM on demand for the Sandbox. The
-// boot implementation is pending.
-func (d *Driver) EnsureSandbox(_ context.Context, _ *fastletapi.SandboxSpec) (*SandboxMetadata, error) {
-	return nil, errLifecycleUnimplemented
+// EnsureSandbox boots one Firecracker microVM on demand. The call is
+// idempotent and emits an OTel span tree correlated by the Sandbox identity.
+func (d *Driver) EnsureSandbox(ctx context.Context, config *fastletapi.SandboxSpec) (_ *SandboxMetadata, resultErr error) {
+	if config == nil || config.SandboxID == "" || config.FastletPodUID == "" ||
+		config.InstanceGeneration <= 0 || config.RuntimeInstanceID == "" || config.AssignmentAttempt <= 0 {
+		return nil, fmt.Errorf("%w: complete Firecracker Sandbox identity is required", ErrInvalidConfig)
+	}
+	ctx = observability.WithIdentity(ctx, observability.Identity{
+		RequestID: config.RequestID, Namespace: config.ClaimNamespace, SandboxName: config.ClaimName,
+		SandboxUID: config.SandboxID, FastletPodUID: config.FastletPodUID,
+		InstanceGeneration: config.InstanceGeneration, AssignmentAttempt: config.AssignmentAttempt,
+	})
+	ctx, createSpan := observability.Start(ctx, "fastlet.firecracker.create")
+	infraPrepared := false
+	defer func() {
+		observability.End(createSpan, resultErr)
+		if resultErr != nil && infraPrepared && d.infraMgr != nil {
+			_ = d.infraMgr.RemoveInstance(config)
+		}
+	}()
+
+	d.mu.RLock()
+	stateRoot := d.config.StateRoot
+	manager := d.networkManager
+	d.mu.RUnlock()
+	if manager == nil {
+		return nil, fmt.Errorf("%w: firecracker requires the Fastlet network manager", ErrNetworkUnavailable)
+	}
+
+	directory, err := ensureSandboxDir(stateRoot, config.SandboxID)
+	if err != nil {
+		return nil, err
+	}
+
+	if existing, err := loadState(directory); err == nil {
+		if alive, probeErr := d.probeVM(ctx, existing); probeErr == nil && alive {
+			if err := validateExistingRuntimeProfile(existingMetadata(existing), config); err != nil {
+				return nil, err
+			}
+			return existingMetadata(existing), nil
+		}
+		if err := d.cleanupStale(ctx, directory, existing); err != nil {
+			return nil, err
+		}
+		// The stale state directory was removed; recreate it for the fresh boot.
+		directory, err = ensureSandboxDir(stateRoot, config.SandboxID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	owner := d.networkOwner(config)
+	createStarted := time.Now()
+	acquireCtx, acquireSpan := observability.Start(ctx, "fastlet.firecracker.acquire")
+	slot, err := manager.Acquire(acquireCtx, owner)
+	observability.End(acquireSpan, err)
+	if err != nil {
+		return nil, fmt.Errorf("%w: acquire Firecracker network slot: %v", ErrNetworkUnavailable, err)
+	}
+	acquireDur := time.Since(createStarted)
+	releaseSlot := func() {
+		_ = manager.Release(context.Background(), owner)
+	}
+
+	rootfsStarted := time.Now()
+	_, rootfsSpan := observability.Start(ctx, "fastlet.firecracker.rootfs")
+	rootfsPath, err := resolveRootfsImage(stateRoot, config.Image)
+	var instanceRootfs string
+	if err == nil {
+		instanceRootfs, err = prepareInstanceRootfs(stateRoot, config.Image, directory)
+	}
+	observability.End(rootfsSpan, err)
+	if err != nil {
+		releaseSlot()
+		return nil, err
+	}
+	d.touchImage(config.Image)
+	rootfsDur := time.Since(rootfsStarted)
+	rootfsMiB := float64(0)
+	if info, statErr := os.Stat(instanceRootfs); statErr == nil {
+		rootfsMiB = float64(info.Size()) / (1024 * 1024)
+	}
+
+	// Infra Components: prepare the instance plan and GuestCopy the artifacts
+	// into the per-instance rootfs before boot.
+	var infraServices []infracontract.ServiceEndpoint
+	var infraDiagnostics []infracontract.ComponentDiagnostic
+	infraDur := time.Duration(0)
+	if d.infraMgr != nil {
+		infraStarted := time.Now()
+		infraCtx, infraSpan := observability.Start(ctx, "fastlet.firecracker.infra")
+		instance, prepareErr := d.prepareInfra(infraCtx, config)
+		if prepareErr == nil {
+			prepareErr = deliverGuestInfra(infraCtx, d.runner, instanceRootfs, instance)
+		}
+		observability.End(infraSpan, prepareErr)
+		if prepareErr != nil {
+			_ = d.infraMgr.RemoveInstance(config)
+			releaseSlot()
+			return nil, fmt.Errorf("%w: prepare Infra Components: %v", ErrInfraUnavailable, prepareErr)
+		}
+		infraServices = instance.Services
+		infraDiagnostics = instance.Diagnostics
+		infraPrepared = true
+		infraDur = time.Since(infraStarted)
+		klog.V(4).InfoS("firecracker Infra Components delivered", "sandboxId", config.SandboxID, "services", len(instance.Services), "duration", infraDur.String())
+	}
+
+	state := &SandboxState{
+		Spec: *config, Phase: PhaseStarting,
+		APIAddress: filepath.Join(directory, "api.sock"), CreatedAt: time.Now().Unix(),
+		InfraServices: infraServices, InfraDiagnostics: infraDiagnostics,
+	}
+	if err := saveState(directory, state); err != nil {
+		releaseSlot()
+		return nil, err
+	}
+
+	launchCtx, launchSpan := observability.Start(ctx, "fastlet.firecracker.launch")
+	launchStarted := time.Now()
+	spawnStarted := time.Now()
+	process, err := d.launchVM(launchCtx, config.SandboxID, state.APIAddress, directory)
+	spawnDur := time.Since(spawnStarted)
+	if err == nil {
+		state.PID = process.PID()
+		d.rememberProcess(config.SandboxID, process)
+		if saveErr := saveState(directory, state); saveErr != nil {
+			d.killAndForget(config.SandboxID, process.PID())
+			releaseSlot()
+			observability.End(launchSpan, saveErr)
+			return nil, saveErr
+		}
+		socketStarted := time.Now()
+		err = d.waitSocket(launchCtx, state.APIAddress, firecrackerSocketWaitTimeout)
+		socketWaitDur := time.Since(socketStarted)
+		if err != nil {
+			detail := readProcessLog(directory)
+			d.killAndForget(config.SandboxID, process.PID())
+			releaseSlot()
+			observability.End(launchSpan, err)
+			return nil, fmt.Errorf("%w: firecracker API socket did not appear: %v%s", ErrRuntimeNotInitialized, err, detail)
+		}
+		klog.V(4).InfoS("firecracker API socket ready", "sandboxId", config.SandboxID, "spawn", spawnDur.String(), "socketWait", socketWaitDur.String())
+	}
+	observability.End(launchSpan, err)
+	if err != nil {
+		releaseSlot()
+		return nil, err
+	}
+	launchDur := time.Since(launchStarted)
+
+	client := d.newClient(state.APIAddress)
+	defer client.Close()
+	configureStarted := time.Now()
+	configureCtx, configureSpan := observability.Start(ctx, "fastlet.firecracker.configure")
+	err = configureVM(configureCtx, client, *config, d.config, rootfsPath, instanceRootfs, slot)
+	observability.End(configureSpan, err)
+	if err != nil {
+		d.killAndForget(config.SandboxID, process.PID())
+		releaseSlot()
+		return nil, err
+	}
+	configureDur := time.Since(configureStarted)
+
+	bootStarted := time.Now()
+	bootCtx, bootSpan := observability.Start(ctx, "fastlet.firecracker.boot")
+	polls, err := bootVM(bootCtx, client, d.config.BootTimeoutSeconds)
+	observability.End(bootSpan, err)
+	if err != nil {
+		d.killAndForget(config.SandboxID, process.PID())
+		releaseSlot()
+		return nil, err
+	}
+	bootDur := time.Since(bootStarted)
+
+	state.Phase = PhaseRunning
+	if err := saveState(directory, state); err != nil {
+		d.killAndForget(config.SandboxID, process.PID())
+		releaseSlot()
+		return nil, err
+	}
+	klog.InfoS("firecracker sandbox created",
+		"sandboxId", config.SandboxID,
+		"total", time.Since(createStarted).String(),
+		"acquire", acquireDur.String(),
+		"rootfs", rootfsDur.String(), "rootfsMiB", fmt.Sprintf("%.1f", rootfsMiB),
+		"infra", infraDur.String(),
+		"launch", launchDur.String(),
+		"configure", configureDur.String(),
+		"boot", bootDur.String(), "vmStatePolls", polls,
+	)
+	return existingMetadata(state), nil
 }
 
-// InspectSandbox reports the metadata of a managed Firecracker microVM.
-func (d *Driver) InspectSandbox(_ context.Context, _ string) (*SandboxMetadata, error) {
-	return nil, errLifecycleUnimplemented
+// InspectSandbox returns the metadata of a managed microVM. An unreachable
+// VM is reported with Phase Stopped instead of an error so Fastlet can
+// reconcile the real state.
+func (d *Driver) InspectSandbox(ctx context.Context, sandboxID string) (_ *SandboxMetadata, resultErr error) {
+	ctx = observability.WithIdentity(ctx, observability.Identity{SandboxUID: sandboxID})
+	ctx, span := observability.Start(ctx, "fastlet.firecracker.inspect")
+	defer func() { observability.End(span, resultErr) }()
+	d.mu.RLock()
+	stateRoot := d.config.StateRoot
+	d.mu.RUnlock()
+	directory, err := sandboxDir(stateRoot, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	state, err := loadState(directory)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrSandboxNotFound
+		}
+		return nil, err
+	}
+	if alive, probeErr := d.probeVM(ctx, state); probeErr == nil && !alive {
+		state.Phase = PhaseStopped
+	}
+	return existingMetadata(state), nil
 }
 
-// DeleteSandbox stops and removes the Firecracker microVM of the Sandbox.
-func (d *Driver) DeleteSandbox(_ context.Context, _ string) error {
-	return errLifecycleUnimplemented
+// DeleteSandbox stops the microVM, releases its network slot, and removes the
+// Sandbox state. The call is idempotent.
+func (d *Driver) DeleteSandbox(ctx context.Context, sandboxID string) (resultErr error) {
+	ctx = observability.WithIdentity(ctx, observability.Identity{SandboxUID: sandboxID})
+	ctx, span := observability.Start(ctx, "fastlet.firecracker.delete")
+	defer func() { observability.End(span, resultErr) }()
+	d.mu.RLock()
+	stateRoot := d.config.StateRoot
+	manager := d.networkManager
+	d.mu.RUnlock()
+	directory, err := sandboxDir(stateRoot, sandboxID)
+	if err != nil {
+		return err
+	}
+	state, err := loadState(directory)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	d.killAndForget(sandboxID, state.PID)
+	if manager != nil && state.Spec.SandboxID != "" {
+		if _, exists := manager.Lookup(sandboxID); exists {
+			_ = manager.Release(ctx, d.networkOwner(&state.Spec))
+		}
+	}
+	d.mu.RLock()
+	infraMgr := d.infraMgr
+	d.mu.RUnlock()
+	if infraMgr != nil {
+		_ = infraMgr.RemoveSandboxInstances(sandboxID)
+	}
+	_ = removeSandboxDir(directory)
+	klog.Infof("firecracker sandbox %s deleted", sandboxID)
+	return nil
 }
 
-// ListManagedSandboxes lists the Sandboxes owned by this Fastlet.
+// ListManagedSandboxes returns the Sandboxes managed by this Fastlet in the
+// configured namespace.
 func (d *Driver) ListManagedSandboxes(_ context.Context) ([]*SandboxMetadata, error) {
-	return nil, errLifecycleUnimplemented
+	d.mu.RLock()
+	stateRoot := d.config.StateRoot
+	namespace := d.namespace
+	d.mu.RUnlock()
+	directories, err := listSandboxDirs(stateRoot)
+	if err != nil {
+		return nil, err
+	}
+	managed := make([]*SandboxMetadata, 0, len(directories))
+	for _, directory := range directories {
+		state, err := loadState(directory)
+		if err != nil || (namespace != "" && state.Spec.ClaimNamespace != namespace) {
+			continue
+		}
+		managed = append(managed, existingMetadata(state))
+	}
+	return managed, nil
 }
 
-// RecoverRuntimeResources reattaches Fastlet to VMs that survived a Fastlet
-// restart.
-func (d *Driver) RecoverRuntimeResources(_ context.Context, _ []*SandboxMetadata) error {
-	return errLifecycleUnimplemented
+// RecoverRuntimeResources cleans up VMs that died with a Fastlet restart:
+// Firecracker processes are pod-local, so stale records are removed and
+// their slots released; surviving VMs are returned.
+func (d *Driver) RecoverRuntimeResources(ctx context.Context, managed []*SandboxMetadata) error {
+	d.mu.RLock()
+	stateRoot := d.config.StateRoot
+	manager := d.networkManager
+	d.mu.RUnlock()
+	directories, err := listSandboxDirs(stateRoot)
+	if err != nil {
+		return err
+	}
+	for _, directory := range directories {
+		state, err := loadState(directory)
+		if err != nil {
+			continue
+		}
+		alive, probeErr := d.probeVM(ctx, state)
+		if probeErr != nil || !alive {
+			if manager != nil {
+				if slot, exists := manager.Lookup(state.Spec.SandboxID); exists {
+					_ = slot
+					_ = manager.Release(ctx, d.networkOwner(&state.Spec))
+				}
+			}
+			d.killAndForget(state.Spec.SandboxID, state.PID)
+			_ = removeSandboxDir(directory)
+		}
+	}
+	return nil
 }
 
-// GetAccessDescriptor returns the data-plane access descriptor for a Sandbox.
-func (d *Driver) GetAccessDescriptor(_ string) (dataplane.AccessDescriptor, error) {
-	return dataplane.AccessDescriptor{}, fmt.Errorf("%w: firecracker access descriptors are not implemented", ErrNetworkUnavailable)
+// GetAccessDescriptor returns the pod-side DirectIP descriptor of the Sandbox.
+func (d *Driver) GetAccessDescriptor(sandboxID string) (dataplane.AccessDescriptor, error) {
+	d.mu.RLock()
+	manager := d.networkManager
+	d.mu.RUnlock()
+	if manager == nil {
+		return dataplane.AccessDescriptor{}, ErrNetworkUnavailable
+	}
+	slot, exists := manager.Lookup(sandboxID)
+	if !exists {
+		return dataplane.AccessDescriptor{}, ErrSandboxNotFound
+	}
+	if err := slot.Access.Validate(); err != nil {
+		return dataplane.AccessDescriptor{}, fmt.Errorf("%w: %v", ErrNetworkUnavailable, err)
+	}
+	return slot.Access, nil
 }
 
-// ListImages lists the images cached by the Firecracker artifact cache.
-func (d *Driver) ListImages(_ context.Context) ([]string, error) {
-	return nil, errLifecycleUnimplemented
-}
-
-// PullImage caches an image for later Firecracker rootfs preparation.
-func (d *Driver) PullImage(_ context.Context, _ string) error {
-	return errLifecycleUnimplemented
-}
-
-// Close resets the driver state.
+// Close stops every managed microVM and releases driver state.
 func (d *Driver) Close() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	for sandboxID, process := range d.processes {
+		_ = process.Kill()
+		delete(d.processes, sandboxID)
+	}
+	if d.gcStop != nil {
+		close(d.gcStop)
+		d.gcStop = nil
+	}
 	d.initialized = false
 	return nil
 }
 
-var (
-	_ RuntimeDriver            = (*Driver)(nil)
-	_ RuntimeArtifactCache     = (*Driver)(nil)
-	_ RuntimeResourceRecoverer = (*Driver)(nil)
-	_ AccessDescriptorProvider = (*Driver)(nil)
-)
+// probeVM reports whether the Firecracker process and its API socket are
+// alive; the PID check rejects stale records with recycled identifiers.
+func (d *Driver) probeVM(ctx context.Context, state *SandboxState) (bool, error) {
+	if state == nil || state.APIAddress == "" {
+		return false, ErrInvalidConfig
+	}
+	d.mu.RLock()
+	probeProcess := d.probeProcess
+	d.mu.RUnlock()
+	if state.PID > 0 {
+		if err := probeProcess(state.PID); err != nil {
+			return false, nil
+		}
+	}
+	client := d.newClient(state.APIAddress)
+	defer client.Close()
+	if _, err := client.Version(ctx); err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+// firecrackerSocketWaitTimeout bounds the time between process launch and API
+// socket readiness.
+const firecrackerSocketWaitTimeout = 5 * time.Second
+
+// launchVM starts the Firecracker process for the Sandbox.
+func (d *Driver) launchVM(ctx context.Context, sandboxID, apiAddress, stateDir string) (Process, error) {
+	d.mu.RLock()
+	config := d.config
+	launcher := d.launcher
+	d.mu.RUnlock()
+	return launch(ctx, launcher, launchConfig{
+		BinaryPath: config.BinaryPath, SandboxID: sandboxID, APIAddress: apiAddress,
+		LogPath: filepath.Join(stateDir, processLogName),
+	})
+}
+
+// waitForAPISocket polls until the Firecracker API Unix socket exists.
+func waitForAPISocket(ctx context.Context, socketPath string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("socket %s not ready within %s", socketPath, timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// readProcessLog returns the tail of the firecracker process log, or an empty
+// string when no log is available.
+func readProcessLog(stateDir string) string {
+	payload, err := os.ReadFile(filepath.Join(stateDir, processLogName))
+	if err != nil {
+		return ""
+	}
+	tail := payload
+	if len(tail) > 4096 {
+		tail = tail[len(tail)-4096:]
+	}
+	return "\nfirecracker process log:\n" + string(tail)
+}
+
+// configureVM drives the Firecracker API: machine config, boot source, root
+// drive, and the guest network interface backed by the pod-side tap.
+func configureVM(ctx context.Context, client *Client, spec fastletapi.SandboxSpec, config runtimecatalog.FirecrackerConfig, rootfsPath, instanceRootfs string, slot *fastletnetwork.Slot) error {
+	machine, err := resolveMachineConfig(spec, config)
+	if err != nil {
+		return err
+	}
+	if err := client.ConfigureMachine(ctx, machine); err != nil {
+		return fmt.Errorf("configure Firecracker machine: %w", err)
+	}
+	bootArgs, err := guestBootArgs(config, slot)
+	if err != nil {
+		return err
+	}
+	if err := client.ConfigureBootSource(ctx, BootSourceRequest{KernelImagePath: config.KernelPath, BootArgs: bootArgs}); err != nil {
+		return fmt.Errorf("configure Firecracker boot source: %w", err)
+	}
+	if err := client.AttachDrive(ctx, DriveRequest{
+		DriveID: "root", PathOnHost: instanceRootfs, IsRootDevice: true, IsReadOnly: false,
+	}); err != nil {
+		return fmt.Errorf("attach Firecracker root drive: %w", err)
+	}
+	tapDevice := slot.GuestTap
+	if tapDevice == "" {
+		return fmt.Errorf("%w: slot %s has no pre-provisioned guest tap", ErrNetworkUnavailable, slot.ID)
+	}
+	if err := client.AttachNetworkInterface(ctx, NetworkInterfaceRequest{
+		IfaceID: "eth0", HostDevName: tapDevice, GuestMAC: guestMAC(spec.SandboxID),
+	}); err != nil {
+		return fmt.Errorf("attach Firecracker network interface: %w", err)
+	}
+	_ = rootfsPath
+	return nil
+}
+
+// guestBootArgs composes the guest kernel command line with the static
+// network configuration derived from the network slot.
+func guestBootArgs(config runtimecatalog.FirecrackerConfig, slot *fastletnetwork.Slot) (string, error) {
+	base := config.BootArgs
+	if base == "" {
+		base = defaultBootArgs
+	}
+	guestIP, err := fastletnetwork.GuestVMIP(slot)
+	if err != nil {
+		return "", err
+	}
+	prefix, err := netip.ParsePrefix(slot.PrivateCIDR)
+	if err != nil {
+		return "", fmt.Errorf("%w: invalid private CIDR %q", ErrInvalidConfig, slot.PrivateCIDR)
+	}
+	// The kernel ip= parameter expects a dotted-quad netmask, not a prefix
+	// length; a bare "24" is parsed as 24.0.0.0 and rejected with EINVAL.
+	mask, err := prefixMask(prefix.Bits())
+	if err != nil {
+		return "", err
+	}
+	return buildBootArgs(base, guestIP, slot.Gateway, mask), nil
+}
+
+// bootVM starts the microVM and waits until the machine state is Running.
+// bootVM starts the microVM, waits until the machine state is Running, and
+// returns the number of VM state polls performed.
+func bootVM(ctx context.Context, client *Client, timeoutSeconds int32) (int, error) {
+	if err := client.Start(ctx); err != nil {
+		return 0, fmt.Errorf("start Firecracker instance: %w", err)
+	}
+	deadline := time.Now().Add(time.Duration(timeoutSeconds) * time.Second)
+	polls := 0
+	for {
+		state, err := client.VMState(ctx)
+		if err != nil {
+			return polls, fmt.Errorf("query Firecracker VM state: %w", err)
+		}
+		polls++
+		if state == "Running" {
+			return polls, nil
+		}
+		if time.Now().After(deadline) {
+			return polls, fmt.Errorf("%w: Firecracker VM did not reach Running within %ds (state %q)", ErrRuntimeNotInitialized, timeoutSeconds, state)
+		}
+		select {
+		case <-ctx.Done():
+			return polls, ctx.Err()
+		case <-time.After(bootPollInterval):
+		}
+	}
+}
+
+// resolveMachineConfig maps the Sandbox resource profile to Firecracker
+// machine configuration, falling back to runtime defaults.
+func resolveMachineConfig(spec fastletapi.SandboxSpec, config runtimecatalog.FirecrackerConfig) (MachineConfigRequest, error) {
+	request := MachineConfigRequest{VCPUs: int(config.DefaultVCPUs), MemSizeMiB: defaultMemoryMiB(config.DefaultMemory)}
+	if spec.CPU != "" {
+		quantity, err := resource.ParseQuantity(spec.CPU)
+		if err != nil {
+			return MachineConfigRequest{}, fmt.Errorf("%w: invalid CPU %q", ErrInvalidConfig, spec.CPU)
+		}
+		millis := quantity.MilliValue()
+		request.VCPUs = int(math.Ceil(float64(millis) / 1000.0))
+		if request.VCPUs < 1 {
+			return MachineConfigRequest{}, fmt.Errorf("%w: CPU %q yields no vCPU", ErrInvalidConfig, spec.CPU)
+		}
+	}
+	if spec.Memory != "" {
+		quantity, err := resource.ParseQuantity(spec.Memory)
+		if err != nil {
+			return MachineConfigRequest{}, fmt.Errorf("%w: invalid memory %q", ErrInvalidConfig, spec.Memory)
+		}
+		request.MemSizeMiB = int(math.Ceil(float64(quantity.Value()) / (1024.0 * 1024.0)))
+		if request.MemSizeMiB < 1 {
+			return MachineConfigRequest{}, fmt.Errorf("%w: memory %q yields no MiB", ErrInvalidConfig, spec.Memory)
+		}
+	}
+	return request, nil
+}
+
+func defaultMemoryMiB(memory string) int {
+	quantity, err := resource.ParseQuantity(memory)
+	if err != nil {
+		return 512
+	}
+	mib := int(math.Ceil(float64(quantity.Value()) / (1024.0 * 1024.0)))
+	if mib < 1 {
+		return 512
+	}
+	return mib
+}
+
+func (d *Driver) networkOwner(config *fastletapi.SandboxSpec) fastletnetwork.Owner {
+	generation := config.InstanceGeneration
+	if generation <= 0 {
+		generation = 1
+	}
+	attempt := config.AssignmentAttempt
+	if attempt <= 0 {
+		attempt = 1
+	}
+	return fastletnetwork.Owner{
+		SandboxUID: config.SandboxID, SandboxName: config.ClaimName, SandboxNamespace: config.ClaimNamespace,
+		InstanceGeneration: generation, RuntimeInstanceID: config.RuntimeInstanceID,
+		AssignmentAttempt: attempt, ResidualProcess: runtimecatalog.ResidualProcessFirecracker,
+	}
+}
+
+func existingMetadata(state *SandboxState) *SandboxMetadata {
+	metadata := &SandboxMetadata{SandboxSpec: state.Spec}
+	metadata.ContainerID = state.Spec.SandboxID
+	metadata.PID = state.PID
+	metadata.Phase = string(state.Phase)
+	metadata.CreatedAt = state.CreatedAt
+	metadata.UserProcessStartSource = fastletapi.UserProcessStartRuntimeDirect
+	metadata.InfraServices = append(metadata.InfraServices, state.InfraServices...)
+	metadata.InfraDiagnostics = append(metadata.InfraDiagnostics, state.InfraDiagnostics...)
+	return metadata
+}
+
+func (d *Driver) rememberProcess(sandboxID string, process Process) {
+	d.mu.Lock()
+	d.processes[sandboxID] = process
+	d.mu.Unlock()
+}
+
+// killAndForget stops the tracked process of a Sandbox; when no process
+// handle exists (Fastlet restart), it falls back to the persisted PID.
+func (d *Driver) killAndForget(sandboxID string, pid int) {
+	d.mu.Lock()
+	process, exists := d.processes[sandboxID]
+	delete(d.processes, sandboxID)
+	d.mu.Unlock()
+	if exists {
+		if process.Kill() == nil {
+			// Wait for the VMM to exit before the network slot is released;
+			// deleting the slot netns races a still-dying firecracker and
+			// leaks the namespace (and its private address) on the bridge.
+			done := make(chan struct{})
+			go func() { _ = process.Wait(); close(done) }()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+			}
+		}
+		return
+	}
+	if d.killProcess != nil {
+		_ = d.killProcess(pid)
+	}
+}
+
+// cleanupStale removes the state of a dead VM and its network binding.
+func (d *Driver) cleanupStale(ctx context.Context, directory string, state *SandboxState) error {
+	d.mu.RLock()
+	manager := d.networkManager
+	d.mu.RUnlock()
+	if manager != nil && state.Spec.SandboxID != "" {
+		if _, exists := manager.Lookup(state.Spec.SandboxID); exists {
+			_ = manager.Release(ctx, d.networkOwner(&state.Spec))
+		}
+	}
+	d.killAndForget(state.Spec.SandboxID, state.PID)
+	return removeSandboxDir(directory)
+}
+
+func killPID(pid int) error {
+	if pid <= 0 {
+		return nil
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Kill()
+}
+
+// pidAlive probes process existence with signal 0.
+func pidAlive(pid int) error {
+	if pid <= 0 {
+		return errors.New("invalid pid")
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Signal(syscall.Signal(0))
+}
+
+var _ runtimecontract.Driver = (*Driver)(nil)

--- a/internal/runtime/firecracker/driver_test.go
+++ b/internal/runtime/firecracker/driver_test.go
@@ -2,14 +2,207 @@ package firecracker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	apiv1alpha2 "fast-sandbox/api/v1alpha2"
+	infracatalog "fast-sandbox/internal/catalog/infra"
 	runtimecatalog "fast-sandbox/internal/catalog/runtime"
+	fastletinfra "fast-sandbox/internal/fastlet/infra"
+	fastletnetwork "fast-sandbox/internal/fastlet/network"
+	infracontract "fast-sandbox/internal/infra/contract"
+	fastletapi "fast-sandbox/internal/protocol/fastlet"
 
 	"github.com/stretchr/testify/require"
 )
+
+// firecrackerConfigForTest returns the built-in Firecracker configuration with
+// the StateRoot redirected to a test directory.
+func firecrackerConfigForTest(t *testing.T, root string) runtimecatalog.FirecrackerConfig {
+	t.Helper()
+	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
+	require.NoError(t, err)
+	profile.Firecracker.StateRoot = root
+	return *profile.Firecracker
+}
+
+// fakeNetworkDriver no-ops the host netns preparation steps.
+type fakeNetworkDriver struct{}
+
+func (fakeNetworkDriver) Prepare(context.Context, *fastletnetwork.Slot) error  { return nil }
+func (fakeNetworkDriver) Validate(context.Context, *fastletnetwork.Slot) error { return nil }
+func (fakeNetworkDriver) Destroy(context.Context, *fastletnetwork.Slot) error  { return nil }
+
+// memoryStateStore keeps slots in memory for the manager fixture.
+type memoryStateStore struct {
+	mu    sync.Mutex
+	slots map[string]*fastletnetwork.Slot
+}
+
+func newMemoryStateStore() *memoryStateStore {
+	return &memoryStateStore{slots: make(map[string]*fastletnetwork.Slot)}
+}
+
+func (s *memoryStateStore) LoadAll(context.Context) ([]*fastletnetwork.Slot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	slots := make([]*fastletnetwork.Slot, 0, len(s.slots))
+	for _, slot := range s.slots {
+		slots = append(slots, cloneSlotForTest(slot))
+	}
+	return slots, nil
+}
+
+func (s *memoryStateStore) Save(_ context.Context, slot *fastletnetwork.Slot) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.slots[slot.ID] = cloneSlotForTest(slot)
+	return nil
+}
+
+func (s *memoryStateStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.slots, id)
+	return nil
+}
+
+func cloneSlotForTest(slot *fastletnetwork.Slot) *fastletnetwork.Slot {
+	clone := *slot
+	return &clone
+}
+
+func newNetworkManagerForTest(t *testing.T) *fastletnetwork.Manager {
+	t.Helper()
+	root := t.TempDir()
+	manager, err := fastletnetwork.NewManager(fastletnetwork.Config{
+		Capacity: 1, PodUID: "pod-1", PrivateCIDR: "172.30.0.0/24",
+		StateRoot: root, NetNSRoot: filepath.Join(root, "netns"), HostNetNSRoot: filepath.Join(root, "host-netns"),
+		IDGenerator: func() (string, error) { return "slot-1", nil },
+		Now:         func() time.Time { return time.Unix(1720000000, 0) },
+	}, fakeNetworkDriver{}, newMemoryStateStore())
+	require.NoError(t, err)
+	require.NoError(t, manager.Initialize(context.Background()))
+	return manager
+}
+
+// statefulFakeServer scripts the Firecracker API and records calls.
+type statefulFakeServer struct {
+	mu      sync.Mutex
+	calls   []string
+	running bool
+	socket  string
+}
+
+func newStatefulFakeServer(t *testing.T) *statefulFakeServer {
+	server := &statefulFakeServer{}
+	server.socket = startFakeFirecracker(t, server.handle)
+	return server
+}
+
+func (s *statefulFakeServer) handle(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	s.calls = append(s.calls, r.Method+" "+r.URL.Path)
+	s.mu.Unlock()
+	switch r.URL.Path {
+	case "/version":
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"1.15.1"}`))
+	case "/actions":
+		var action actionRequest
+		_ = json.NewDecoder(r.Body).Decode(&action)
+		s.mu.Lock()
+		s.running = action.ActionType == "InstanceStart"
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	case "/":
+		s.mu.Lock()
+		state := "NotStarted"
+		if s.running {
+			state = "Running"
+		}
+		s.mu.Unlock()
+		_, _ = w.Write([]byte(`{"state":"` + state + `"}`))
+	default:
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (s *statefulFakeServer) recordedCalls() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.calls...)
+}
+
+// driverFixture wires a Driver with fake Firecracker, process, and network
+// backends.
+type driverFixture struct {
+	driver      *Driver
+	runner      *infraRunner
+	launcher    *fakeProcessRunner
+	server      *statefulFakeServer
+	killCalls   []int
+	stateRoot   string
+	manager     *fastletnetwork.Manager
+	sandboxSpec fastletapi.SandboxSpec
+}
+
+func newDriverFixture(t *testing.T) *driverFixture {
+	t.Helper()
+	stateRoot := t.TempDir()
+	config := firecrackerConfigForTest(t, stateRoot)
+	profile := runtimecatalog.RuntimeProfile{
+		Name: apiv1alpha2.RuntimeFirecracker, ProfileHash: "hash",
+		Firecracker:  &config,
+		Capabilities: runtimecatalog.Capabilities{DefaultState: runtimecatalog.CapabilityReady},
+	}
+	server := newStatefulFakeServer(t)
+	launcher := &fakeProcessRunner{}
+	runner := &infraRunner{}
+	fixture := &driverFixture{
+		runner: runner, launcher: launcher, server: server, stateRoot: stateRoot,
+		manager: newNetworkManagerForTest(t),
+	}
+	driver := &Driver{
+		profile: profile, config: config,
+		runner: runner, launcher: launcher,
+		newClient: func(string) *Client { return NewClient(server.socket) },
+		stat:      func(string) (os.FileInfo, error) { return fakeFileInfoForTest{}, nil },
+		killProcess: func(pid int) error {
+			fixture.killCalls = append(fixture.killCalls, pid)
+			return nil
+		},
+		probeProcess:         func(int) error { return nil },
+		waitSocket:           func(context.Context, string, time.Duration) error { return nil },
+		processes:            make(map[string]Process),
+		imageGCInterval:      defaultImageGCInterval,
+		imageCacheLimitBytes: defaultImageCacheLimitBytes,
+	}
+	driver.SetNetworkManager(fixture.manager)
+	fixture.driver = driver
+	fixture.sandboxSpec = fastletapi.SandboxSpec{
+		SandboxID: "sandbox-1", ClaimUID: "claim-1", ClaimName: "sandbox-1", ClaimNamespace: "tenant-a",
+		InstanceGeneration: 1, RuntimeInstanceID: "runtime-1", AssignmentAttempt: 1,
+		FastletPodUID: "pod-1", Image: "example.com/app:v1", CPU: "2", Memory: "1Gi",
+		RuntimeProfileHash: "hash", ResourceProfileHash: "r-hash",
+	}
+	return fixture
+}
+
+func (f *driverFixture) prepareCachedImage(t *testing.T, image string) {
+	t.Helper()
+	path, err := imageCachePath(f.stateRoot, image)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte("rootfs-image-data"), 0o640))
+}
 
 func TestNewRequiresProfileConfig(t *testing.T) {
 	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
@@ -22,67 +215,381 @@ func TestNewRequiresProfileConfig(t *testing.T) {
 }
 
 func TestInitializeValidatesBootConfig(t *testing.T) {
-	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
-	require.NoError(t, err)
+	fixture := newDriverFixture(t)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
 
-	driver, err := New(profile)
-	require.NoError(t, err)
-	require.NoError(t, driver.Initialize(context.Background(), ""))
-	require.NoError(t, driver.Initialize(context.Background(), ""))
-
-	broken, err := New(profile)
+	broken, err := New(fixture.driver.profile)
 	require.NoError(t, err)
 	broken.config.BinaryPath = ""
 	require.ErrorIs(t, broken.Initialize(context.Background(), ""), ErrInvalidConfig)
 
-	invalid, err := New(profile)
+	invalid, err := New(fixture.driver.profile)
 	require.NoError(t, err)
 	invalid.config.BootTimeoutSeconds = 0
 	require.ErrorIs(t, invalid.Initialize(context.Background(), ""), ErrInvalidConfig)
 }
 
-func TestProbeCapabilitiesFailsClosed(t *testing.T) {
-	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
-	require.NoError(t, err)
-	driver, err := New(profile)
-	require.NoError(t, err)
-
-	report := driver.ProbeCapabilities(context.Background())
+func TestProbeCapabilitiesFailsClosedWithProfileGate(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.driver.profile.Capabilities.DefaultState = runtimecatalog.CapabilityUnsupported
+	fixture.driver.profile.Capabilities.Reason = "FirecrackerDriverUnimplemented"
+	report := fixture.driver.ProbeCapabilities(context.Background())
 	require.Equal(t, runtimecatalog.CapabilityUnsupported, report.State)
 	require.Equal(t, "FirecrackerDriverUnimplemented", report.Reason)
-	require.False(t, report.Ready())
 }
 
-func TestLifecycleOperationsFailClosed(t *testing.T) {
-	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
-	require.NoError(t, err)
-	driver, err := New(profile)
-	require.NoError(t, err)
-	require.NoError(t, driver.Initialize(context.Background(), ""))
+func TestProbeCapabilitiesReady(t *testing.T) {
+	fixture := newDriverFixture(t)
+	report := fixture.driver.ProbeCapabilities(context.Background())
+	require.Equal(t, runtimecatalog.CapabilityReady, report.State)
+	require.Empty(t, report.Missing)
 
-	ctx := context.Background()
-	_, err = driver.EnsureSandbox(ctx, nil)
-	require.True(t, errors.Is(err, errLifecycleUnimplemented))
-	_, err = driver.InspectSandbox(ctx, "sandbox-1")
-	require.True(t, errors.Is(err, errLifecycleUnimplemented))
-	require.True(t, errors.Is(driver.DeleteSandbox(ctx, "sandbox-1"), errLifecycleUnimplemented))
-	_, err = driver.ListManagedSandboxes(ctx)
-	require.True(t, errors.Is(err, errLifecycleUnimplemented))
-	require.True(t, errors.Is(driver.RecoverRuntimeResources(ctx, nil), errLifecycleUnimplemented))
-	_, err = driver.GetAccessDescriptor("sandbox-1")
-	require.True(t, errors.Is(err, ErrNetworkUnavailable))
-	_, err = driver.ListImages(ctx)
-	require.True(t, errors.Is(err, errLifecycleUnimplemented))
-	require.True(t, errors.Is(driver.PullImage(ctx, "example.com/image:latest"), errLifecycleUnimplemented))
+	fixture.driver.stat = func(path string) (os.FileInfo, error) {
+		if path == "/dev/kvm" {
+			return nil, os.ErrNotExist
+		}
+		return fakeFileInfoForTest{}, nil
+	}
+	report = fixture.driver.ProbeCapabilities(context.Background())
+	require.Equal(t, runtimecatalog.CapabilityDegraded, report.State)
+	require.Equal(t, "KVMUnavailable", report.Reason)
+	require.Contains(t, report.Missing, "/dev/kvm")
+}
+
+type fakeFileInfoForTest struct{}
+
+func (fakeFileInfoForTest) Name() string       { return "probe" }
+func (fakeFileInfoForTest) Size() int64        { return 0 }
+func (fakeFileInfoForTest) Mode() os.FileMode  { return 0 }
+func (fakeFileInfoForTest) ModTime() time.Time { return time.Time{} }
+func (fakeFileInfoForTest) IsDir() bool        { return false }
+func (fakeFileInfoForTest) Sys() any           { return nil }
+
+func TestEnsureSandboxDeliversInfraComponents(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	infraJSON := filepath.Join(t.TempDir(), "infra.json")
+	require.NoError(t, os.WriteFile(infraJSON, []byte(`{"version":1}`), 0o400))
+	fixture.driver.prepareInfra = func(context.Context, *fastletapi.SandboxSpec) (fastletinfra.PreparedInstance, error) {
+		return fastletinfra.PreparedInstance{
+			ConfigHostPath: infraJSON,
+			Mounts: []fastletinfra.Mount{
+				{Source: infraJSON, Destination: "/.fast/run/infra.json", Options: []string{"ro"}},
+			},
+			Services: []infracontract.ServiceEndpoint{
+				{Component: "execd", Protocol: "HTTP", Port: 44772},
+			},
+			Diagnostics: []infracontract.ComponentDiagnostic{{Component: "execd", State: "Starting"}},
+		}, nil
+	}
+	fixture.driver.infraMgr = &fastletinfra.Manager{} // enable the infra path; prepareInfra is faked
+
+	metadata, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+	require.Len(t, metadata.InfraServices, 1)
+	require.Equal(t, uint32(44772), metadata.InfraServices[0].Port)
+	require.Len(t, metadata.InfraDiagnostics, 1)
+
+	joined := strings.Join(fixture.runner.commands, "\n")
+	require.Contains(t, joined, "mount -o loop")
+	require.Contains(t, joined, "/.fast/run/infra.json")
+	require.Contains(t, joined, "umount ")
+
+	// The persisted state carries the services for route publication.
+	directory, err := sandboxDir(fixture.stateRoot, "sandbox-1")
+	require.NoError(t, err)
+	state, err := loadState(directory)
+	require.NoError(t, err)
+	require.Len(t, state.InfraServices, 1)
+}
+
+func TestEnsureSandboxInfraFailureReleasesResources(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	fixture.driver.prepareInfra = func(context.Context, *fastletapi.SandboxSpec) (fastletinfra.PreparedInstance, error) {
+		return fastletinfra.PreparedInstance{}, errors.New("plan revision mismatch")
+	}
+	root := t.TempDir()
+	store, err := fastletinfra.NewArtifactStore(filepath.Join(root, "pod"), filepath.Join(root, "host"))
+	require.NoError(t, err)
+	fixture.driver.infraMgr, err = fastletinfra.NewManagerWithConfig(fastletinfra.ManagerConfig{Store: store, Resolver: fakeResolver{}})
+	require.NoError(t, err)
+
+	_, err = fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.ErrorIs(t, err, ErrInfraUnavailable)
+	require.Empty(t, fixture.launcher.started)
+	require.Equal(t, 0, fixture.manager.Snapshot().Bound)
+}
+
+// fakeResolver is a minimal ArtifactResolver used to construct an Infra
+// Manager in tests.
+type fakeResolver struct{}
+
+func (fakeResolver) Prepare(context.Context, infracatalog.ArtifactSource, *fastletinfra.ArtifactStore) (fastletinfra.PreparedSource, error) {
+	return fastletinfra.PreparedSource{}, nil
+}
+
+func TestEnsureSandboxBootsVM(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	metadata, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+	require.Equal(t, "sandbox-1", metadata.ContainerID)
+	require.Equal(t, 4242, metadata.PID)
+	require.Equal(t, string(PhaseRunning), metadata.Phase)
+	require.Empty(t, metadata.InfraServices)
+
+	require.Len(t, fixture.launcher.started, 1)
+	require.Equal(t, "/usr/local/bin/firecracker", fixture.launcher.started[0][0])
+	require.Contains(t, fixture.launcher.started[0], "--api-sock")
+
+	calls := fixture.server.recordedCalls()
+	require.Contains(t, calls, "PUT /machine-config")
+	require.Contains(t, calls, "PUT /boot-source")
+	require.Contains(t, calls, "PUT /drives/root")
+	require.Contains(t, calls, "PUT /network-interfaces/eth0")
+	require.Contains(t, calls, "PUT /actions")
+
+	directory, err := sandboxDir(fixture.stateRoot, "sandbox-1")
+	require.NoError(t, err)
+	state, err := loadState(directory)
+	require.NoError(t, err)
+	require.Equal(t, PhaseRunning, state.Phase)
+
+	instanceRootfs := filepath.Join(directory, instanceRootfsName)
+	content, err := os.ReadFile(instanceRootfs)
+	require.NoError(t, err)
+	require.Equal(t, "rootfs-image-data", string(content))
+}
+
+func TestEnsureSandboxIsIdempotent(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	first, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+	second, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+	require.Equal(t, first.ContainerID, second.ContainerID)
+	require.Len(t, fixture.launcher.started, 1)
+}
+
+func TestEnsureSandboxValidatesIdentity(t *testing.T) {
+	fixture := newDriverFixture(t)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	spec := fixture.sandboxSpec
+	spec.AssignmentAttempt = 0
+	_, err := fixture.driver.EnsureSandbox(context.Background(), &spec)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+
+	_, err = fixture.driver.EnsureSandbox(context.Background(), nil)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+}
+
+func TestEnsureSandboxMissingImageReleasesSlot(t *testing.T) {
+	fixture := newDriverFixture(t)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	_, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.ErrorIs(t, err, ErrImageNotReady)
+	require.Empty(t, fixture.launcher.started)
+	require.Equal(t, 0, fixture.manager.Snapshot().Bound)
+}
+
+func TestEnsureSandboxCleansStaleRecord(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	// Plant a stale record whose process is dead.
+	directory, err := ensureSandboxDir(fixture.stateRoot, "sandbox-1")
+	require.NoError(t, err)
+	require.NoError(t, saveState(directory, &SandboxState{
+		Spec: fixture.sandboxSpec, Phase: PhaseRunning, PID: 999, APIAddress: filepath.Join(directory, "dead.sock"),
+	}))
+	fixture.driver.probeProcess = func(pid int) error {
+		if pid == 999 {
+			return os.ErrNotExist
+		}
+		return nil
+	}
+
+	metadata, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+	require.Equal(t, "sandbox-1", metadata.ContainerID)
+	require.Len(t, fixture.launcher.started, 1)
+	require.Contains(t, fixture.killCalls, 999)
+}
+
+func TestInspectSandbox(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	_, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+
+	metadata, err := fixture.driver.InspectSandbox(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	require.Equal(t, string(PhaseRunning), metadata.Phase)
+
+	_, err = fixture.driver.InspectSandbox(context.Background(), "sandbox-missing")
+	require.ErrorIs(t, err, ErrSandboxNotFound)
+}
+
+func TestDeleteSandboxIsIdempotent(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	_, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+	require.NoError(t, fixture.driver.DeleteSandbox(context.Background(), "sandbox-1"))
+	require.NoError(t, fixture.driver.DeleteSandbox(context.Background(), "sandbox-1"))
+	require.NoError(t, fixture.driver.DeleteSandbox(context.Background(), "sandbox-missing"))
+
+	directory, err := sandboxDir(fixture.stateRoot, "sandbox-1")
+	require.NoError(t, err)
+	_, err = os.Stat(directory)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestListManagedSandboxesFiltersNamespace(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	fixture.driver.SetNamespace("tenant-a")
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	_, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+
+	managed, err := fixture.driver.ListManagedSandboxes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, managed, 1)
+	require.Equal(t, "sandbox-1", managed[0].SandboxID)
+
+	fixture.driver.SetNamespace("tenant-b")
+	managed, err = fixture.driver.ListManagedSandboxes(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, managed)
+}
+
+func TestRecoverRuntimeResourcesCleansDeadVM(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.driver.probeProcess = func(int) error { return os.ErrNotExist }
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	directory, err := ensureSandboxDir(fixture.stateRoot, "sandbox-1")
+	require.NoError(t, err)
+	require.NoError(t, saveState(directory, &SandboxState{
+		Spec: fixture.sandboxSpec, Phase: PhaseRunning, PID: 777, APIAddress: filepath.Join(directory, "dead.sock"),
+	}))
+
+	require.NoError(t, fixture.driver.RecoverRuntimeResources(context.Background(), nil))
+	_, err = os.Stat(directory)
+	require.True(t, os.IsNotExist(err))
+	require.Contains(t, fixture.killCalls, 777)
+	require.Equal(t, 0, fixture.manager.Snapshot().Bound)
+}
+
+func TestRecoverRuntimeResourcesKeepsAliveVM(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	_, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+
+	require.NoError(t, fixture.driver.RecoverRuntimeResources(context.Background(), nil))
+	managed, err := fixture.driver.ListManagedSandboxes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, managed, 1)
+}
+
+func TestGetAccessDescriptor(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	_, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+
+	access, err := fixture.driver.GetAccessDescriptor("sandbox-1")
+	require.NoError(t, err)
+	require.Equal(t, "172.30.0.2", access.Address)
+	require.NoError(t, access.Validate())
+
+	_, err = fixture.driver.GetAccessDescriptor("sandbox-missing")
+	require.ErrorIs(t, err, ErrSandboxNotFound)
+}
+
+func TestCloseKillsManagedProcesses(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	_, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+
+	fixture.driver.mu.Lock()
+	process := fixture.driver.processes["sandbox-1"]
+	fixture.driver.mu.Unlock()
+	require.NotNil(t, process)
+
+	require.NoError(t, fixture.driver.Close())
+	fixture.driver.mu.Lock()
+	require.Empty(t, fixture.driver.processes)
+	fixture.driver.mu.Unlock()
+	require.True(t, process.(*fakeProcess).killed)
+}
+
+func TestResolveMachineConfig(t *testing.T) {
+	config := firecrackerConfigForTest(t, t.TempDir())
+
+	request, err := resolveMachineConfig(fastletapi.SandboxSpec{}, config)
+	require.NoError(t, err)
+	require.Equal(t, int(config.DefaultVCPUs), request.VCPUs)
+	require.Equal(t, 512, request.MemSizeMiB)
+
+	request, err = resolveMachineConfig(fastletapi.SandboxSpec{CPU: "500m", Memory: "1Gi"}, config)
+	require.NoError(t, err)
+	require.Equal(t, 1, request.VCPUs)
+	require.Equal(t, 1024, request.MemSizeMiB)
+
+	request, err = resolveMachineConfig(fastletapi.SandboxSpec{CPU: "2.5", Memory: "256Mi"}, config)
+	require.NoError(t, err)
+	require.Equal(t, 3, request.VCPUs)
+	require.Equal(t, 256, request.MemSizeMiB)
+
+	_, err = resolveMachineConfig(fastletapi.SandboxSpec{CPU: "not-a-quantity"}, config)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+}
+
+func TestGuestBootArgs(t *testing.T) {
+	config := firecrackerConfigForTest(t, t.TempDir())
+	slot := &fastletnetwork.Slot{IP: "172.30.0.2", Gateway: "172.30.0.1", PrivateCIDR: "172.30.0.0/24"}
+	args, err := guestBootArgs(config, slot)
+	require.NoError(t, err)
+	require.Equal(t, "console=ttyS0 reboot=k panic=1 pci=off ip=172.30.0.3::172.30.0.1:255.255.255.0::eth0:off", args)
+
+	config.BootArgs = "console=ttyS0 console=tty1"
+	args, err = guestBootArgs(config, slot)
+	require.NoError(t, err)
+	require.Equal(t, "console=ttyS0 console=tty1 ip=172.30.0.3::172.30.0.1:255.255.255.0::eth0:off", args)
 }
 
 func TestCloseResetsDriver(t *testing.T) {
-	profile, err := runtimecatalog.Builtin().Resolve(apiv1alpha2.RuntimeFirecracker)
-	require.NoError(t, err)
-	driver, err := New(profile)
-	require.NoError(t, err)
-	require.NoError(t, driver.Initialize(context.Background(), ""))
-
-	require.NoError(t, driver.Close())
-	require.NoError(t, driver.Initialize(context.Background(), ""))
+	fixture := newDriverFixture(t)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+	require.NoError(t, fixture.driver.Close())
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
 }

--- a/internal/runtime/firecracker/e2e_test.go
+++ b/internal/runtime/firecracker/e2e_test.go
@@ -1,0 +1,502 @@
+//go:build firecracker
+
+package firecracker
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	apiv1alpha2 "fast-sandbox/api/v1alpha2"
+	runtimecatalog "fast-sandbox/internal/catalog/runtime"
+	fastletinfra "fast-sandbox/internal/fastlet/infra"
+	fastletnetwork "fast-sandbox/internal/fastlet/network"
+	"fast-sandbox/internal/observability"
+	fastletapi "fast-sandbox/internal/protocol/fastlet"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TestFirecrackerDriverE2E boots a real Firecracker microVM through the
+// driver on the local machine with a real Infra plan (GuestCopy delivery).
+// It requires root (netns, tap, iptables), /dev/kvm, /dev/net/tun, a
+// firecracker binary, a kernel image, and a converted rootfs.
+// See scripts/firecracker-e2e.sh.
+func TestFirecrackerDriverE2E(t *testing.T) {
+	runE2EOnce(t, true)
+}
+
+// TestFirecrackerDriverE2ENoInfra exercises the same lifecycle without Infra
+// delivery: no SetInfraManager, no infra.json, no components in the guest.
+func TestFirecrackerDriverE2ENoInfra(t *testing.T) {
+	runE2EOnce(t, false)
+}
+
+// TestFirecrackerDriverE2EConcurrent pre-provisions 5 network slots and boots
+// 5 microVMs in parallel through the same driver and slot manager, verifying
+// per-sandbox trace correlation, distinct processes, Infra delivery, and
+// guest reachability for every instance.
+func TestFirecrackerDriverE2EConcurrent(t *testing.T) {
+	const vmCount = 5
+	env := newE2EEnvironment(t, vmCount, true)
+	defer env.teardown()
+
+	snapshot := env.manager.Snapshot()
+	require.Equal(t, vmCount, snapshot.Clean, "all slots must be pre-provisioned before boot")
+	require.Zero(t, snapshot.Bound)
+
+	type bootResult struct {
+		metadata *SandboxMetadata
+		err      error
+		traceID  trace.TraceID
+	}
+	results := make([]bootResult, vmCount)
+	var wg sync.WaitGroup
+	started := time.Now()
+	for index := 0; index < vmCount; index++ {
+		spec := env.spec(index + 1)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, end := env.traceContext(spec.SandboxID)
+			defer end()
+			result := &results[index]
+			result.traceID = trace.SpanContextFromContext(ctx).TraceID()
+			result.metadata, result.err = env.driver.EnsureSandbox(ctx, spec)
+		}()
+	}
+	wg.Wait()
+	t.Logf("%d VMs booted concurrently in %s", vmCount, time.Since(started))
+
+	snapshot = env.manager.Snapshot()
+	require.Zero(t, snapshot.Clean, "all pre-provisioned slots must be bound")
+	require.Equal(t, vmCount, snapshot.Bound)
+
+	pids := make(map[int]string, vmCount)
+	for index := 0; index < vmCount; index++ {
+		spec := env.spec(index + 1)
+		result := results[index]
+		require.NoErrorf(t, result.err, "sandbox %s", spec.SandboxID)
+		env.assertBooted(result.metadata, spec, result.traceID)
+		if owner, exists := pids[result.metadata.PID]; exists {
+			t.Fatalf("VMs must be distinct processes: pid %d used by both %s and %s", result.metadata.PID, owner, spec.SandboxID)
+		}
+		pids[result.metadata.PID] = spec.SandboxID
+		env.assertInfra(result.metadata, spec.SandboxID)
+		env.assertGuestReachable(spec.SandboxID)
+	}
+}
+
+// TestFirecrackerDriverE2EImageGC verifies the independent LFU image cache
+// GC on a real StateRoot: unreferenced low-frequency images are evicted when
+// the cache is over its limit, a running Sandbox pins its image, and deleting
+// the Sandbox releases it for eviction.
+func TestFirecrackerDriverE2EImageGC(t *testing.T) {
+	env := newE2EEnvironment(t, 1, false)
+	defer env.teardown()
+
+	waitGone := func(t *testing.T, path string) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(path); os.IsNotExist(err) {
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		require.Failf(t, "image was not collected: %s", path)
+	}
+	waitPresent := func(t *testing.T, path string) {
+		t.Helper()
+		time.Sleep(500 * time.Millisecond)
+		_, err := os.Stat(path)
+		require.NoError(t, err, "image must be pinned: %s", path)
+	}
+	seedImage := func(t *testing.T, image string) string {
+		t.Helper()
+		path, err := imageCachePath(env.stateRoot, image)
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+		require.NoError(t, os.WriteFile(path, []byte("unused rootfs"), 0o640))
+		return path
+	}
+
+	// The cache limit only fits the real e2e:ubuntu image: any unreferenced
+	// extra image is over the limit and gets evicted by the independent loop.
+	usedPath, err := imageCachePath(env.stateRoot, env.imageRef)
+	require.NoError(t, err)
+	info, err := os.Stat(usedPath)
+	require.NoError(t, err)
+	env.driver.imageCacheLimitBytes = info.Size() + 1
+	unusedPath := seedImage(t, "e2e:unused")
+	env.driver.TriggerImageGC()
+	waitGone(t, unusedPath)
+
+	// A live Sandbox pins its cached image even when the cache is over the
+	// limit; booting also records a use for it.
+	spec := env.spec(1)
+	ctx, end := env.traceContext(spec.SandboxID)
+	defer end()
+	metadata := env.boot(ctx, spec)
+	env.assertGuestReachable(spec.SandboxID)
+	env.driver.TriggerImageGC()
+	waitPresent(t, usedPath)
+
+	// Deleting the Sandbox releases the reference; with the cache over its
+	// limit the now-unreferenced image is evicted on the next collection.
+	env.delete(spec.SandboxID)
+	env.driver.imageCacheLimitBytes = 1
+	env.driver.TriggerImageGC()
+	waitGone(t, usedPath)
+	require.Equal(t, string(PhaseRunning), metadata.Phase)
+}
+
+// runE2EOnce drives one full create/inspect/delete lifecycle.
+func runE2EOnce(t *testing.T, useInfra bool) {
+	env := newE2EEnvironment(t, 1, useInfra)
+	defer env.teardown()
+	t.Logf("infra=%t", useInfra)
+
+	spec := env.spec(1)
+	ctx, end := env.traceContext(spec.SandboxID)
+	defer end()
+
+	started := time.Now()
+	metadata := env.boot(ctx, spec)
+	t.Logf("VM running in %s (pid=%d)", time.Since(started), metadata.PID)
+
+	if useInfra {
+		env.assertInfra(metadata, spec.SandboxID)
+	} else {
+		require.Empty(t, metadata.InfraServices)
+		require.Empty(t, metadata.InfraDiagnostics)
+	}
+
+	env.assertGuestReachable(spec.SandboxID)
+
+	// Inspect reports the running VM.
+	inspected, err := env.driver.InspectSandbox(ctx, spec.SandboxID)
+	require.NoError(t, err)
+	require.Equal(t, string(PhaseRunning), inspected.Phase)
+
+	// Delete stops the VM, releases the slot, and removes the state.
+	env.delete(spec.SandboxID)
+}
+
+// e2eEnvironment bundles the host checks, StateRoot, slot manager, driver,
+// and per-sandbox helpers shared by the E2E tests.
+type e2eEnvironment struct {
+	t            *testing.T
+	manager      *fastletnetwork.Manager
+	driver       *Driver
+	infraMgr     *fastletinfra.Manager // nil when Infra delivery is disabled
+	imageRef     string
+	stateRoot    string
+	podUID       string
+	infraEnabled bool
+	created      []string
+}
+
+// newE2EEnvironment validates the host, seeds the image cache, pre-provisions
+// capacity network slots, and wires the driver (with a real Infra plan when
+// infraEnabled).
+func newE2EEnvironment(t *testing.T, capacity int, infraEnabled bool) *e2eEnvironment {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("requires root: netns, tap, and iptables setup")
+	}
+	if _, err := os.Stat("/dev/kvm"); err != nil {
+		t.Skip("requires /dev/kvm")
+	}
+	if _, err := os.Stat("/dev/net/tun"); err != nil {
+		t.Skip("requires /dev/net/tun")
+	}
+
+	binary := envOr("FC_BINARY", "")
+	kernel := envOr("FC_KERNEL", "")
+	rootfs := envOr("FC_ROOTFS", "")
+	imageRef := envOr("FC_IMAGE_REF", "e2e:ubuntu")
+	for name, path := range map[string]string{"FC_BINARY": binary, "FC_KERNEL": kernel, "FC_ROOTFS": rootfs} {
+		require.FileExists(t, path, name)
+	}
+
+	ctx := context.Background()
+	stateRoot := os.Getenv("FC_STATE_ROOT")
+	if stateRoot == "" {
+		stateRoot = t.TempDir()
+	} else {
+		require.NoError(t, os.MkdirAll(stateRoot, 0o750))
+	}
+	imagePath, err := imageCachePath(stateRoot, imageRef)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(imagePath), 0o750))
+	require.NoError(t, copyFile(rootfs, imagePath))
+
+	// Unique Pod UID per run keeps the resourceName-derived netns/bridge names
+	// from colliding with leftovers of earlier runs.
+	podUID := "e2e-pod-" + strconv.FormatInt(time.Now().UnixNano(), 16)
+	// In-memory slot store: the manager's async Replenish keeps writing
+	// durable files, which would race with t.TempDir cleanup.
+	netStateRoot, err := os.MkdirTemp("", "fc-e2e-netstate")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for attempt := 0; attempt < 20; attempt++ {
+			if removeErr := os.RemoveAll(netStateRoot); removeErr == nil || os.IsNotExist(removeErr) {
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		_ = os.RemoveAll(netStateRoot)
+	})
+	var slotCounter atomic.Int64
+	manager, err := fastletnetwork.NewManager(fastletnetwork.Config{
+		Capacity: capacity, PodUID: podUID,
+		StateRoot: netStateRoot, NetNSRoot: "/run/netns", HostNetNSRoot: "/run/fast-sandbox/netns",
+		IDGenerator:      func() (string, error) { return fmt.Sprintf("e2e-slot-%d", slotCounter.Add(1)), nil },
+		Now:              time.Now,
+		ReplenishTimeout: time.Minute,
+	}, fastletnetwork.NewGuestVMNetNSDriver(fastletnetwork.LinuxDriverConfig{}),
+		newMemoryStateStore())
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll("/run/netns", 0o755))
+	require.NoError(t, os.MkdirAll("/run/fast-sandbox/netns", 0o755))
+	require.NoError(t, manager.Initialize(ctx))
+
+	profile := runtimecatalog.RuntimeProfile{
+		Name: apiv1alpha2.RuntimeFirecracker, ProfileHash: "e2e-profile",
+		Firecracker: &runtimecatalog.FirecrackerConfig{
+			BinaryPath: binary, KernelPath: kernel, RootfsPath: imagePath, StateRoot: stateRoot,
+			DefaultVCPUs: 1, DefaultMemory: "512Mi", BootTimeoutSeconds: 90,
+			BootArgs: "console=ttyS0 reboot=k panic=1 pci=off net.ifnames=0 biosdevname=0",
+		},
+		Capabilities: runtimecatalog.Capabilities{DefaultState: runtimecatalog.CapabilityReady},
+	}
+	driver, err := New(profile)
+	require.NoError(t, err)
+	driver.SetNetworkManager(manager)
+
+	env := &e2eEnvironment{
+		t: t, manager: manager, driver: driver, imageRef: imageRef,
+		stateRoot: stateRoot, podUID: podUID, infraEnabled: infraEnabled,
+	}
+	if infraEnabled {
+		// Real Infra plan: EnsureSandbox performs a genuine GuestCopy delivery
+		// (loop mount + copy) of sandbox-init and an "execd" component into the
+		// instance rootfs, verified later with debugfs.
+		sandboxInit := filepath.Join(t.TempDir(), "sandbox-init")
+		require.NoError(t, os.WriteFile(sandboxInit, []byte("#!/bin/sh\n"), 0o755))
+		env.infraMgr = newE2EInfraManager(t, profile, sandboxInit)
+		driver.SetInfraManager(env.infraMgr)
+		require.NoError(t, driver.Initialize(ctx, ""))
+	}
+	require.NoError(t, driver.Initialize(ctx, ""))
+
+	// Local sampled provider so spans carry real trace IDs without an OTLP
+	// endpoint; the root trace ID is derived from the sandbox id.
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	t.Logf("booting Firecracker microVM (kernel=%s)", kernel)
+	for index := 1; index <= capacity; index++ {
+		env.created = append(env.created, fmt.Sprintf("e2e-sandbox-%d", index))
+	}
+	return env
+}
+
+// spec builds the SandboxSpec for the i-th sandbox ("e2e-sandbox-<i>").
+func (env *e2eEnvironment) spec(index int) *fastletapi.SandboxSpec {
+	sandboxID := fmt.Sprintf("e2e-sandbox-%d", index)
+	spec := &fastletapi.SandboxSpec{
+		SandboxID: sandboxID, ClaimUID: fmt.Sprintf("e2e-claim-%d", index), ClaimName: sandboxID, ClaimNamespace: "e2e",
+		InstanceGeneration: 1, RuntimeInstanceID: fmt.Sprintf("e2e-ri-%d", index), AssignmentAttempt: 1,
+		FastletPodUID: env.podUID, Image: env.imageRef, CPU: "1", Memory: "512Mi",
+		RuntimeProfileHash: "e2e-profile", ResourceProfileHash: "e2e-resource",
+	}
+	if env.infraEnabled {
+		spec.InfraRevision = env.infraMgr.Revision()
+	}
+	return spec
+}
+
+// traceContext returns a context carrying a sampled root span whose trace ID
+// is derived from the sandbox id, exercising the identity correlation used by
+// the production Fastlet.
+func (env *e2eEnvironment) traceContext(sandboxID string) (context.Context, func()) {
+	digest := sha256.Sum256([]byte(sandboxID))
+	rootContext := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID(digest[:16]),
+		SpanID:     trace.SpanID(digest[16:24]),
+		TraceFlags: trace.FlagsSampled,
+	}))
+	ctx, span := observability.Start(rootContext, "e2e.firecracker.create",
+		attribute.String("sandbox_uid", sandboxID),
+		attribute.String("image", env.imageRef),
+	)
+	return ctx, func() { observability.End(span, nil) }
+}
+
+// boot creates one sandbox through the driver and validates the result.
+// It must be called from the test goroutine (it uses require).
+func (env *e2eEnvironment) boot(ctx context.Context, spec *fastletapi.SandboxSpec) *SandboxMetadata {
+	env.t.Helper()
+	metadata, err := env.driver.EnsureSandbox(ctx, spec)
+	require.NoError(env.t, err)
+	env.assertBooted(metadata, spec, trace.SpanContextFromContext(ctx).TraceID())
+	return metadata
+}
+
+// assertBooted validates the metadata, trace correlation, and process
+// identity of one successful boot.
+func (env *e2eEnvironment) assertBooted(metadata *SandboxMetadata, spec *fastletapi.SandboxSpec, traceID trace.TraceID) {
+	t := env.t
+	t.Helper()
+	digest := sha256.Sum256([]byte(spec.SandboxID))
+	require.True(t, traceID.IsValid(), "trace context must carry a valid trace ID")
+	require.Equal(t, trace.TraceID(digest[:16]), traceID, "trace ID must be derived from the sandbox id")
+	t.Logf("traceId=%s sandboxId=%s", traceID.String(), spec.SandboxID)
+	require.Equal(t, string(PhaseRunning), metadata.Phase)
+	require.Positive(t, metadata.PID)
+	// The launched process must match the NodeJanitor residual-process
+	// matcher: binary "firecracker" and --id equal to the truncated sandbox id.
+	cmdline := readProcCmdline(t, metadata.PID)
+	require.Equal(t, "firecracker", filepath.Base(cmdline[0]))
+	require.Equal(t, spec.SandboxID, cmdline[indexOf(cmdline, "--id")+1])
+}
+
+// assertInfra verifies the delivered Infra plan: services for route
+// publication and the artifacts inside the instance rootfs image (checked
+// with debugfs against the image file).
+func (env *e2eEnvironment) assertInfra(metadata *SandboxMetadata, sandboxID string) {
+	t := env.t
+	t.Helper()
+	require.True(t, env.infraEnabled, "infra assertions require an infra environment")
+	require.Len(t, metadata.InfraServices, 1)
+	require.Equal(t, "execd", metadata.InfraServices[0].Component)
+	require.Equal(t, uint32(44772), metadata.InfraServices[0].Port)
+	instanceRootfs := filepath.Join(env.stateRoot, "sandboxes", sandboxID, instanceRootfsName)
+	assertGuestFile(t, instanceRootfs, "/.fast/run/infra.json", sandboxID)
+	assertGuestFile(t, instanceRootfs, "/.fast/components/execd/execd", "fake-execd")
+	assertGuestFile(t, instanceRootfs, "/.fast/bin/sandbox-init", "#!/bin/sh")
+}
+
+// assertGuestReachable verifies the guest VM answers ICMP on its address
+// inside the private CIDR. The host routes the guest address via the shared
+// bridge to the pre-provisioned slot tap, so this exercises the real
+// tap/bridge/guest data path (the slot IP itself is owned by the slot netns
+// and would answer locally, which is why the guest address is probed).
+func (env *e2eEnvironment) assertGuestReachable(sandboxID string) {
+	t := env.t
+	t.Helper()
+	if _, err := exec.LookPath("ping"); err != nil {
+		t.Logf("ping not installed; skipping reachability check")
+		return
+	}
+	slot, ok := env.manager.Lookup(sandboxID)
+	require.True(t, ok)
+	guestIP, err := fastletnetwork.GuestVMIP(slot)
+	require.NoError(t, err)
+	// Earlier tests in this process reused the same private addresses and
+	// left the host neighbour cache pointing at their (now dead) VMs and
+	// stale bridge ports; a frame to a stale MAC is flooded to a gone tap and
+	// dropped. Flush the bridge neighbours so ARP is re-resolved against the
+	// live guest.
+	_, _ = exec.Command("ip", "neigh", "flush", "dev", slot.Bridge).CombinedOutput()
+	output, err := exec.Command("ping", "-c", "1", "-W", "3", guestIP).CombinedOutput()
+	if err != nil {
+		t.Logf("ping failed; dumping guest network diagnostics:\n%s", dumpNetworkDiagnostics(t, slot, env.stateRoot))
+		require.NoErrorf(t, err, "guest %s not reachable: %s", guestIP, output)
+	}
+	t.Logf("guest reachable at %s (slot %s, tap %s)", guestIP, slot.IP, slot.GuestTap)
+}
+
+// delete stops the VM, releases the slot, and removes the state.
+func (env *e2eEnvironment) delete(sandboxID string) {
+	t := env.t
+	t.Helper()
+	require.NoError(t, env.driver.DeleteSandbox(context.Background(), sandboxID))
+	directory, err := sandboxDir(env.stateRoot, sandboxID)
+	require.NoError(t, err)
+	_, err = os.Stat(directory)
+	require.True(t, os.IsNotExist(err))
+	_, exists := env.manager.Lookup(sandboxID)
+	require.False(t, exists)
+}
+
+// teardown removes any sandbox that is still around and closes the driver.
+// Individual tests call delete() first; teardown is the idempotent safety net.
+func (env *e2eEnvironment) teardown() {
+	for _, sandboxID := range env.created {
+		_ = env.driver.DeleteSandbox(context.Background(), sandboxID)
+	}
+	_ = env.driver.Close()
+}
+
+// dumpNetworkDiagnostics collects the netns and guest state for failure logs.
+func dumpNetworkDiagnostics(t *testing.T, slot *fastletnetwork.Slot, stateRoot string) string {
+	t.Helper()
+	var builder strings.Builder
+	for _, args := range [][]string{
+		{"addr", "show"},
+		{"route", "show"},
+		{"netns", "exec", slot.NetNSName, "ip", "addr", "show"},
+		{"netns", "exec", slot.NetNSName, "ip", "route", "show"},
+		{"netns", "exec", slot.NetNSName, "sysctl", "net.ipv4.ip_forward"},
+		{"netns", "exec", slot.NetNSName, "iptables", "-t", "nat", "-L", "-n"},
+	} {
+		output, err := exec.Command("ip", args...).CombinedOutput()
+		fmt.Fprintf(&builder, "$ ip %s\n%s\n", strings.Join(args, " "), output)
+		if err != nil {
+			fmt.Fprintf(&builder, "(exit %v)\n", err)
+		}
+	}
+	// The firecracker process log carries the guest serial console, which
+	// shows the guest-side network configuration.
+	directory, err := sandboxDir(stateRoot, slot.Owner.SandboxUID)
+	if err == nil {
+		if payload, readErr := os.ReadFile(filepath.Join(directory, processLogName)); readErr == nil {
+			tail := payload
+			if len(tail) > 8192 {
+				tail = tail[len(tail)-8192:]
+			}
+			fmt.Fprintf(&builder, "--- firecracker.log (guest serial) ---\n%s\n", tail)
+		}
+	}
+	return builder.String()
+}
+
+func envOr(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func readProcCmdline(t *testing.T, pid int) []string {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	require.NoError(t, err)
+	return strings.Split(strings.TrimRight(string(payload), "\x00"), "\x00")
+}
+
+func indexOf(values []string, target string) int {
+	for index, value := range values {
+		if value == target {
+			return index
+		}
+	}
+	return -1
+}

--- a/internal/runtime/firecracker/images.go
+++ b/internal/runtime/firecracker/images.go
@@ -1,0 +1,250 @@
+package firecracker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// imageCacheDir holds content-addressed rootfs images:
+//
+//	<StateRoot>/images/<digest>/rootfs.img
+//
+// Images are produced by the OCI conversion pipeline (out of band); the
+// driver never converts an image on the Sandbox create hot path.
+const imageCacheDir = "images"
+
+// rootfsImageName is the converted rootfs file inside each image directory.
+const rootfsImageName = "rootfs.img"
+
+// ErrImageNotReady reports that a rootfs image has not been converted and
+// cached yet; the conversion build job must run before the Sandbox can boot.
+var ErrImageNotReady = errors.New("rootfs image is not ready in the local cache")
+
+// imageKey derives the content-addressed cache key of an image reference.
+func imageKey(image string) string {
+	digest := sha256.Sum256([]byte(image))
+	return hex.EncodeToString(digest[:])
+}
+
+// imageCachePath returns the rootfs image path for an image reference. The
+// cache key is the reference digest, not the reference string, so cache
+// entries are stable across naming schemes.
+func imageCachePath(stateRoot, image string) (string, error) {
+	if strings.TrimSpace(image) == "" {
+		return "", fmt.Errorf("%w: image reference is required", ErrInvalidConfig)
+	}
+	return filepath.Join(stateRoot, imageCacheDir, imageKey(image), rootfsImageName), nil
+}
+
+// resolveRootfsImage returns the cached rootfs image path or ErrImageNotReady
+// when the conversion pipeline has not produced it yet.
+func resolveRootfsImage(stateRoot, image string) (string, error) {
+	path, err := imageCachePath(stateRoot, image)
+	if err != nil {
+		return "", err
+	}
+	if info, err := os.Stat(path); err != nil || info.IsDir() {
+		return "", fmt.Errorf("%w: %q", ErrImageNotReady, image)
+	}
+	return path, nil
+}
+
+// listCachedImages returns the converted image references stored under the
+// StateRoot, keyed by their content-addressed cache directory.
+func listCachedImages(stateRoot string) ([]string, error) {
+	base := filepath.Join(stateRoot, imageCacheDir)
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	images := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(base, entry.Name(), rootfsImageName)); err == nil {
+			images = append(images, entry.Name())
+		}
+	}
+	return images, nil
+}
+
+// instanceRootfsName is the per-Sandbox writable copy of the cached rootfs.
+// The cached image stays immutable and content-addressed; the instance copy
+// is the VM root drive. OverlayBD-native storage replaces the copy in a later
+// phase.
+const instanceRootfsName = "rootfs.img"
+
+// prepareInstanceRootfs copies the cached rootfs image into the Sandbox state
+// directory so the VM root drive is writable without mutating the cache. A
+// reflink (CoW) copy is preferred: it shares extents with the cache and leaves
+// no dirty pages, so the first fsync on the instance image (from debugfs
+// delivery or the VM) is instant instead of forcing the full dirty writeback.
+func prepareInstanceRootfs(stateRoot, image, instanceDir string) (string, error) {
+	cached, err := resolveRootfsImage(stateRoot, image)
+	if err != nil {
+		return "", err
+	}
+	target := filepath.Join(instanceDir, instanceRootfsName)
+	if err := copyReflinkOrCopy(cached, target); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+// copyReflinkOrCopy attempts a CoW reflink copy and falls back to a plain
+// copy when the host filesystem does not support reflinks.
+func copyReflinkOrCopy(source, target string) error {
+	if exec.Command("cp", "--reflink=always", source, target).Run() == nil {
+		return nil
+	}
+	_ = os.Remove(target)
+	return copyFile(source, target)
+}
+
+func copyFile(source, target string) error {
+	input, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	output, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o640)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(output, input); err != nil {
+		_ = output.Close()
+		return err
+	}
+	return output.Close()
+}
+
+// defaultImageCacheLimitBytes bounds the converted-image cache. When the
+// cache exceeds it, the GC evicts unreferenced images in least-frequently-used
+// order. 20 GiB holds roughly a few dozen rootfs images.
+const defaultImageCacheLimitBytes = 20 << 30
+
+// garbageCollectImages evicts cached rootfs images to keep the cache under
+// limitBytes. Candidates are images no managed Sandbox references; among them
+// the least frequently used (recorded in memory by the driver, not derived
+// from filesystem timestamps) are removed first, newest/unknown entries
+// counting as zero uses. References are read from the durable per-Sandbox
+// state, so a VM that died with its Fastlet still pins its image until its
+// state directory is removed. Reflink instance copies are independent once
+// created, so deleting a cache entry never affects a running VM. A Sandbox
+// whose state cannot be read aborts the whole collection: it might reference
+// an image, and the cost of keeping a few hundred MiB beats breaking a
+// recoverable Sandbox.
+func garbageCollectImages(stateRoot string, limitBytes int64, useCount map[string]int64) ([]string, error) {
+	referenced := make(map[string]struct{})
+	directories, err := listSandboxDirs(stateRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, directory := range directories {
+		state, err := loadState(directory)
+		if err != nil {
+			// A directory without durable state is a deletion in progress;
+			// it pins no image. Any other read failure aborts the whole
+			// collection: the Sandbox might reference an image, and keeping a
+			// few hundred MiB beats breaking a recoverable Sandbox.
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("read Sandbox state %s for image GC: %w", directory, err)
+		}
+		referenced[imageKey(state.Spec.Image)] = struct{}{}
+	}
+	cached, err := listCachedImages(stateRoot)
+	if err != nil {
+		return nil, err
+	}
+	type entry struct {
+		digest string
+		bytes  int64
+		uses   int64
+	}
+	entries := make([]entry, 0, len(cached))
+	total := int64(0)
+	for _, digest := range cached {
+		// Only content-addressed cache directories (64 lowercase hex chars)
+		// are eligible; anything else in the cache root is left untouched.
+		if !validImageDigest(digest) {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(stateRoot, imageCacheDir, digest, rootfsImageName))
+		if err != nil {
+			continue
+		}
+		total += info.Size()
+		if _, used := referenced[digest]; used {
+			continue
+		}
+		entries = append(entries, entry{digest: digest, bytes: info.Size(), uses: useCount[digest]})
+	}
+	// Least-frequently-used first; ties resolve deterministically by digest.
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].uses != entries[j].uses {
+			return entries[i].uses < entries[j].uses
+		}
+		return entries[i].digest < entries[j].digest
+	})
+	removed := make([]string, 0, len(entries))
+	for _, candidate := range entries {
+		if total <= limitBytes {
+			break
+		}
+		if err := os.RemoveAll(filepath.Join(stateRoot, imageCacheDir, candidate.digest)); err != nil {
+			return removed, err
+		}
+		total -= candidate.bytes
+		removed = append(removed, candidate.digest)
+	}
+	return removed, nil
+}
+
+// validImageDigest reports whether name is a lowercase sha256 hex digest.
+func validImageDigest(name string) bool {
+	if len(name) != sha256.Size*2 {
+		return false
+	}
+	for _, character := range name {
+		if !((character >= '0' && character <= '9') || (character >= 'a' && character <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+// ListImages implements RuntimeArtifactCache over the converted-image cache.
+func (d *Driver) ListImages(_ context.Context) ([]string, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return listCachedImages(d.config.StateRoot)
+}
+
+// PullImage ensures the converted rootfs image is present in the local cache.
+// Conversion is out of band; an unconverted reference is reported as
+// ErrImageNotReady instead of blocking the create path.
+func (d *Driver) PullImage(_ context.Context, image string) error {
+	d.mu.RLock()
+	stateRoot := d.config.StateRoot
+	d.mu.RUnlock()
+	if _, err := resolveRootfsImage(stateRoot, image); err != nil {
+		return err
+	}
+	d.touchImage(image)
+	return nil
+}

--- a/internal/runtime/firecracker/images_test.go
+++ b/internal/runtime/firecracker/images_test.go
@@ -1,0 +1,203 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	apiv1alpha2 "fast-sandbox/api/v1alpha2"
+	runtimecatalog "fast-sandbox/internal/catalog/runtime"
+	fastletapi "fast-sandbox/internal/protocol/fastlet"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageCachePathIsContentAddressed(t *testing.T) {
+	root := t.TempDir()
+	first, err := imageCachePath(root, "example.com/app:v1")
+	require.NoError(t, err)
+	second, err := imageCachePath(root, "example.com/app@sha256:deadbeef")
+	require.NoError(t, err)
+	require.NotEqual(t, first, second)
+	require.Equal(t, filepath.Join(root, imageCacheDir, imageKey("example.com/app:v1"), rootfsImageName), first)
+
+	_, err = imageCachePath(root, "")
+	require.ErrorIs(t, err, ErrInvalidConfig)
+}
+
+func TestResolveRootfsImage(t *testing.T) {
+	root := t.TempDir()
+	image := "example.com/app:v1"
+
+	_, err := resolveRootfsImage(root, image)
+	require.True(t, errors.Is(err, ErrImageNotReady))
+
+	path, err := imageCachePath(root, image)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte("rootfs"), 0o640))
+
+	resolved, err := resolveRootfsImage(root, image)
+	require.NoError(t, err)
+	require.Equal(t, path, resolved)
+}
+
+func TestListCachedImagesAndDriverSurfaces(t *testing.T) {
+	root := t.TempDir()
+	driver := &Driver{config: firecrackerConfigForTest(t, root)}
+
+	images, err := driver.ListImages(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, images)
+
+	require.True(t, errors.Is(driver.PullImage(context.Background(), "example.com/missing:v1"), ErrImageNotReady))
+
+	path, err := imageCachePath(root, "example.com/app:v1")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte("rootfs"), 0o640))
+	require.NoError(t, driver.PullImage(context.Background(), "example.com/app:v1"))
+
+	images, err = driver.ListImages(context.Background())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{imageKey("example.com/app:v1")}, images)
+}
+
+func TestGarbageCollectImages(t *testing.T) {
+	root := t.TempDir()
+	useCount := make(map[string]int64)
+	seedImage := func(image string) string {
+		path, err := imageCachePath(root, image)
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+		require.NoError(t, os.WriteFile(path, []byte("rootfs"), 0o640))
+		return imageKey(image)
+	}
+	// hot and cold are both unreferenced; the LFU order evicts cold first.
+	hot := seedImage("example.com/hot:v1")
+	cold := seedImage("example.com/cold:v1")
+	useCount[hot] = 100
+	useCount[cold] = 1
+	// unknown has no recorded use: it counts as zero and is the first victim.
+	unknown := seedImage("example.com/unknown:v1")
+
+	// A managed Sandbox pins its image through its durable state.
+	used := seedImage("example.com/used:v1")
+	useCount[used] = 5
+	directory, err := ensureSandboxDir(root, "sbx-1")
+	require.NoError(t, err)
+	require.NoError(t, saveState(directory, &SandboxState{
+		Spec:  fastletapi.SandboxSpec{SandboxID: "sbx-1", Image: "example.com/used:v1"},
+		Phase: PhaseRunning,
+	}))
+
+	// Unknown content in the cache root is never collected.
+	junk := filepath.Join(root, imageCacheDir, "not-a-digest")
+	require.NoError(t, os.MkdirAll(junk, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(junk, "rootfs.img"), []byte("junk"), 0o640))
+
+	// The limit fits exactly the referenced image (6 bytes): everything
+	// unreferenced is evicted, hot last because it is the most frequently
+	// used.
+	removed, err := garbageCollectImages(root, 6, useCount)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{unknown, cold, hot}, removed)
+	_, err = os.Stat(filepath.Join(root, imageCacheDir, used))
+	require.NoError(t, err, "referenced image must survive GC")
+	_, err = os.Stat(junk)
+	require.NoError(t, err, "non-digest entries must be left alone")
+
+	// With a limit of two images the least frequently used are evicted first
+	// and the hot image survives.
+	cold = seedImage("example.com/cold:v1")
+	unknown = seedImage("example.com/unknown:v1")
+	hot = seedImage("example.com/hot:v1")
+	removed, err = garbageCollectImages(root, 12, useCount)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{unknown, cold}, removed)
+	_, err = os.Stat(filepath.Join(root, imageCacheDir, hot))
+	require.NoError(t, err, "high-frequency image must survive eviction")
+
+	// Unreadable Sandbox state aborts the collection entirely.
+	second, err := ensureSandboxDir(root, "sbx-2")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath(second), []byte("{corrupt"), 0o600))
+	_, err = garbageCollectImages(root, 12, useCount)
+	require.Error(t, err)
+	_, err = os.Stat(filepath.Join(root, imageCacheDir, hot))
+	require.NoError(t, err, "collection must not remove anything when a state cannot be read")
+
+	// After the referencing Sandbox is deleted the image becomes evictable;
+	// the lower-frequency one goes first.
+	require.NoError(t, removeSandboxDir(directory))
+	require.NoError(t, os.Remove(metaPath(second)))
+	removed, err = garbageCollectImages(root, 6, useCount)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{used}, removed)
+	_, err = os.Stat(filepath.Join(root, imageCacheDir, hot))
+	require.NoError(t, err, "high-frequency image must survive eviction")
+}
+
+// TestImageGCLoopRunsIndependently verifies the cache GC is driven by its own
+// periodic loop, not by Sandbox lifecycle events, and stops on Close.
+func TestImageGCLoopRunsIndependently(t *testing.T) {
+	root := t.TempDir()
+	config := firecrackerConfigForTest(t, root)
+	driver, err := New(runtimecatalog.RuntimeProfile{
+		Name: apiv1alpha2.RuntimeFirecracker, Firecracker: &config,
+		Capabilities: runtimecatalog.Capabilities{DefaultState: runtimecatalog.CapabilityReady},
+	})
+	require.NoError(t, err)
+	driver.imageGCInterval = 30 * time.Millisecond
+	require.NoError(t, driver.Initialize(context.Background(), ""))
+	t.Cleanup(func() { _ = driver.Close() })
+
+	seedImage := func(image string) string {
+		path, err := imageCachePath(root, image)
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+		require.NoError(t, os.WriteFile(path, []byte("rootfs"), 0o640))
+		digest := imageKey(image)
+		driver.imageUseCount[digest] = 1
+		return digest
+	}
+	waitFor := func(image string, gone bool) {
+		t.Helper()
+		path := filepath.Join(root, imageCacheDir, image)
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			_, err := os.Stat(path)
+			if (err != nil && gone) || (err == nil && !gone) {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		require.Failf(t, "timeout waiting for image %s (gone=%v)", image, gone)
+	}
+
+	// The cache is over its limit, so the loop evicts the unreferenced
+	// low-frequency image without any Sandbox event.
+	driver.imageCacheLimitBytes = 1
+	unused := seedImage("example.com/unused:v1")
+	waitFor(unused, true)
+
+	// Under its limit again, the loop leaves images alone even when
+	// unreferenced.
+	driver.imageCacheLimitBytes = 6
+	hot := seedImage("example.com/hot:v1")
+	driver.imageUseCount[hot] = 100
+	time.Sleep(3 * driver.imageGCInterval)
+	_, err = os.Stat(filepath.Join(root, imageCacheDir, hot))
+	require.NoError(t, err, "image under the cache limit must survive the loop")
+
+	// Close stops the loop: an image added afterwards is left alone.
+	require.NoError(t, driver.Close())
+	t.Cleanup(func() {}) // Close already ran
+	after := seedImage("example.com/after:v1")
+	time.Sleep(3 * driver.imageGCInterval)
+	_, err = os.Stat(filepath.Join(root, imageCacheDir, after))
+	require.NoError(t, err, "loop must stop when the driver is closed")
+}

--- a/internal/runtime/firecracker/infra_delivery.go
+++ b/internal/runtime/firecracker/infra_delivery.go
@@ -1,0 +1,59 @@
+package firecracker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	fastletinfra "fast-sandbox/internal/fastlet/infra"
+	fastletnetwork "fast-sandbox/internal/fastlet/network"
+)
+
+// deliverGuestInfra performs the GuestCopy Infra delivery by loop-mounting the
+// per-instance rootfs and copying every prepared artifact to its guest
+// destination (sandbox-init, sandbox-tunnel, infra.json, component mappings).
+// Kernel-journaled writes survive the guest's later read-write mount, which
+// non-journaled debugfs writes do not. The mount costs nothing extra because
+// the instance image is a reflink copy with no dirty pages.
+func deliverGuestInfra(ctx context.Context, runner fastletnetwork.CommandRunner, rootfsImage string, instance fastletinfra.PreparedInstance) error {
+	if runner == nil {
+		return fmt.Errorf("%w: command runner is required for Infra delivery", ErrInvalidConfig)
+	}
+	if len(instance.Mounts) == 0 {
+		return nil
+	}
+	mountpoint, err := os.MkdirTemp("", "fc-infra")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(mountpoint)
+
+	if _, err := runner.Run(ctx, "mount", "-o", "loop", rootfsImage, mountpoint); err != nil {
+		return fmt.Errorf("mount guest rootfs for Infra delivery: %w", err)
+	}
+	mounted := true
+	defer func() {
+		if mounted {
+			_, _ = runner.Run(context.Background(), "umount", mountpoint)
+		}
+	}()
+
+	for _, mount := range instance.Mounts {
+		if mount.Source == "" || mount.Destination == "" {
+			continue
+		}
+		target := filepath.Join(mountpoint, mount.Destination)
+		if _, err := runner.Run(ctx, "mkdir", "-p", filepath.Dir(target)); err != nil {
+			return err
+		}
+		if _, err := runner.Run(ctx, "cp", "-a", mount.Source, target); err != nil {
+			return fmt.Errorf("copy Infra artifact to %s: %w", mount.Destination, err)
+		}
+	}
+	if _, err := runner.Run(ctx, "umount", mountpoint); err != nil {
+		return err
+	}
+	mounted = false
+	return nil
+}

--- a/internal/runtime/firecracker/infra_delivery_test.go
+++ b/internal/runtime/firecracker/infra_delivery_test.go
@@ -1,0 +1,78 @@
+package firecracker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	fastletinfra "fast-sandbox/internal/fastlet/infra"
+
+	"github.com/stretchr/testify/require"
+)
+
+// infraRunner records commands and can fail a specific command.
+type infraRunner struct {
+	commands []string
+	failOn   string
+}
+
+func (r *infraRunner) Run(_ context.Context, command string, args ...string) ([]byte, error) {
+	line := command + " " + strings.Join(args, " ")
+	r.commands = append(r.commands, line)
+	if r.failOn != "" && strings.Contains(line, r.failOn) {
+		return nil, os.ErrPermission
+	}
+	return nil, nil
+}
+
+func infraMounts(t *testing.T) []fastletinfra.Mount {
+	t.Helper()
+	sandboxInit := filepath.Join(t.TempDir(), "sandbox-init")
+	infraJSON := filepath.Join(t.TempDir(), "infra.json")
+	execd := filepath.Join(t.TempDir(), "execd")
+	for _, path := range []string{sandboxInit, infraJSON, execd} {
+		require.NoError(t, os.WriteFile(path, []byte("payload"), 0o755))
+	}
+	return []fastletinfra.Mount{
+		{Source: sandboxInit, Destination: "/.fast/bin/sandbox-init", Options: []string{"ro"}},
+		{Source: infraJSON, Destination: "/.fast/run/infra.json", Options: []string{"ro"}},
+		{Source: execd, Destination: "/.fast/components/execd/execd", Options: []string{"ro"}},
+	}
+}
+
+func TestDeliverGuestInfraCopiesArtifacts(t *testing.T) {
+	runner := &infraRunner{}
+	instance := fastletinfra.PreparedInstance{Mounts: infraMounts(t)}
+	err := deliverGuestInfra(context.Background(), runner, "/var/lib/fast-sandbox/rootfs.img", instance)
+	require.NoError(t, err)
+
+	joined := strings.Join(runner.commands, "\n")
+	require.Contains(t, joined, "mount -o loop /var/lib/fast-sandbox/rootfs.img")
+	for _, want := range []string{
+		"mkdir -p ", "cp -a ",
+		"/.fast/bin/sandbox-init", "/.fast/run/infra.json", "/.fast/components/execd/execd",
+	} {
+		require.Contains(t, joined, want)
+	}
+	require.Equal(t, 1, strings.Count(joined, "umount "))
+}
+
+func TestDeliverGuestInfraSkipsEmptyPlan(t *testing.T) {
+	runner := &infraRunner{}
+	require.NoError(t, deliverGuestInfra(context.Background(), runner, "img", fastletinfra.PreparedInstance{}))
+	require.Empty(t, runner.commands)
+}
+
+func TestDeliverGuestInfraUnmountsOnFailure(t *testing.T) {
+	runner := &infraRunner{failOn: "execd"}
+	err := deliverGuestInfra(context.Background(), runner, "img", fastletinfra.PreparedInstance{Mounts: infraMounts(t)})
+	require.Error(t, err)
+	require.Contains(t, strings.Join(runner.commands, "\n"), "umount ")
+}
+
+func TestDeliverGuestInfraRequiresRunner(t *testing.T) {
+	err := deliverGuestInfra(context.Background(), nil, "img", fastletinfra.PreparedInstance{Mounts: infraMounts(t)})
+	require.ErrorIs(t, err, ErrInvalidConfig)
+}

--- a/internal/runtime/firecracker/infra_e2e_test.go
+++ b/internal/runtime/firecracker/infra_e2e_test.go
@@ -1,0 +1,111 @@
+package firecracker
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	infracatalog "fast-sandbox/internal/catalog/infra"
+	runtimecatalog "fast-sandbox/internal/catalog/runtime"
+	fastletinfra "fast-sandbox/internal/fastlet/infra"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newE2EInfraManager builds a real Infra Manager with one archive component
+// ("execd") served from a local tar.gz, so EnsureSandbox performs a genuine
+// GuestCopy delivery into the instance rootfs.
+func newE2EInfraManager(t *testing.T, profile runtimecatalog.RuntimeProfile, sandboxInitPath string) *fastletinfra.Manager {
+	t.Helper()
+	payload := filepath.Join(t.TempDir(), "execd")
+	require.NoError(t, os.WriteFile(payload, []byte("#!/bin/sh\necho fake-execd\n"), 0o755))
+	archive := createE2EComponentArchive(t, payload, "execd")
+	digest := sha256.Sum256(mustReadFile(t, archive))
+
+	component := infracatalog.Component{
+		Name: "execd",
+		Artifact: infracatalog.Artifact{
+			Source: infracatalog.ArtifactSource{
+				Type: infracatalog.SourceArchive, Reference: "https://e2e.local/component.tar.gz",
+				Digest: "sha256:" + hex.EncodeToString(digest[:]),
+			},
+			Mappings: []infracatalog.ArtifactMapping{{SourcePath: "/execd", TargetPath: "/.fast/components/execd/execd"}},
+		},
+		Process: infracatalog.Process{
+			Command: []string{"/.fast/components/execd/execd"}, RestartPolicy: infracatalog.RestartNever,
+			Readiness: infracatalog.ReadinessProbe{Type: infracatalog.ProbeTCP, Timeout: 5 * time.Second},
+		},
+		Endpoint: infracatalog.Endpoint{Protocol: "HTTP", Port: 44772},
+		Delivery: runtimecatalog.InfraDeliveryGuestCopy,
+	}
+	storeRoot := t.TempDir()
+	store, err := fastletinfra.NewArtifactStore(storeRoot, storeRoot)
+	require.NoError(t, err)
+	manager, err := fastletinfra.NewManagerWithConfig(fastletinfra.ManagerConfig{
+		Plan:           infracatalog.Plan{Components: []infracatalog.Component{component}},
+		RuntimeProfile: profile, Store: store,
+		Resolver:        e2eFileResolver{archivePath: archive},
+		SandboxInitPath: sandboxInitPath,
+	})
+	require.NoError(t, err)
+	require.NoError(t, manager.Prepare(context.Background()))
+	return manager
+}
+
+// e2eFileResolver serves a local tar.gz for the archive component source,
+// bypassing the HTTPS download used by the platform resolver.
+type e2eFileResolver struct {
+	archivePath string
+}
+
+func (r e2eFileResolver) Prepare(_ context.Context, source infracatalog.ArtifactSource, store *fastletinfra.ArtifactStore) (fastletinfra.PreparedSource, error) {
+	return store.StageTree(context.Background(), source.Digest, true, true, func() (io.ReadCloser, error) {
+		return os.Open(r.archivePath)
+	})
+}
+
+func createE2EComponentArchive(t *testing.T, payload, payloadName string) string {
+	t.Helper()
+	archivePath := filepath.Join(t.TempDir(), "component.tar.gz")
+	file, err := os.Create(archivePath)
+	require.NoError(t, err)
+	gz := gzip.NewWriter(file)
+	tw := tar.NewWriter(gz)
+	body, err := os.ReadFile(payload)
+	require.NoError(t, err)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: payloadName, Mode: 0o755, Size: int64(len(body))}))
+	_, err = tw.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	require.NoError(t, file.Close())
+	return archivePath
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	payload, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return payload
+}
+
+// assertGuestFile verifies a file inside the instance rootfs image using
+// debugfs (userspace ext4 reader, no mount conflicts with the running VM).
+func assertGuestFile(t *testing.T, imagePath, guestPath, want string) {
+	t.Helper()
+	if _, err := exec.LookPath("debugfs"); err != nil {
+		t.Logf("debugfs not installed; skipping guest file assertion for %s", guestPath)
+		return
+	}
+	output, err := exec.Command("debugfs", "-R", "cat "+guestPath, imagePath).CombinedOutput()
+	require.NoErrorf(t, err, "guest file %s missing from %s: %s", guestPath, imagePath, output)
+	require.Contains(t, string(output), want)
+}

--- a/internal/runtime/firecracker/launcher.go
+++ b/internal/runtime/firecracker/launcher.go
@@ -1,0 +1,122 @@
+package firecracker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// firecrackerIDLimit matches the NodeJanitor residual-process matcher
+// (internal/nodecleanup/process.go): firecracker is launched with
+// --id <sandboxID[:32]> so the node daemon can identify and clean up a VMM
+// that outlived both the Sandbox object and the Fastlet Pod.
+const firecrackerIDLimit = 32
+
+// Process is the host-side handle of one Firecracker microVM process.
+type Process interface {
+	PID() int
+	Kill() error
+	Wait() error
+}
+
+// ProcessRunner starts Firecracker processes. It is injectable so tests can
+// substitute a fake process.
+type ProcessRunner interface {
+	Start(ctx context.Context, name string, args []string, logPath string) (Process, error)
+}
+
+// ExecProcessRunner starts Firecracker with exec.Command. The VM deliberately
+// outlives the caller context: only Kill terminates it. The process stdout
+// and stderr are appended to logPath so a failed boot is diagnosable.
+type ExecProcessRunner struct{}
+
+// Start launches the process without binding its lifetime to ctx.
+func (ExecProcessRunner) Start(_ context.Context, name string, args []string, logPath string) (Process, error) {
+	command := exec.Command(name, args...)
+	if logPath != "" {
+		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+		if err != nil {
+			return nil, err
+		}
+		command.Stdout = logFile
+		command.Stderr = logFile
+	}
+	if err := command.Start(); err != nil {
+		return nil, err
+	}
+	return &execProcess{command: command}, nil
+}
+
+type execProcess struct {
+	command *exec.Cmd
+}
+
+func (p *execProcess) PID() int {
+	if p.command.Process == nil {
+		return 0
+	}
+	return p.command.Process.Pid
+}
+
+func (p *execProcess) Kill() error {
+	if p.command.Process == nil {
+		return nil
+	}
+	return p.command.Process.Kill()
+}
+
+func (p *execProcess) Wait() error {
+	if p.command.Process == nil {
+		return nil
+	}
+	return p.command.Wait()
+}
+
+// launchConfig is the immutable per-Sandbox Firecracker launch plan.
+type launchConfig struct {
+	// BinaryPath is the host path of the firecracker binary.
+	BinaryPath string
+	// SandboxID is the full Sandbox identity; the argv id is truncated.
+	SandboxID string
+	// APIAddress is the host path of the per-Sandbox API Unix socket.
+	APIAddress string
+	// ChrootBase is the optional jailer working root. Empty disables the jailer.
+	ChrootBase string
+	// LogPath receives the firecracker stdout/stderr (empty discards output).
+	LogPath string
+}
+
+// buildArgv produces the Firecracker command line. The binary name must stay
+// "firecracker" and the --id value must match the NodeJanitor matcher.
+func (c launchConfig) buildArgv() []string {
+	arguments := []string{
+		"--id", c.truncatedID(),
+		"--api-sock", c.APIAddress,
+	}
+	if c.ChrootBase != "" {
+		arguments = append(arguments, "--chroot-base", c.ChrootBase)
+	}
+	return arguments
+}
+
+// truncatedID returns the NodeJanitor-compatible VM id.
+func (c launchConfig) truncatedID() string {
+	if len(c.SandboxID) > firecrackerIDLimit {
+		return c.SandboxID[:firecrackerIDLimit]
+	}
+	return c.SandboxID
+}
+
+// launch invokes the firecracker binary with the launch configuration.
+func launch(ctx context.Context, runner ProcessRunner, config launchConfig) (Process, error) {
+	if strings.TrimSpace(config.BinaryPath) == "" || strings.TrimSpace(config.SandboxID) == "" || strings.TrimSpace(config.APIAddress) == "" {
+		return nil, fmt.Errorf("%w: firecracker binary, sandbox id, and API address are required", ErrInvalidConfig)
+	}
+	if !filepath.IsAbs(config.APIAddress) {
+		return nil, fmt.Errorf("%w: firecracker API address must be an absolute path", ErrInvalidConfig)
+	}
+	return runner.Start(ctx, config.BinaryPath, config.buildArgv(), config.LogPath)
+}

--- a/internal/runtime/firecracker/launcher_test.go
+++ b/internal/runtime/firecracker/launcher_test.go
@@ -1,0 +1,84 @@
+package firecracker
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeProcess struct {
+	pid    int
+	killed bool
+}
+
+func (f *fakeProcess) PID() int { return f.pid }
+func (f *fakeProcess) Kill() error {
+	f.killed = true
+	return nil
+}
+func (f *fakeProcess) Wait() error { return nil }
+
+type fakeProcessRunner struct {
+	started [][]string
+	err     error
+}
+
+func (f *fakeProcessRunner) Start(_ context.Context, name string, args []string, _ string) (Process, error) {
+	f.started = append(f.started, append([]string{name}, args...))
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &fakeProcess{pid: 4242}, nil
+}
+
+func TestBuildArgvTruncatesID(t *testing.T) {
+	longID := strings.Repeat("s", 40)
+	argv := (launchConfig{SandboxID: longID, APIAddress: "/var/lib/fast-sandbox/api.sock"}).buildArgv()
+	require.Equal(t, []string{"--id", strings.Repeat("s", 32), "--api-sock", "/var/lib/fast-sandbox/api.sock"}, argv)
+
+	shortID := "sandbox-1"
+	argv = (launchConfig{SandboxID: shortID, APIAddress: "/var/lib/fast-sandbox/api.sock"}).buildArgv()
+	require.Contains(t, argv, "--id")
+	require.Equal(t, shortID, argv[argvIndex(argv, "--id")+1])
+}
+
+func TestBuildArgvWithChrootBase(t *testing.T) {
+	argv := (launchConfig{SandboxID: "sandbox-1", APIAddress: "/run/api.sock", ChrootBase: "/var/lib/fast-sandbox/jails"}).buildArgv()
+	require.Contains(t, argv, "--chroot-base")
+	require.Equal(t, "/var/lib/fast-sandbox/jails", argv[argvIndex(argv, "--chroot-base")+1])
+}
+
+func TestLaunchValidation(t *testing.T) {
+	runner := &fakeProcessRunner{}
+	ctx := context.Background()
+
+	_, err := launch(ctx, runner, launchConfig{SandboxID: "sandbox-1", APIAddress: "/run/api.sock"})
+	require.ErrorIs(t, err, ErrInvalidConfig)
+
+	_, err = launch(ctx, runner, launchConfig{BinaryPath: "/usr/local/bin/firecracker", APIAddress: "relative.sock"})
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Empty(t, runner.started)
+}
+
+func TestLaunchInvokesRunner(t *testing.T) {
+	runner := &fakeProcessRunner{}
+	ctx := context.Background()
+
+	process, err := launch(ctx, runner, launchConfig{BinaryPath: "/usr/local/bin/firecracker", SandboxID: "sandbox-1", APIAddress: "/run/api.sock"})
+	require.NoError(t, err)
+	require.Equal(t, 4242, process.PID())
+	require.Len(t, runner.started, 1)
+	require.Equal(t, "/usr/local/bin/firecracker", runner.started[0][0])
+	require.Contains(t, runner.started[0], "--api-sock")
+}
+
+func argvIndex(argv []string, flag string) int {
+	for index, value := range argv {
+		if value == flag {
+			return index
+		}
+	}
+	return -1
+}

--- a/internal/runtime/firecracker/network.go
+++ b/internal/runtime/firecracker/network.go
@@ -1,0 +1,37 @@
+package firecracker
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// guestInterface is the virtio-net interface name configured inside the guest
+// through the kernel boot argument ip= parameter.
+const guestInterface = "eth0"
+
+// buildBootArgs appends a static guest network configuration to the base
+// kernel command line. The guest owns its address inside the private CIDR;
+// the pod-side IP remains on the slot netns and is DNATed to the guest by
+// the pre-provisioned GuestVMNetNSDriver.
+func buildBootArgs(base string, guestIP, gateway, prefixMask string) string {
+	if !strings.Contains(base, " ip=") && !strings.HasSuffix(base, " ip=") {
+		return fmt.Sprintf("%s ip=%s::%s:%s::%s:off", base, guestIP, gateway, prefixMask, guestInterface)
+	}
+	return base
+}
+
+// prefixMask converts a CIDR prefix length to a dotted IPv4 mask.
+func prefixMask(prefixBits int) (string, error) {
+	if prefixBits < 0 || prefixBits > 32 {
+		return "", fmt.Errorf("%w: invalid prefix length %d", ErrInvalidConfig, prefixBits)
+	}
+	return net.IP(net.CIDRMask(prefixBits, 32)).String(), nil
+}
+
+// guestMAC derives a stable, locally administered MAC from the Sandbox id.
+func guestMAC(sandboxID string) string {
+	digest := sha256.Sum256([]byte(sandboxID))
+	return fmt.Sprintf("02:%02x:%02x:%02x:%02x:%02x", digest[0], digest[1], digest[2], digest[3], digest[4])
+}

--- a/internal/runtime/firecracker/network_test.go
+++ b/internal/runtime/firecracker/network_test.go
@@ -1,0 +1,34 @@
+package firecracker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildBootArgsAppendsGuestNetwork(t *testing.T) {
+	base := "console=ttyS0 reboot=k panic=1 pci=off"
+	args := buildBootArgs(base, "172.30.0.3", "172.30.0.1", "255.255.255.0")
+	require.Equal(t, "console=ttyS0 reboot=k panic=1 pci=off ip=172.30.0.3::172.30.0.1:255.255.255.0::eth0:off", args)
+}
+
+func TestBuildBootArgsPreservesExistingIPArg(t *testing.T) {
+	args := buildBootArgs("console=ttyS0 ip=10.0.0.1::10.0.0.254:255.255.255.0::eth0:off", "172.30.0.3", "172.30.0.1", "255.255.255.0")
+	require.Equal(t, "console=ttyS0 ip=10.0.0.1::10.0.0.254:255.255.255.0::eth0:off", args)
+}
+
+func TestPrefixMask(t *testing.T) {
+	mask, err := prefixMask(16)
+	require.NoError(t, err)
+	require.Equal(t, "255.255.0.0", mask)
+
+	_, err = prefixMask(33)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+}
+
+func TestGuestMACIsDeterministic(t *testing.T) {
+	require.Equal(t, guestMAC("sandbox-1"), guestMAC("sandbox-1"))
+	require.NotEqual(t, guestMAC("sandbox-1"), guestMAC("sandbox-2"))
+	mac := guestMAC("sandbox-1")
+	require.True(t, len(mac) == 17 && mac[:3] == "02:")
+}

--- a/internal/runtime/firecracker/state.go
+++ b/internal/runtime/firecracker/state.go
@@ -1,0 +1,163 @@
+package firecracker
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	infracontract "fast-sandbox/internal/infra/contract"
+	fastletapi "fast-sandbox/internal/protocol/fastlet"
+)
+
+// sandboxStateDir holds one directory per managed Sandbox under the runtime
+// StateRoot. Layout:
+//
+//	<StateRoot>/sandboxes/<sandboxID>/meta.json
+//	<StateRoot>/sandboxes/<sandboxID>/api.sock
+//
+// The directory is the durable anchor for Fastlet restart recovery.
+const sandboxStateDir = "sandboxes"
+
+// sandboxMetaName is the persisted runtime state of one Sandbox.
+const sandboxMetaName = "meta.json"
+
+// processLogName receives the firecracker process stdout/stderr of a Sandbox.
+const processLogName = "firecracker.log"
+
+// VMPhase mirrors the Firecracker machine state tracked by the driver.
+type VMPhase string
+
+const (
+	PhaseStarting VMPhase = "Starting"
+	PhaseRunning  VMPhase = "Running"
+	PhaseStopped  VMPhase = "Stopped"
+)
+
+// SandboxState is the durable per-Sandbox driver record. It keeps the full
+// immutable SandboxSpec so Fastlet restart recovery can validate that a
+// re-admitted request matches the existing VM identity.
+type SandboxState struct {
+	Spec             fastletapi.SandboxSpec              `json:"spec"`
+	Phase            VMPhase                             `json:"phase"`
+	PID              int                                 `json:"pid,omitempty"`
+	APIAddress       string                              `json:"apiAddress,omitempty"`
+	CreatedAt        int64                               `json:"createdAt"`
+	InfraServices    []infracontract.ServiceEndpoint     `json:"infraServices,omitempty"`
+	InfraDiagnostics []infracontract.ComponentDiagnostic `json:"infraDiagnostics,omitempty"`
+}
+
+// validateSandboxID rejects identities that could escape the StateRoot or
+// contain characters unsafe for host paths and Firecracker ids.
+func validateSandboxID(sandboxID string) error {
+	if sandboxID == "" || sandboxID == "." || sandboxID == ".." {
+		return fmt.Errorf("%w: invalid sandbox id %q", ErrInvalidConfig, sandboxID)
+	}
+	for _, character := range sandboxID {
+		if !isSafeIDCharacter(character) {
+			return fmt.Errorf("%w: invalid sandbox id %q", ErrInvalidConfig, sandboxID)
+		}
+	}
+	return nil
+}
+
+// isSafeIDCharacter allows the DNS-style identifier set plus underscore and
+// dot, matching what firecracker --id accepts.
+func isSafeIDCharacter(character rune) bool {
+	return (character >= 'a' && character <= 'z') ||
+		(character >= 'A' && character <= 'Z') ||
+		(character >= '0' && character <= '9') ||
+		character == '-' || character == '_' || character == '.'
+}
+
+// sandboxDir returns the per-Sandbox state directory under stateRoot.
+func sandboxDir(stateRoot, sandboxID string) (string, error) {
+	if err := validateSandboxID(sandboxID); err != nil {
+		return "", err
+	}
+	return filepath.Join(stateRoot, sandboxStateDir, sandboxID), nil
+}
+
+// ensureSandboxDir creates the per-Sandbox state directory.
+func ensureSandboxDir(stateRoot, sandboxID string) (string, error) {
+	directory, err := sandboxDir(stateRoot, sandboxID)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(directory, 0o750); err != nil {
+		return "", err
+	}
+	return directory, nil
+}
+
+// metaPath returns the meta file path for a Sandbox state directory.
+func metaPath(directory string) string {
+	return filepath.Join(directory, sandboxMetaName)
+}
+
+// saveState atomically persists the Sandbox state.
+func saveState(directory string, state *SandboxState) error {
+	if state == nil {
+		return fmt.Errorf("%w: sandbox state is required", ErrInvalidConfig)
+	}
+	payload, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := metaPath(directory)
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		return err
+	}
+	return os.Chtimes(path, time.Now(), time.Now())
+}
+
+// loadState reads the Sandbox state; os.ErrNotExist means the Sandbox is not
+// managed by this Fastlet.
+func loadState(directory string) (*SandboxState, error) {
+	payload, err := os.ReadFile(metaPath(directory))
+	if err != nil {
+		return nil, err
+	}
+	var state SandboxState
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return nil, fmt.Errorf("decode sandbox state %s: %w", directory, err)
+	}
+	if state.Spec.SandboxID == "" || state.Phase == "" {
+		return nil, fmt.Errorf("%w: incomplete sandbox state in %s", ErrInvalidConfig, directory)
+	}
+	return &state, nil
+}
+
+// removeSandboxDir removes the Sandbox state directory and everything under it.
+func removeSandboxDir(directory string) error {
+	if directory == "" || filepath.Base(directory) == sandboxStateDir {
+		return fmt.Errorf("%w: refusing to remove %q", ErrInvalidConfig, directory)
+	}
+	return os.RemoveAll(directory)
+}
+
+// listSandboxDirs returns the managed Sandbox state directories, skipping
+// entries that fail to parse as Sandbox IDs.
+func listSandboxDirs(stateRoot string) ([]string, error) {
+	base := filepath.Join(stateRoot, sandboxStateDir)
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	directories := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if err := validateSandboxID(entry.Name()); err != nil {
+			continue
+		}
+		directories = append(directories, filepath.Join(base, entry.Name()))
+	}
+	return directories, nil
+}

--- a/internal/runtime/firecracker/state_test.go
+++ b/internal/runtime/firecracker/state_test.go
@@ -1,0 +1,77 @@
+package firecracker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	fastletapi "fast-sandbox/internal/protocol/fastlet"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSandboxDirRejectsUnsafeIDs(t *testing.T) {
+	root := t.TempDir()
+	for _, sandboxID := range []string{"", ".", "..", "a/b", "a\\b", "a\x00b"} {
+		_, err := sandboxDir(root, sandboxID)
+		require.ErrorIs(t, err, ErrInvalidConfig, "sandbox id %q", sandboxID)
+	}
+}
+
+func TestStateRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	directory, err := ensureSandboxDir(root, "sandbox-1")
+	require.NoError(t, err)
+
+	state := &SandboxState{
+		Spec:       fastletapi.SandboxSpec{SandboxID: "sandbox-1", ClaimUID: "claim-1", Image: "example.com/app:v1"},
+		Phase:      PhaseRunning,
+		PID:        4242,
+		APIAddress: filepath.Join(directory, "api.sock"),
+		CreatedAt:  1720000000,
+	}
+	require.NoError(t, saveState(directory, state))
+
+	loaded, err := loadState(directory)
+	require.NoError(t, err)
+	require.Equal(t, state.Spec.SandboxID, loaded.Spec.SandboxID)
+	require.Equal(t, state.Spec.Image, loaded.Spec.Image)
+	require.Equal(t, PhaseRunning, loaded.Phase)
+	require.Equal(t, 4242, loaded.PID)
+	require.Equal(t, state.APIAddress, loaded.APIAddress)
+}
+
+func TestLoadStateRejectsIncomplete(t *testing.T) {
+	root := t.TempDir()
+	directory, err := ensureSandboxDir(root, "sandbox-1")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath(directory), []byte(`{"phase":"Running"}`), 0o600))
+
+	_, err = loadState(directory)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+}
+
+func TestListAndRemoveSandboxDirs(t *testing.T) {
+	root := t.TempDir()
+	first, err := ensureSandboxDir(root, "sandbox-1")
+	require.NoError(t, err)
+	second, err := ensureSandboxDir(root, "sandbox-2")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(root, sandboxStateDir, "not a valid id!"), 0o750))
+
+	directories, err := listSandboxDirs(root)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{first, second}, directories)
+
+	require.NoError(t, removeSandboxDir(first))
+	_, err = os.Stat(first)
+	require.True(t, os.IsNotExist(err))
+	_, err = loadState(first)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestRemoveSandboxDirRefusesRoot(t *testing.T) {
+	root := t.TempDir()
+	err := removeSandboxDir(filepath.Join(root, sandboxStateDir))
+	require.ErrorIs(t, err, ErrInvalidConfig)
+}

--- a/scripts/firecracker-e2e.sh
+++ b/scripts/firecracker-e2e.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# firecracker-e2e.sh — run the Firecracker runtime driver E2E on a Linux host.
+#
+# Requirements:
+#   - Linux x86_64 with KVM (/dev/kvm) and /dev/net/tun
+#   - root (netns, tap, iptables setup) — the script re-invokes itself with sudo
+#   - ip, iptables, sysctl, ping, tar, curl
+#
+# The script downloads a firecracker release and the firecracker quickstart
+# kernel/rootfs, then runs:
+#   go test -tags firecracker -run TestFirecrackerDriverE2E ./internal/runtime/firecracker/
+#
+# Host impact: the test uses a private 172.30.0.0/24 bridge and sets host-wide
+# ip_forward plus one MASQUERADE rule; these are restored automatically on
+# exit (only when they did not exist before the run). --cleanup is available
+# for interrupted runs.
+#
+# Overrides (environment):
+#   FC_VERSION    firecracker release tag, default v1.16.1 (latest upstream stable)
+#   FC_BINARY     firecracker binary path (skips download when set)
+#   FC_KERNEL     kernel image path (skips download when set)
+#   FC_ROOTFS     converted rootfs ext4 image (skips download when set)
+#   FC_STATE_ROOT driver StateRoot (defaults to a temp dir; use a reflink-
+#                 capable filesystem to avoid the first-fsync writeback cost)
+#   WORK          workspace dir, default $PWD/.firecracker-e2e
+#
+# Version baseline: latest upstream stable firecracker (vanilla). The driver
+# client only uses the stable v1.x API surface, so any v1.x >= 1.0 works for
+# cold boot; the version only matters once snapshot ABI compatibility is
+# pinned per the runtime manifest.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="${WORK:-$PWD/.firecracker-e2e}"
+BIN_DIR="$WORK/bin"
+ART_DIR="$WORK/artifacts"
+FC_VERSION="${FC_VERSION:-v1.16.1}"
+FC_BINARY="${FC_BINARY:-$BIN_DIR/firecracker}"
+FC_KERNEL="${FC_KERNEL:-$ART_DIR/vmlinux.bin}"
+FC_ROOTFS="${FC_ROOTFS:-$ART_DIR/bionic.rootfs.ext4}"
+
+PRIVATE_CIDR="172.30.0.0/24"
+BRIDGE_NAME="fsb0"
+
+log() { printf '\033[1;34m[e2e]\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m[e2e] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# --- cleanup -----------------------------------------------------------------
+# Every resource this E2E family creates is derived from a per-run Pod UID:
+#   netns      fsb<64 hex>      resourceName("fsb", podUID, slotID, 63)
+#   host veth  fh<13 hex>       resourceName("fh", podUID, slotID, 15)
+#   guest tap  fc<13 hex>       resourceName("fc", podUID, slotID, 15)
+# Stale copies from earlier runs (crashed script, interrupted test) survive
+# `ip netns del` and carry the same private addresses, which corrupts ARP on
+# the shared bridge. purge_fsb_resources removes every fsb netns and every
+# fsb0-attached fh/fc device so a rerun starts from a clean host. The bridge
+# and its own address are restored separately by cleanup_host_state.
+
+fsb_netns_pattern='^fsb[0-9a-f]{32,}$'
+fsb0_dev_pattern='^(fc|fh)[0-9a-f]{10,}$'
+PRE_RUN_NETNS="$WORK/pre-run-netns"
+
+is_live_netns() { ip netns list 2>/dev/null | awk '{print $1}' | grep -qx "$1"; }
+
+kill_firecracker_vms() {
+    # Firecracker processes this E2E family launched carry --id e2e-sandbox-*.
+    for pid in $(pgrep -f "firecracker .*--id e2e-sandbox-" 2>/dev/null || true); do
+        kill "$pid" 2>/dev/null || true
+    done
+    # Netns deletion races the dying VMM holding the namespace (EBUSY), so
+    # wait a moment for the processes to exit before tearing devices down.
+    sleep 1
+}
+
+purge_fsb_resources() {
+    kill_firecracker_vms
+    for path in /var/run/netns/fsb*; do
+        [[ -e "$path" ]] || continue
+        name="$(basename "$path")"
+        [[ "$name" =~ $fsb_netns_pattern ]] || continue
+        if is_live_netns "$name"; then
+            for attempt in 1 2 3; do
+                ip netns del "$name" 2>/dev/null && break
+                sleep 0.2
+            done
+        fi
+        if [[ -e "$path" ]]; then
+            rm -f "$path"
+            log "removed stale netns $name"
+        fi
+    done
+    # Host-side veths/taps left on the bridge by earlier runs (or by the
+    # firecracker fallback tap naming fc-<10 hex>) keep stale addresses alive.
+    for dev in $(ip -o link show master "$BRIDGE_NAME" 2>/dev/null | awk -F'[ :]+' '{print $2}' | sort -u); do
+        [[ "$dev" =~ $fsb0_dev_pattern ]] || [[ "$dev" =~ ^fc-[0-9a-f]{10}$ ]] || continue
+        ip link del "$dev" 2>/dev/null || true
+        log "removed stale bridge device $dev"
+    done
+}
+
+record_pre_run_netns() {
+    ip netns list 2>/dev/null | awk '{print $1}' | sort > "$PRE_RUN_NETNS"
+}
+
+# Records the pre-existing host state so cleanup only removes what the test
+# created (the bridge, MASQUERADE, and ip_forward are restored by
+# cleanup_host_state; per-slot resources are always purged).
+record_host_state() {
+    _forward_before="$(cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo 1)"
+    _bridge_before="no"
+    if ip link show "$BRIDGE_NAME" >/dev/null 2>&1; then _bridge_before="yes"; fi
+    _masq_before="no"
+    if iptables -t nat -C POSTROUTING -s "$PRIVATE_CIDR" ! -d "$PRIVATE_CIDR" -j MASQUERADE 2>/dev/null; then _masq_before="yes"; fi
+}
+
+cleanup_leftovers() {
+    # Per-slot resources of this and earlier runs: netns, taps, and veths.
+    # The bridge and host-wide rules are restored by cleanup_host_state.
+    purge_fsb_resources
+}
+
+cleanup_host_state() {
+    # Restore only what the test created.
+    if [[ "$_bridge_before" == "no" ]] && ip link show "$BRIDGE_NAME" >/dev/null 2>&1; then
+        ip link del "$BRIDGE_NAME" 2>/dev/null || true
+    fi
+    if [[ "$_masq_before" == "no" ]]; then
+        iptables -t nat -D POSTROUTING -s "$PRIVATE_CIDR" ! -d "$PRIVATE_CIDR" -j MASQUERADE 2>/dev/null || true
+    fi
+    if [[ "$_forward_before" != "1" ]]; then
+        sysctl -w net.ipv4.ip_forward="$_forward_before" >/dev/null 2>&1 || true
+    fi
+}
+
+# --- re-invoke as root -------------------------------------------------------
+if [[ "$(id -u)" -ne 0 ]]; then
+    if command -v sudo >/dev/null; then
+        log "re-invoking as root (sudo -E)"
+        exec sudo -E env "PATH=$PATH" "WORK=$WORK" "FC_VERSION=$FC_VERSION" \
+            "FC_BINARY=$FC_BINARY" "FC_KERNEL=$FC_KERNEL" "FC_ROOTFS=$FC_ROOTFS" \
+            "FC_STATE_ROOT=${FC_STATE_ROOT:-}" \
+            "$0" "$@"
+    fi
+    die "must run as root (or install sudo)"
+fi
+
+# --- explicit cleanup mode ---------------------------------------------------
+if [[ "${1:-}" == "--cleanup" ]]; then
+    record_host_state
+    cleanup_leftovers
+    cleanup_host_state
+    log "host cleanup done (netns, firecracker processes, $BRIDGE_NAME bridge, MASQUERADE rule)"
+    exit 0
+fi
+
+# --- host prechecks ----------------------------------------------------------
+[[ "$(uname -s)" == "Linux" ]] || die "requires Linux, got $(uname -s)"
+[[ "$(uname -m)" == "x86_64" ]] || die "requires x86_64, got $(uname -m)"
+[[ -e /dev/kvm ]] || die "/dev/kvm is missing (enable KVM/nested virt)"
+[[ -w /dev/kvm ]] || die "/dev/kvm is not writable"
+[[ -e /dev/net/tun ]] || die "/dev/net/tun is missing"
+for cmd in ip iptables sysctl ping tar curl; do
+    command -v "$cmd" >/dev/null || die "missing required command: $cmd"
+done
+
+mkdir -p "$BIN_DIR" "$ART_DIR" /run/netns /run/fast-sandbox/netns
+
+# --- artifacts ---------------------------------------------------------------
+download() { # url target
+    log "downloading $2"
+    curl -fL --retry 3 -o "$2.tmp" "$1" || die "download failed: $1"
+    mv "$2.tmp" "$2"
+}
+
+if [[ ! -x "$FC_BINARY" ]]; then
+    tarball="$WORK/firecracker-$FC_VERSION-x86_64.tgz"
+    download "https://github.com/firecracker-microvm/firecracker/releases/download/$FC_VERSION/firecracker-$FC_VERSION-x86_64.tgz" "$tarball"
+    mkdir -p "$WORK/extract"
+    tar -xzf "$tarball" -C "$WORK/extract"
+    found="$(find "$WORK/extract" -type f -name "firecracker-v${FC_VERSION#v}-x86_64" | head -1)"
+    [[ -n "$found" ]] || die "firecracker binary not found in release tarball"
+    cp "$found" "$FC_BINARY"
+    chmod +x "$FC_BINARY"
+    rm -rf "$WORK/extract"
+fi
+"$FC_BINARY" --version >/dev/null || die "firecracker binary does not run (needs recent glibc)"
+
+if [[ ! -f "$FC_KERNEL" ]]; then
+    download "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin" "$FC_KERNEL"
+fi
+if [[ ! -f "$FC_ROOTFS" ]]; then
+    download "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/rootfs/bionic.rootfs.ext4" "$FC_ROOTFS"
+fi
+
+log "firecracker: $FC_BINARY ($("$FC_BINARY" --version | head -1))"
+log "kernel:     $FC_KERNEL"
+log "rootfs:     $FC_ROOTFS"
+
+# --- run the test ------------------------------------------------------------
+record_host_state
+# Purge leftovers of earlier runs (stale fsb netns with duplicate private
+# addresses corrupt ARP on the bridge) before recording the pre-run set.
+purge_fsb_resources
+record_pre_run_netns
+# On any exit: remove run-created netns/taps/firecracker processes, then
+# restore host resources (bridge, MASQUERADE, ip_forward) that did not exist
+# before the run. --cleanup remains available for interrupted runs.
+trap 'cleanup_leftovers; cleanup_host_state' EXIT
+log "running TestFirecrackerDriverE2E (+TestFirecrackerDriverE2ENoInfra, root)"
+cd "$REPO_ROOT"
+env FC_BINARY="$FC_BINARY" FC_KERNEL="$FC_KERNEL" FC_ROOTFS="$FC_ROOTFS" \
+    FC_STATE_ROOT="${FC_STATE_ROOT:-}" \
+    go test -tags firecracker -count=1 -v -run '^TestFirecrackerDriverE2E' \
+    ./internal/runtime/firecracker/
+
+log "E2E passed"
+log "host resources created by this run (netns, taps, rules) are restored automatically on exit"
+log "run the same command with --cleanup after an interrupted run"

--- a/scripts/firecracker-xfs-stateroot.sh
+++ b/scripts/firecracker-xfs-stateroot.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# firecracker-xfs-stateroot.sh — put the fast-sandbox StateRoot on a
+# reflink-capable filesystem so per-Sandbox rootfs copies are CoW (no dirty
+# pages, instant fsync) instead of paying the full dirty writeback (~2.7s per
+# create on throttled hosts). Point FC_STATE_ROOT at the resulting mount when
+# running scripts/firecracker-e2e.sh.
+#
+# Usage:
+#   ./firecracker-xfs-stateroot.sh <free-disk> [size]
+#       Format a free disk as xfs and mount at $MOUNT_POINT.
+#       size is passed to mkfs.xfs (default: keep disk size).
+#   ./firecracker-xfs-stateroot.sh --loop [size]
+#       Sparse loop-backed xfs file on an existing disk (default size 64G).
+#   ./firecracker-xfs-stateroot.sh --grow <size>
+#       Grow an existing loop-backed xfs online (truncate + xfs_growfs).
+#
+# The script never touches a disk/partition that already carries a filesystem.
+
+set -euo pipefail
+
+MOUNT_POINT="${FC_STATE_ROOT_MOUNT:-/var/lib/fast-sandbox}"
+REFLINK_LOOP_FILE="${REFLINK_LOOP_FILE:-/data/fast-sandbox.img}"
+
+log() { printf '\033[1;34m[fc-xfs]\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m[fc-xfs] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+[[ "$(id -u)" -eq 0 ]] || die "must run as root"
+command -v mkfs.xfs >/dev/null || die "xfsprogs not installed (yum install xfsprogs / apt install xfsprogs)"
+
+mount_xfs() { # device_or_file mountpoint
+    [[ -d "$2" ]] || mkdir -p "$2"
+    mount -o noatime "$1" "$2"
+}
+
+[[ -d "$MOUNT_POINT" ]] || mkdir -p "$MOUNT_POINT"
+if findmnt -no FSTYPE "$MOUNT_POINT" >/dev/null 2>&1; then
+    log "$MOUNT_POINT already mounted: $(findmnt -no SOURCE,FSTYPE "$MOUNT_POINT")"
+    exit 0
+fi
+
+verify_reflink() {
+    a="$MOUNT_POINT/.reflink-a"
+    b="$MOUNT_POINT/.reflink-b"
+    printf 'probe' > "$a"
+    cp --reflink=always "$a" "$b"
+    rm -f "$a" "$b"
+}
+
+if [[ "${1:-}" == "--loop" ]]; then
+    size="${2:-64G}"
+    log "loop-backed sparse xfs: $REFLINK_LOOP_FILE (virtual ${size})"
+    truncate -s "$size" "$REFLINK_LOOP_FILE"          # sparse: space is used on write
+    mkfs.xfs -f "$REFLINK_LOOP_FILE"
+    mount_xfs "$REFLINK_LOOP_FILE" "$MOUNT_POINT"
+    echo "$REFLINK_LOOP_FILE $MOUNT_POINT xfs loop,noatime 0 0" >> /etc/fstab
+elif [[ "${1:-}" == "--grow" ]]; then
+    size="${2:-}"
+    [[ -n "$size" ]] || die "usage: $0 --grow <size>"
+    [[ -f "$REFLINK_LOOP_FILE" ]] || die "loop file missing: $REFLINK_LOOP_FILE"
+    [[ -d "$MOUNT_POINT" ]] || mkdir -p "$MOUNT_POINT"
+    mount_xfs "$REFLINK_LOOP_FILE" "$MOUNT_POINT"
+    truncate -s "$size" "$REFLINK_LOOP_FILE"
+    xfs_growfs "$MOUNT_POINT"
+    log "grown to ${size}: $(df -h "$MOUNT_POINT" | tail -1)"
+    exit 0
+else
+    DISK="${1:-}"
+    [[ -n "$DISK" ]] || die "usage: $0 <free-disk> | --loop [size] | --grow <size>"
+    [[ -b "$DISK" ]] || die "not a block device: $DISK"
+    lsblk -no FSTYPE "$DISK" | grep -q . && die "refusing to format $DISK: it already has a filesystem"
+    size="${2:-}"
+    log "formatting $DISK as xfs and mounting at $MOUNT_POINT"
+    if [[ -n "$size" ]]; then
+        die "size argument is only valid with --loop"
+    fi
+    mkfs.xfs -f "$DISK"
+    mount_xfs "$DISK" "$MOUNT_POINT"
+    echo "$DISK $MOUNT_POINT xfs defaults,noatime 0 0" >> /etc/fstab
+fi
+
+verify_reflink && log "reflink OK on $MOUNT_POINT ($(findmnt -no FSTYPE "$MOUNT_POINT"))" \
+    || die "reflink verification failed on $MOUNT_POINT"
+
+log "done. Point the fast-sandbox StateRoot at $MOUNT_POINT"
+log "ops: du -sh $MOUNT_POINT/* ; cache GC under $MOUNT_POINT/images ; fstrim -v $MOUNT_POINT ; grow with $0 --grow <size>"

--- a/test/e2e/suites/secureruntime/runtime_validation_test.go
+++ b/test/e2e/suites/secureruntime/runtime_validation_test.go
@@ -129,6 +129,72 @@ func TestRuntimeValidationUnsupportedBoxLite(t *testing.T) {
 	testSuite.Env().Test(t, feature)
 }
 
+func TestRuntimeValidationUnsupportedFirecracker(t *testing.T) {
+	suiteenv.RequireBasic(t)
+
+	feature := features.New("firecracker-capability-gate").
+		WithLabel("suite", "secureruntime").
+		WithLabel("tier", "validation").
+		Assess("Firecracker remains fail closed until the KVM E2E suite passes", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			k8sClient := testSuite.MustKubeClient(t)
+			fixture := fixtures.New(k8sClient, fixtures.WithPollInterval(250*time.Millisecond))
+
+			namespace := testSuite.AllocateNamespace("unsupported-firecracker")
+			if err := k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}); err != nil {
+				t.Fatalf("create namespace: %v", err)
+			}
+			defer suiteenv.DeleteNamespace(ctx, t, k8sClient, namespace)
+
+			// The Firecracker driver is registered but its production capability
+			// gate stays closed until the driver lifecycle and KVM E2E pass.
+			pool := newSecureRuntimePool(namespace, "unsupported-firecracker-pool", apiv1alpha2.RuntimeFirecracker, 1, 1)
+			if _, err := fixture.CreateSandboxPool(ctx, namespace, pool); err != nil {
+				t.Fatalf("create pool: %v", err)
+			}
+
+			conditionCtx, cancelCondition := context.WithTimeout(ctx, 30*time.Second)
+			defer cancelCondition()
+
+			var runtimeReady *metav1.Condition
+			for {
+				updatedPool := &apiv1alpha2.SandboxPool{}
+				if err := k8sClient.Get(conditionCtx, types.NamespacedName{Name: pool.Name, Namespace: namespace}, updatedPool); err != nil {
+					t.Fatalf("get pool: %v", err)
+				}
+				for _, c := range updatedPool.Status.Conditions {
+					if c.Type == apiv1alpha2.PoolConditionRuntimeReady {
+						runtimeReady = &c
+						break
+					}
+				}
+				if runtimeReady != nil || conditionCtx.Err() != nil {
+					break
+				}
+				time.Sleep(500 * time.Millisecond)
+			}
+
+			if runtimeReady == nil {
+				t.Fatal("expected RuntimeReady condition to be set")
+			}
+			if runtimeReady.Status != metav1.ConditionFalse {
+				t.Errorf("expected RuntimeReady condition to be False, got: %v", runtimeReady.Status)
+			}
+			if runtimeReady.Reason != apiv1alpha2.ReasonRuntimeUnsupported {
+				t.Errorf("expected Reason to be RuntimeUnsupported, got: %v", runtimeReady.Reason)
+			}
+			if runtimeReady.Message != "FirecrackerDriverUnimplemented" {
+				t.Errorf("unexpected Firecracker capability message: %q", runtimeReady.Message)
+			}
+
+			t.Logf("Pool condition correctly shows error: %s", runtimeReady.Message)
+
+			return ctx
+		}).
+		Feature()
+
+	testSuite.Env().Test(t, feature)
+}
+
 func TestRuntimeValidationContainerDefault(t *testing.T) {
 	suiteenv.RequireBasic(t)
 


### PR DESCRIPTION
## Summary

Implements the Firecracker runtime driver end to end in fast-sandbox, closing the runtime gap so a Sandbox can be backed by a real Firecracker microVM on a KVM node: on-demand VM boot, pre-provisioned network slots, Infra Components (execd) delivery into the guest rootfs, image cache management, and a real-KVM E2E suite.

## What's in this PR

**Driver lifecycle** (`internal/runtime/firecracker/`)
- Ensure / Inspect / Delete / List / Recover / Probe / Close; idempotent create, stale-record cleanup, per-Sandbox state under `<StateRoot>/sandboxes/<id>`
- Firecracker API client (machine config, boot source, root drive, network interface, GET / instance state) and process launcher with NodeJanitor-compatible `--id <sandboxID[:32]>` argv, API socket wait, and guest serial log capture
- Per-phase create timing and OTel spans (`fastlet.firecracker.{create,acquire,rootfs,infra,launch,configure,boot}`), trace ID derived from the Sandbox id

**Pre-provisioned network slots** (`internal/fastlet/network/`)
- `GuestVMNetNSDriver`: per-slot host-side tap bridged to the shared bridge, pod-IP DNAT and FORWARD rules at the host, guest owns slot IP + 1, static `ip=` boot arg (dotted-quad netmask)
- `NetworkModeFirecracker = "firecracker-tap"` in the runtime catalog; the driver performs no ip/iptables work at create time

**Infra Components delivery**
- Loop-mount the per-instance reflink rootfs copy, land sandbox-init / infra.json / components, publish services and diagnostics into Sandbox metadata, roll back on failure
- Instance rootfs uses `cp --reflink=always` (plain-copy fallback): create drops from ~3.0 s to ~282 ms on a reflink-capable StateRoot

**Image cache with LFU GC**
- Content-addressed cache `<StateRoot>/images/<sha256(imageRef)>/rootfs.img` produced out-of-band by the conversion pipeline
- Independent GC loop (1h interval + on-demand trigger), in-memory use counts, evicts unreferenced least-frequently-used images when the cache exceeds its size limit

**Fail-closed capability gate**
- The built-in profile stays `CapabilityUnsupported` (`FirecrackerDriverUnimplemented`) until the KVM E2E passes; cluster-level validation asserts Firecracker remains fail-closed

## E2E (real KVM, scripts/firecracker-e2e.sh)

| Test | Verifies |
|------|----------|
| `TestFirecrackerDriverE2E` | Full lifecycle with real Infra delivery; guest files asserted via debugfs; real guest reachability |
| `TestFirecrackerDriverE2ENoInfra` | Same lifecycle without infra |
| `TestFirecrackerDriverE2EConcurrent` | 5 pre-provisioned slots, 5 VMs booted concurrently (~470-515 ms), per-Sandbox trace correlation, distinct processes, guest reachability per instance |
| `TestFirecrackerDriverE2EImageGC` | LFU cache GC: unreferenced low-frequency image evicted, live Sandbox pins its image, deletion releases it |

Host state (bridge, MASQUERADE, ip_forward, netns, taps) is auto-restored on exit; stale `fsb*` netns/taps from interrupted runs are purged before each run; the host neighbour cache is flushed before guest probes so repeated runs do not interfere. The suite has been run back-to-back with all green.

## Performance (reference host: bare-metal x86_64, Xeon Platinum 8163, Alibaba Cloud Linux 3)

- Single VM with infra: ~317 ms (infra ~200 ms, launch ~100 ms, boot ~10 ms)
- Single VM without infra: ~113 ms
- 5 VMs concurrently: ~470-515 ms (infra phase inflates 200→~350 ms due to mount+copy kernel serialization, see #14)

## Out of scope (follow-ups)

- execd guest bootstrap execution (driver delivers Command/Env + GuestInit; control plane assembles bootstrap.sh) — required before the capability gate flips to Ready
- SDK end-to-end before gate flip
- RecoverRuntimeResources real-scenario fault drill (#15)
- pause/resume, snapshot/cross-host, warm instance pool, cgroup enforcement, OverlayBD phase

Environment reference: `docs/guides/firecracker-runtime-e2e.md`
