### PR TITLE
feat(builder): publish SHA256SUMS and the image reference index

### DIFF
--- a/cmd/sandboxtemplate-builder/publish.go
+++ b/cmd/sandboxtemplate-builder/publish.go
@@ -105,7 +105,20 @@ func imageIndexPayload(image, manifestURI, artifactDigest string) ([]byte, error
 // consumers can resolve the published artifact set from the image reference
 // alone. The index lives outside the per-build digest namespace, so a
 // rebuild of the same image reference atomically moves the pointer.
+//
+// The index key is derived from the raw image reference string and must be
+// byte-identical to the consumer-side reference (SandboxSpec.Image): no
+// normalization, no default tags, no whitespace trimming. Any divergence
+// breaks the addressing chain.
+//
+// Concurrent builds of the same image reference against the same store
+// root are last-writer-wins: every build is complete before its index is
+// written, so no half-published state is ever observable, but the winner
+// is not deterministic (publishers should serialize per image).
 func publishImageIndex(ctx context.Context, aws string, args []string, image, manifestURI, artifactDigest, storeRoot string) error {
+	if strings.TrimSpace(image) == "" {
+		return fmt.Errorf("publish image index: image reference is required (empty image would collide on the empty-hash index key)")
+	}
 	payload, err := imageIndexPayload(image, manifestURI, artifactDigest)
 	if err != nil {
 		return err

--- a/cmd/sandboxtemplate-builder/publish.go
+++ b/cmd/sandboxtemplate-builder/publish.go
@@ -21,8 +21,10 @@ import (
 )
 
 // publish uploads the artifacts under a digest namespace and returns the
-// manifest URI. The manifest is uploaded last so consumers never observe a
-// half-published artifact set. OverlayBD layers keep their relative paths
+// manifest URI. Upload order guarantees consumers never observe a
+// half-published artifact set: artifacts and SHA256SUMS first, then the
+// manifest, and finally the image index that points at this build.
+// OverlayBD layers keep their relative paths
 // (overlaybd/rootfs/layer.lsmt, overlaybd/memory/layer.lsmt) — a flat
 // basename would collide on the same S3 key.
 func publish(ctx context.Context, spec apiv1alpha2.SandboxTemplateSpec, workdir string, manifestBytes []byte) (string, error) {
@@ -35,6 +37,9 @@ func publish(ctx context.Context, spec apiv1alpha2.SandboxTemplateSpec, workdir 
 		{filepath.Join(workdir, "rootfs.ext4"), "rootfs.ext4"},
 		{filepath.Join(workdir, "vmstate.snap"), "vmstate.snap"},
 		{filepath.Join(workdir, "memory.snap"), "memory.snap"},
+		// SHA256SUMS covers only the published artifact set; it belongs to
+		// the immutable build directory and goes up with the artifacts.
+		{filepath.Join(workdir, "SHA256SUMS"), "SHA256SUMS"},
 	}
 	if layers, err := filepath.Glob(filepath.Join(workdir, "overlaybd", "*", "layer.lsmt")); err == nil {
 		for _, layer := range layers {
@@ -60,7 +65,65 @@ func publish(ctx context.Context, spec apiv1alpha2.SandboxTemplateSpec, workdir 
 	if err := uploadWithRetry(ctx, aws, args, filepath.Join(workdir, "manifest.json"), manifestURI, "manifest.json"); err != nil {
 		return "", err
 	}
+	// The image index is uploaded last: a consumer that can resolve the
+	// index is guaranteed a complete artifact set (artifacts, checksums,
+	// and manifest are all already in place).
+	if err := publishImageIndex(ctx, aws, args, spec.Image, manifestURI, sha256Of(manifestBytes), spec.Output.Publish); err != nil {
+		return "", err
+	}
 	return manifestURI, nil
+}
+
+// imageIndexKey derives the content-addressed index key of an image
+// reference. It matches the consumer-side cache key, so a consumer can
+// resolve the latest published manifest for an image reference without any
+// control-plane coordination.
+func imageIndexKey(image string) string {
+	return sha256Of([]byte(image))
+}
+
+// imageIndexPayload builds the image index document pointing at the latest
+// published manifest. The manifest reference is content-addressed, so an
+// older build of the same image reference stays intact and only the index
+// pointer moves.
+func imageIndexPayload(image, manifestURI, artifactDigest string) ([]byte, error) {
+	document := struct {
+		Image          string `json:"image"`
+		ManifestRef    string `json:"manifestRef"`
+		ArtifactDigest string `json:"artifactDigest"`
+		UpdatedAt      string `json:"updatedAt"`
+	}{
+		Image:          image,
+		ManifestRef:    manifestURI,
+		ArtifactDigest: artifactDigest,
+		UpdatedAt:      time.Now().UTC().Format(time.RFC3339),
+	}
+	return json.MarshalIndent(document, "", "  ")
+}
+
+// publishImageIndex uploads the image index object under the store root so
+// consumers can resolve the published artifact set from the image reference
+// alone. The index lives outside the per-build digest namespace, so a
+// rebuild of the same image reference atomically moves the pointer.
+func publishImageIndex(ctx context.Context, aws string, args []string, image, manifestURI, artifactDigest, storeRoot string) error {
+	payload, err := imageIndexPayload(image, manifestURI, artifactDigest)
+	if err != nil {
+		return err
+	}
+	local, err := os.CreateTemp("", "fc-image-index-*.json")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(local.Name())
+	if _, err := local.Write(payload); err != nil {
+		return err
+	}
+	if err := local.Close(); err != nil {
+		return err
+	}
+	key := "index/" + imageIndexKey(image) + ".json"
+	target := strings.TrimRight(storeRoot, "/") + "/" + key
+	return uploadWithRetry(ctx, aws, args, local.Name(), target, key)
 }
 
 // publishRetries is how many times a transient upload failure is retried.

--- a/cmd/sandboxtemplate-builder/publish_test.go
+++ b/cmd/sandboxtemplate-builder/publish_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestImageIndexKeyMatchesConsumerCacheKey verifies the index key derivation
+// matches the consumer-side cache key (sha256 of the image reference string),
+// so the addressing chain Image -> index works without control-plane help.
+func TestImageIndexKeyMatchesConsumerCacheKey(t *testing.T) {
+	const image = "registry.example.com/sandbox:v1.0.21"
+	digest := sha256.Sum256([]byte(image))
+	if got, want := imageIndexKey(image), hex.EncodeToString(digest[:]); got != want {
+		t.Fatalf("imageIndexKey(%q) = %s, want %s", image, got, want)
+	}
+	if got := imageIndexKey(image); len(got) != sha256.Size*2 {
+		t.Fatalf("imageIndexKey length = %d, want %d", len(got), sha256.Size*2)
+	}
+}
+
+// TestImageIndexPayload verifies the index document shape: manifestRef,
+// artifactDigest, and an RFC3339 updatedAt timestamp.
+func TestImageIndexPayload(t *testing.T) {
+	const (
+		image          = "registry.example.com/sandbox:v1.0.21"
+		manifestURI    = "s3://bucket/sandbox-images/0123456789abcdef/manifest.json"
+		artifactDigest = "deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+	)
+	payload, err := imageIndexPayload(image, manifestURI, artifactDigest)
+	if err != nil {
+		t.Fatalf("imageIndexPayload: %v", err)
+	}
+	var document struct {
+		Image          string `json:"image"`
+		ManifestRef    string `json:"manifestRef"`
+		ArtifactDigest string `json:"artifactDigest"`
+		UpdatedAt      string `json:"updatedAt"`
+	}
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatalf("unmarshal index: %v", err)
+	}
+	if document.Image != image {
+		t.Fatalf("image = %q, want %q", document.Image, image)
+	}
+	if document.ManifestRef != manifestURI {
+		t.Fatalf("manifestRef = %q, want %q", document.ManifestRef, manifestURI)
+	}
+	if document.ArtifactDigest != artifactDigest {
+		t.Fatalf("artifactDigest = %q, want %q", document.ArtifactDigest, artifactDigest)
+	}
+	if _, err := time.Parse(time.RFC3339, document.UpdatedAt); err != nil {
+		t.Fatalf("updatedAt %q is not RFC3339: %v", document.UpdatedAt, err)
+	}
+}

--- a/cmd/sandboxtemplate-builder/publish_test.go
+++ b/cmd/sandboxtemplate-builder/publish_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -54,5 +56,22 @@ func TestImageIndexPayload(t *testing.T) {
 	}
 	if _, err := time.Parse(time.RFC3339, document.UpdatedAt); err != nil {
 		t.Fatalf("updatedAt %q is not RFC3339: %v", document.UpdatedAt, err)
+	}
+}
+
+// TestPublishImageIndexRejectsEmptyImage verifies the empty-reference guard:
+// an empty image must not silently hash into a valid index key (the
+// consumer side rejects empty images the same way).
+func TestPublishImageIndexRejectsEmptyImage(t *testing.T) {
+	for _, image := range []string{"", "   ", "\t\n"} {
+		err := publishImageIndex(context.Background(), "aws", []string{"s3", "cp"}, image,
+			"s3://bucket/sandbox-images/0123456789abcdef/manifest.json",
+			"deadbeef", "s3://bucket/sandbox-images")
+		if err == nil {
+			t.Fatalf("expected an error for empty image reference %q", image)
+		}
+		if !strings.Contains(err.Error(), "image reference is required") {
+			t.Fatalf("error %q does not mention the required guard", err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fills the two publisher gaps of the SandboxTemplate builder `publish`
stage (the publisher-side changes of `firecracker-on-demand-loading.md`
§1.2), so the consumer-side addressing chain
`SandboxSpec.Image -> index -> manifest -> content-addressed artifacts`
closes on the publisher side.

## Changes

1. **Publish SHA256SUMS**: `writeChecksums` previously only staged the
   file in the workdir; it is now uploaded with the artifact set
   (`<base>/SHA256SUMS`) for audit/manual verification (consumers still
   verify against `manifest.files`).
2. **Image reference index**: after the manifest, the builder uploads
   `<store>/index/<sha256(imageRef)>.json`:
   ```json
   { "image": "...", "manifestRef": "<base>/manifest.json", "artifactDigest": "...", "updatedAt": "RFC3339" }
   ```
   - The index lives outside the per-build digest namespace: rebuilding
     the same image reference atomically moves the pointer, older builds
     stay intact.
   - **Upload order guarantee**: artifacts + SHA256SUMS -> manifest ->
     index; a consumer that can resolve the index is guaranteed a
     complete artifact set.

## Tests

- `TestImageIndexKeyMatchesConsumerCacheKey`: index key derivation
  matches the consumer-side cache key (`sha256(imageRef)`).
- `TestImageIndexPayload`: document shape (manifestRef / artifactDigest /
  RFC3339 updatedAt).

`go build` / `go test` / `go vet` pass on go1.26.7.

## Related

Design: opensandbox-group/fast-sandbox#21 (draft: Firecracker on-demand
loading design + verification script).