### PR TITLE
feat(agent): stage-1 consumer PullImage chain (index -> manifest -> digest-verified pull)

### DIFF
--- a/internal/runtime/contract/errors.go
+++ b/internal/runtime/contract/errors.go
@@ -12,4 +12,9 @@ var (
 	ErrInfraUnavailable             = errors.New("sandbox Infra Components unavailable")
 	ErrSandboxProfileMismatch       = errors.New("sandbox profile mismatch")
 	ErrInvalidConfig                = errors.New("invalid sandbox config")
+	// ErrImageNotReady reports that a rootfs image has not been converted
+	// and cached yet. It is shared between the driver's local cache and the
+	// firecracker runtime-agent pull layer so both can fail a create with
+	// the same sentinel.
+	ErrImageNotReady = errors.New("rootfs image is not ready in the local cache")
 )

--- a/internal/runtime/firecracker/agent/cache.go
+++ b/internal/runtime/firecracker/agent/cache.go
@@ -44,6 +44,11 @@ func imageDir(stateRoot, image string) string {
 // cacheComplete reports whether the image directory holds a committed pull:
 // the local manifest plus a native file set whose digests match. It is the
 // idempotency check: a complete cache is never touched again.
+//
+// Deliberate trade-off: a committed cache is never refreshed for the same
+// image reference, even when the publisher rebuilds it. Picking up a new
+// build requires clearing the cache directory or using a new tag. Warm-image
+// preheating relies on this "pull once per reference" behavior.
 func cacheComplete(dir string) (bool, error) {
 	payload, err := os.ReadFile(filepath.Join(dir, manifestName))
 	if err != nil {
@@ -61,7 +66,7 @@ func cacheComplete(dir string) (bool, error) {
 		return false, nil
 	}
 	for _, file := range files {
-		match, err := fileMatches(filepath.Join(dir, file.cache), file.sha256)
+		match, err := fileMatches(filepath.Join(dir, file.cache), file)
 		if err != nil || !match {
 			return false, nil
 		}
@@ -69,13 +74,14 @@ func cacheComplete(dir string) (bool, error) {
 	return true, nil
 }
 
-// stageFile ensures the artifact is in the cache with the expected digest:
-// an existing matching file is skipped (resume semantics), a mismatching
-// file is deleted and re-pulled, and the download lands in a temporary file
-// that is renamed into place only after the whole content verifies.
+// stageFile ensures the artifact is in the cache with the expected size and
+// digest: an existing matching file is skipped (resume semantics), a
+// mismatching file is deleted and re-pulled, and the download lands in a
+// temporary file that is renamed into place only after the whole content
+// verifies.
 func stageFile(ctx context.Context, s3 *s3Client, dir, storeKey string, file nativeFile) error {
 	target := filepath.Join(dir, file.cache)
-	match, err := fileMatches(target, file.sha256)
+	match, err := fileMatches(target, file)
 	if err == nil && match {
 		return nil
 	}
@@ -108,8 +114,12 @@ func stageFile(ctx context.Context, s3 *s3Client, dir, storeKey string, file nat
 		}
 	}()
 	digest := sha256.New()
-	if _, err := io.Copy(tmp, io.TeeReader(body, digest)); err != nil {
+	written, err := io.Copy(tmp, io.TeeReader(body, digest))
+	if err != nil {
 		return fmt.Errorf("download %s: %w", file.publish, err)
+	}
+	if written != file.sizeBytes {
+		return fmt.Errorf("artifact %s size mismatch: got %d bytes, want %d", file.publish, written, file.sizeBytes)
 	}
 	sum := hex.EncodeToString(digest.Sum(nil))
 	if sum != file.sha256 {
@@ -152,8 +162,18 @@ func commitManifest(dir string, payload []byte) error {
 	return os.Rename(tmp.Name(), filepath.Join(dir, manifestName))
 }
 
-// fileMatches reports whether the file exists and its sha256 matches.
-func fileMatches(path, want string) (bool, error) {
+// fileMatches reports whether the file exists with the expected size and
+// sha256. The size is compared first via stat: hashing a multi-GiB rootfs
+// on every idempotency check would defeat the point of the warm cache, so
+// the full digest is only computed when the size matches.
+func fileMatches(path string, file nativeFile) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	if info.Size() != file.sizeBytes {
+		return false, nil
+	}
 	input, err := os.Open(path)
 	if err != nil {
 		return false, err
@@ -163,5 +183,5 @@ func fileMatches(path, want string) (bool, error) {
 	if _, err := io.Copy(digest, input); err != nil {
 		return false, err
 	}
-	return hex.EncodeToString(digest.Sum(nil)) == want, nil
+	return hex.EncodeToString(digest.Sum(nil)) == file.sha256, nil
 }

--- a/internal/runtime/firecracker/agent/cache.go
+++ b/internal/runtime/firecracker/agent/cache.go
@@ -107,8 +107,11 @@ func stageFile(ctx context.Context, s3 *s3Client, dir, storeKey string, file nat
 		return err
 	}
 	keep := false
+	closed := false
 	defer func() {
-		_ = tmp.Close()
+		if !closed {
+			_ = tmp.Close()
+		}
 		if !keep {
 			_ = os.Remove(tmp.Name())
 		}
@@ -128,9 +131,12 @@ func stageFile(ctx context.Context, s3 *s3Client, dir, storeKey string, file nat
 	if err := tmp.Chmod(cacheFileMode); err != nil {
 		return err
 	}
+	// Flush before the rename so the committed name never points at a
+	// half-written file; the deferred cleanup skips the already-closed file.
 	if err := tmp.Close(); err != nil {
 		return err
 	}
+	closed = true
 	if err := os.Rename(tmp.Name(), target); err != nil {
 		return err
 	}
@@ -146,8 +152,11 @@ func commitManifest(dir string, payload []byte) error {
 	if err != nil {
 		return err
 	}
+	closed := false
 	defer func() {
-		_ = tmp.Close()
+		if !closed {
+			_ = tmp.Close()
+		}
 		_ = os.Remove(tmp.Name())
 	}()
 	if _, err := tmp.Write(payload); err != nil {
@@ -156,9 +165,12 @@ func commitManifest(dir string, payload []byte) error {
 	if err := tmp.Chmod(cacheFileMode); err != nil {
 		return err
 	}
+	// Flush before the rename so the committed name never points at a
+	// half-written file; the deferred cleanup skips the already-closed file.
 	if err := tmp.Close(); err != nil {
 		return err
 	}
+	closed = true
 	return os.Rename(tmp.Name(), filepath.Join(dir, manifestName))
 }
 

--- a/internal/runtime/firecracker/agent/cache.go
+++ b/internal/runtime/firecracker/agent/cache.go
@@ -1,0 +1,167 @@
+package agent
+
+// Cache layout (implementation plan §5):
+//
+//	<StateRoot>/images/<sha256(image)>/
+//	├── rootfs.img      # ← published rootfs.ext4
+//	├── vmstate.snap
+//	├── memory.snap
+//	└── manifest.json   # commit point, written last
+//
+// The imageKey derivation must stay byte-identical to the driver's cache
+// key (internal/runtime/firecracker/images.go) so the driver's
+// resolveRootfsImage and GC work on the pulled artifacts unchanged.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const (
+	imageCacheDir = "images"
+	manifestName  = "manifest.json"
+	cacheFileMode = 0o640
+	cacheDirMode  = 0o750
+)
+
+// imageKey derives the content-addressed cache key of an image reference.
+func imageKey(image string) string {
+	digest := sha256.Sum256([]byte(image))
+	return hex.EncodeToString(digest[:])
+}
+
+// imageDir returns the cache directory of an image reference.
+func imageDir(stateRoot, image string) string {
+	return filepath.Join(stateRoot, imageCacheDir, imageKey(image))
+}
+
+// cacheComplete reports whether the image directory holds a committed pull:
+// the local manifest plus a native file set whose digests match. It is the
+// idempotency check: a complete cache is never touched again.
+func cacheComplete(dir string) (bool, error) {
+	payload, err := os.ReadFile(filepath.Join(dir, manifestName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	document, err := parseManifest(payload)
+	if err != nil {
+		return false, nil
+	}
+	files, err := document.nativeFiles()
+	if err != nil {
+		return false, nil
+	}
+	for _, file := range files {
+		match, err := fileMatches(filepath.Join(dir, file.cache), file.sha256)
+		if err != nil || !match {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// stageFile ensures the artifact is in the cache with the expected digest:
+// an existing matching file is skipped (resume semantics), a mismatching
+// file is deleted and re-pulled, and the download lands in a temporary file
+// that is renamed into place only after the whole content verifies.
+func stageFile(ctx context.Context, s3 *s3Client, dir, storeKey string, file nativeFile) error {
+	target := filepath.Join(dir, file.cache)
+	match, err := fileMatches(target, file.sha256)
+	if err == nil && match {
+		return nil
+	}
+	if err == nil {
+		// Corrupt cache entry: drop it before re-pulling. The local
+		// manifest is left alone; the commit-point check decides whether
+		// the whole pull needs redoing.
+		if removeErr := os.Remove(target); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return removeErr
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	body, err := s3.get(ctx, storeKey)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+
+	tmp, err := os.CreateTemp(dir, file.cache+".tmp-*")
+	if err != nil {
+		return err
+	}
+	keep := false
+	defer func() {
+		_ = tmp.Close()
+		if !keep {
+			_ = os.Remove(tmp.Name())
+		}
+	}()
+	digest := sha256.New()
+	if _, err := io.Copy(tmp, io.TeeReader(body, digest)); err != nil {
+		return fmt.Errorf("download %s: %w", file.publish, err)
+	}
+	sum := hex.EncodeToString(digest.Sum(nil))
+	if sum != file.sha256 {
+		return fmt.Errorf("artifact %s digest mismatch: got %s, want %s", file.publish, sum, file.sha256)
+	}
+	if err := tmp.Chmod(cacheFileMode); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp.Name(), target); err != nil {
+		return err
+	}
+	keep = true
+	return nil
+}
+
+// commitManifest writes the downloaded manifest as the pull commit point:
+// its presence with matching files means the pull is complete. The write is
+// atomic so a crash never leaves a half-written manifest.
+func commitManifest(dir string, payload []byte) error {
+	tmp, err := os.CreateTemp(dir, manifestName+".tmp-*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+	}()
+	if _, err := tmp.Write(payload); err != nil {
+		return err
+	}
+	if err := tmp.Chmod(cacheFileMode); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), filepath.Join(dir, manifestName))
+}
+
+// fileMatches reports whether the file exists and its sha256 matches.
+func fileMatches(path, want string) (bool, error) {
+	input, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer input.Close()
+	digest := sha256.New()
+	if _, err := io.Copy(digest, input); err != nil {
+		return false, err
+	}
+	return hex.EncodeToString(digest.Sum(nil)) == want, nil
+}

--- a/internal/runtime/firecracker/agent/cache_test.go
+++ b/internal/runtime/firecracker/agent/cache_test.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFileMatchesSizeFastPath verifies the stat-first size check: a file
+// with the wrong size is rejected without reading (the fast path), a file
+// with the right size but wrong content is rejected by the digest, and an
+// exact match passes.
+func TestFileMatchesSizeFastPath(t *testing.T) {
+	content := bytes.Repeat([]byte{0xab}, 1<<20)
+	file := nativeFile{publish: "rootfs.ext4", cache: "rootfs.img", sha256: sha256Hex(content), sizeBytes: int64(len(content))}
+	path := filepath.Join(t.TempDir(), "rootfs.img")
+
+	// Missing file.
+	match, err := fileMatches(path, file)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.False(t, match)
+
+	// Wrong size: rejected by stat, no content read needed.
+	require.NoError(t, os.WriteFile(path, []byte("tiny"), cacheFileMode))
+	match, err = fileMatches(path, file)
+	require.NoError(t, err)
+	require.False(t, match)
+
+	// Right size, wrong content: caught by the digest.
+	wrong := bytes.Repeat([]byte{0x00}, len(content))
+	require.NoError(t, os.WriteFile(path, wrong, cacheFileMode))
+	match, err = fileMatches(path, file)
+	require.NoError(t, err)
+	require.False(t, match)
+
+	// Exact match.
+	require.NoError(t, os.WriteFile(path, content, cacheFileMode))
+	match, err = fileMatches(path, file)
+	require.NoError(t, err)
+	require.True(t, match)
+}
+
+// TestCacheComplete checks the committed-pull predicate: any missing,
+// resized, or corrupted file (or a missing manifest) invalidates the cache.
+func TestCacheComplete(t *testing.T) {
+	artifacts := map[string][]byte{
+		"rootfs.ext4":  bytes.Repeat([]byte{0xab}, 1<<16),
+		"vmstate.snap": []byte("vmstate"),
+		"memory.snap":  []byte("memory"),
+	}
+	manifestPayload := testManifest(artifacts)
+	document, err := parseManifest(manifestPayload)
+	require.NoError(t, err)
+	files, err := document.nativeFiles()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(dir, cacheDirMode))
+
+	// No manifest: not complete.
+	complete, err := cacheComplete(dir)
+	require.NoError(t, err)
+	require.False(t, complete)
+
+	// Manifest but no files: not complete.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, manifestName), manifestPayload, cacheFileMode))
+	complete, err = cacheComplete(dir)
+	require.NoError(t, err)
+	require.False(t, complete)
+
+	// A file with the wrong size: not complete (fast path).
+	for _, file := range files[:1] {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, file.cache), []byte("tiny"), cacheFileMode))
+	}
+	complete, err = cacheComplete(dir)
+	require.NoError(t, err)
+	require.False(t, complete)
+
+	// All files exact: complete.
+	for _, file := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, file.cache), artifacts[file.publish], cacheFileMode))
+	}
+	complete, err = cacheComplete(dir)
+	require.NoError(t, err)
+	require.True(t, complete)
+
+	// Any single corrupt file breaks the commit.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, files[1].cache), []byte("tampered"), cacheFileMode))
+	complete, err = cacheComplete(dir)
+	require.NoError(t, err)
+	require.False(t, complete)
+}

--- a/internal/runtime/firecracker/agent/doc.go
+++ b/internal/runtime/firecracker/agent/doc.go
@@ -1,0 +1,9 @@
+// Package agent implements the node-level firecracker-runtime-agent pull
+// layer (stage 1 of the Firecracker on-demand loading design): the consumer
+// side of the addressing chain SandboxSpec.Image -> index -> manifest ->
+// content-addressed native artifacts, materialized in the cache shared with
+// the driver (<StateRoot>/images/<sha256(image)>/).
+//
+// Stage 1 scope: no UDS server, no P2P, no overlaybd, and the driver keeps
+// its local PullImage until the agent wiring lands.
+package agent

--- a/internal/runtime/firecracker/agent/index.go
+++ b/internal/runtime/firecracker/agent/index.go
@@ -26,6 +26,11 @@ func indexKey(image string) string {
 	return "index/" + imageKey(image) + ".json"
 }
 
+// maxIndexBytes caps the downloaded image index document. Indexes are tiny
+// (four fields); a larger document is never legitimate, so it is rejected
+// instead of being read unbounded.
+const maxIndexBytes = 1 << 20
+
 // fetchIndex downloads and validates the image reference index. A missing
 // index surfaces as ErrObjectNotFound so the caller can map it to
 // ErrImageNotReady.
@@ -35,9 +40,12 @@ func fetchIndex(ctx context.Context, s3 *s3Client, image string) (imageIndex, er
 		return imageIndex{}, err
 	}
 	defer body.Close()
-	payload, err := io.ReadAll(body)
+	payload, err := io.ReadAll(io.LimitReader(body, maxIndexBytes+1))
 	if err != nil {
 		return imageIndex{}, fmt.Errorf("read image index for %q: %w", image, err)
+	}
+	if len(payload) > maxIndexBytes {
+		return imageIndex{}, fmt.Errorf("image index for %q exceeds the %d-byte limit", image, maxIndexBytes)
 	}
 	var index imageIndex
 	if err := json.Unmarshal(payload, &index); err != nil {

--- a/internal/runtime/firecracker/agent/index.go
+++ b/internal/runtime/firecracker/agent/index.go
@@ -1,0 +1,50 @@
+package agent
+
+// The image reference index (design details doc §1.2) resolves a published
+// build from the image reference alone: <store>/index/<sha256(image)>.json
+// points at the latest complete artifact set.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// imageIndex is the published image reference index document.
+type imageIndex struct {
+	Image          string `json:"image"`
+	ManifestRef    string `json:"manifestRef"`
+	ArtifactDigest string `json:"artifactDigest"`
+	UpdatedAt      string `json:"updatedAt"`
+}
+
+// indexKey returns the store-relative key of the image reference index. The
+// derivation matches the publisher's imageIndexKey and the driver's cache
+// key, so the addressing chain needs no control-plane coordination.
+func indexKey(image string) string {
+	return "index/" + imageKey(image) + ".json"
+}
+
+// fetchIndex downloads and validates the image reference index. A missing
+// index surfaces as ErrObjectNotFound so the caller can map it to
+// ErrImageNotReady.
+func fetchIndex(ctx context.Context, s3 *s3Client, image string) (imageIndex, error) {
+	body, err := s3.get(ctx, indexKey(image))
+	if err != nil {
+		return imageIndex{}, err
+	}
+	defer body.Close()
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		return imageIndex{}, fmt.Errorf("read image index for %q: %w", image, err)
+	}
+	var index imageIndex
+	if err := json.Unmarshal(payload, &index); err != nil {
+		return imageIndex{}, fmt.Errorf("decode image index for %q: %w", image, err)
+	}
+	if index.ManifestRef == "" || index.ArtifactDigest == "" {
+		return imageIndex{}, fmt.Errorf("image index for %q is incomplete: manifestRef and artifactDigest are required", image)
+	}
+	return index, nil
+}

--- a/internal/runtime/firecracker/agent/index_test.go
+++ b/internal/runtime/firecracker/agent/index_test.go
@@ -1,0 +1,90 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchIndex(t *testing.T) {
+	index := imageIndex{
+		Image:          testImage,
+		ManifestRef:    "s3://" + testBucket + "/" + testPrefix + "/abc123def456/manifest.json",
+		ArtifactDigest: strings.Repeat("a", 64),
+		UpdatedAt:      "2026-08-27T00:00:00Z",
+	}
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{}}
+	payload, err := json.MarshalIndent(index, "", "  ")
+	require.NoError(t, err)
+	store.objects[indexKey(testImage)] = payload
+	client := testS3Client(t, store)
+
+	got, err := fetchIndex(context.Background(), client, testImage)
+	require.NoError(t, err)
+	require.Equal(t, index, got)
+}
+
+func TestFetchIndexNotFound(t *testing.T) {
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{}}
+	client := testS3Client(t, store)
+
+	_, err := fetchIndex(context.Background(), client, testImage)
+	require.ErrorIs(t, err, ErrObjectNotFound)
+}
+
+func TestFetchIndexIncomplete(t *testing.T) {
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{}}
+	payload, err := json.Marshal(map[string]string{"image": testImage})
+	require.NoError(t, err)
+	store.objects[indexKey(testImage)] = payload
+	client := testS3Client(t, store)
+
+	_, err = fetchIndex(context.Background(), client, testImage)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "incomplete")
+}
+
+func TestFetchIndexInvalidJSON(t *testing.T) {
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{}}
+	store.objects[indexKey(testImage)] = []byte("{not json")
+	client := testS3Client(t, store)
+
+	_, err := fetchIndex(context.Background(), client, testImage)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode image index")
+}
+
+func TestIndexKeyMatchesCacheKey(t *testing.T) {
+	// The index key derivation must match the driver cache key so the
+	// addressing chain works without control-plane coordination.
+	require.Equal(t, indexKey(testImage), "index/"+imageKey(testImage)+".json")
+	require.Len(t, imageKey(testImage), 64)
+}
+
+// s3NotFoundServer returns 404 for every path.
+func s3NotFoundServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, nil)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// clientForEndpoint builds a client without the fake store (used for
+// signing/path assertions against a raw server).
+func clientForEndpoint(t *testing.T, endpoint, prefix string) *s3Client {
+	t.Helper()
+	return &s3Client{
+		endpoint: endpoint, region: "us-east-1", bucket: testBucket, prefix: prefix,
+		accessKey: "test-access-key", secretKey: "test-secret-key",
+		http:       &http.Client{},
+		retryDelay: time.Millisecond,
+	}
+}

--- a/internal/runtime/firecracker/agent/manifest.go
+++ b/internal/runtime/firecracker/agent/manifest.go
@@ -1,0 +1,88 @@
+package agent
+
+// Published manifest (design details doc §1.3): the content-addressed file
+// list of one build, downloaded at index.manifestRef and verified against
+// index.artifactDigest before any artifact is pulled.
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+)
+
+// manifestFile describes one published artifact.
+type manifestFile struct {
+	SHA256    string `json:"sha256"`
+	SizeBytes int64  `json:"sizeBytes"`
+}
+
+// manifest is the consumer-side view of manifest.json; only the file list
+// is needed by the pull layer.
+type manifest struct {
+	Files map[string]manifestFile `json:"files"`
+}
+
+// parseManifest decodes a downloaded manifest document.
+func parseManifest(payload []byte) (manifest, error) {
+	var document manifest
+	if err := json.Unmarshal(payload, &document); err != nil {
+		return manifest{}, fmt.Errorf("decode manifest: %w", err)
+	}
+	if len(document.Files) == 0 {
+		return manifest{}, fmt.Errorf("manifest has no files")
+	}
+	return document, nil
+}
+
+// nativeFile pairs a published artifact with its local cache name and the
+// expected digest.
+type nativeFile struct {
+	publish   string
+	cache     string
+	sha256    string
+	sizeBytes int64
+}
+
+// nativeArtifactNames maps published artifact names to the local cache
+// names (implementation plan §5). rootfs.ext4 is renamed to rootfs.img so
+// the existing resolveRootfsImage consumer needs no change; the rest keep
+// their published names. OverlayBD layers are deliberately absent: they
+// arrive with the overlaybd stage.
+var nativeArtifactNames = []struct{ publish, cache string }{
+	{"rootfs.ext4", "rootfs.img"},
+	{"vmstate.snap", "vmstate.snap"},
+	{"memory.snap", "memory.snap"},
+}
+
+// nativeFiles validates that the manifest carries the complete native
+// artifact set and returns the mapping with their expected digests.
+func (m manifest) nativeFiles() ([]nativeFile, error) {
+	files := make([]nativeFile, 0, len(nativeArtifactNames))
+	for _, name := range nativeArtifactNames {
+		entry, ok := m.Files[name.publish]
+		if !ok {
+			return nil, fmt.Errorf("manifest is missing the %s artifact", name.publish)
+		}
+		if !validSHA256(entry.SHA256) {
+			return nil, fmt.Errorf("manifest artifact %s has an invalid sha256", name.publish)
+		}
+		files = append(files, nativeFile{
+			publish: name.publish, cache: name.cache,
+			sha256: entry.SHA256, sizeBytes: entry.SizeBytes,
+		})
+	}
+	return files, nil
+}
+
+// validSHA256 reports whether sum is a lowercase sha256 hex digest.
+func validSHA256(sum string) bool {
+	if len(sum) != sha256.Size*2 {
+		return false
+	}
+	for _, character := range sum {
+		if !((character >= '0' && character <= '9') || (character >= 'a' && character <= 'f')) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runtime/firecracker/agent/manifest_test.go
+++ b/internal/runtime/firecracker/agent/manifest_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseManifest(t *testing.T) {
+	payload := testManifest(map[string][]byte{
+		"rootfs.ext4":  []byte("rootfs"),
+		"vmstate.snap": []byte("vmstate"),
+		"memory.snap":  []byte("memory"),
+	})
+	document, err := parseManifest(payload)
+	require.NoError(t, err)
+	require.Len(t, document.Files, 3)
+	require.Equal(t, sha256Hex([]byte("rootfs")), document.Files["rootfs.ext4"].SHA256)
+	require.Equal(t, int64(6), document.Files["rootfs.ext4"].SizeBytes)
+}
+
+func TestParseManifestInvalidJSON(t *testing.T) {
+	_, err := parseManifest([]byte("{nope"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode manifest")
+}
+
+func TestParseManifestEmptyFiles(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{"files": map[string]any{}})
+	require.NoError(t, err)
+	_, err = parseManifest(payload)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no files")
+}
+
+func TestNativeFiles(t *testing.T) {
+	artifacts := map[string][]byte{
+		"rootfs.ext4":  []byte("rootfs"),
+		"vmstate.snap": []byte("vmstate"),
+		"memory.snap":  []byte("memory"),
+	}
+	payload := testManifest(artifacts)
+	document, err := parseManifest(payload)
+	require.NoError(t, err)
+
+	files, err := document.nativeFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 3)
+	// The mapping renames rootfs.ext4 to rootfs.img and keeps the rest;
+	// every entry carries the expected digest.
+	want := map[string]string{"rootfs.img": "rootfs.ext4", "vmstate.snap": "vmstate.snap", "memory.snap": "memory.snap"}
+	for _, file := range files {
+		publishName, ok := want[file.cache]
+		require.True(t, ok, file.cache)
+		require.Equal(t, publishName, file.publish)
+		require.Equal(t, sha256Hex(artifacts[publishName]), file.sha256)
+	}
+}
+
+func TestNativeFilesMissingArtifact(t *testing.T) {
+	payload := testManifest(map[string][]byte{
+		"rootfs.ext4": []byte("rootfs"),
+		"memory.snap": []byte("memory"),
+	})
+	document, err := parseManifest(payload)
+	require.NoError(t, err)
+	_, err = document.nativeFiles()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing the vmstate.snap artifact")
+}
+
+func TestNativeFilesInvalidDigest(t *testing.T) {
+	payload := testManifest(map[string][]byte{
+		"rootfs.ext4":  []byte("rootfs"),
+		"vmstate.snap": []byte("vmstate"),
+		"memory.snap":  []byte("memory"),
+	})
+	var document map[string]any
+	require.NoError(t, json.Unmarshal(payload, &document))
+	files := document["files"].(map[string]any)
+	files["rootfs.ext4"].(map[string]any)["sha256"] = strings.Repeat("Z", 64)
+	tampered, err := json.Marshal(document)
+	require.NoError(t, err)
+
+	parsed, err := parseManifest(tampered)
+	require.NoError(t, err)
+	_, err = parsed.nativeFiles()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid sha256")
+}
+
+func TestValidSHA256(t *testing.T) {
+	require.True(t, validSHA256(strings.Repeat("a", 64)))
+	require.False(t, validSHA256(strings.Repeat("a", 63)))
+	require.False(t, validSHA256(strings.Repeat("A", 64)))
+	require.False(t, validSHA256(strings.Repeat("g", 64)))
+	require.False(t, validSHA256(""))
+}

--- a/internal/runtime/firecracker/agent/pull.go
+++ b/internal/runtime/firecracker/agent/pull.go
@@ -82,6 +82,12 @@ func WithHTTPClient(client *http.Client) Option {
 // The call is safe to race with a concurrent PullImage of the same image:
 // every write lands in a temporary file and renames into place only after
 // full verification, so no half-published state is ever observable.
+//
+// Idempotency semantics: a committed cache is returned without any network
+// request and is never refreshed for the same image reference. A publisher
+// rebuild of the same reference (last-writer-wins index) is therefore only
+// picked up after clearing the cache directory or switching to a new tag —
+// the intended trade-off for warm-image preheating.
 func (c *Client) PullImage(ctx context.Context, stateRoot, image string) error {
 	if strings.TrimSpace(image) == "" {
 		return fmt.Errorf("%w: image reference is required", runtimecontract.ErrInvalidConfig)

--- a/internal/runtime/firecracker/agent/pull.go
+++ b/internal/runtime/firecracker/agent/pull.go
@@ -143,6 +143,11 @@ func (c *Client) PullImage(ctx context.Context, stateRoot, image string) error {
 	return commitManifest(dir, payload)
 }
 
+// maxManifestBytes caps the downloaded manifest document. Manifests are
+// small metadata (file list + compatibility tuple); a larger document is
+// never legitimate, so it is rejected instead of being read unbounded.
+const maxManifestBytes = 1 << 20
+
 // fetchManifest downloads the manifest and verifies its content against the
 // index artifactDigest, binding the whole artifact set to the index.
 func (c *Client) fetchManifest(ctx context.Context, manifestKey, artifactDigest string) ([]byte, error) {
@@ -154,9 +159,12 @@ func (c *Client) fetchManifest(ctx context.Context, manifestKey, artifactDigest 
 		return nil, fmt.Errorf("fetch published manifest: %w", err)
 	}
 	defer body.Close()
-	payload, err := io.ReadAll(body)
+	payload, err := io.ReadAll(io.LimitReader(body, maxManifestBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read published manifest: %w", err)
+	}
+	if len(payload) > maxManifestBytes {
+		return nil, fmt.Errorf("published manifest exceeds the %d-byte limit", maxManifestBytes)
 	}
 	if sum := sha256Hex(payload); sum != artifactDigest {
 		return nil, fmt.Errorf("published manifest digest mismatch: got %s, want %s", sum, artifactDigest)

--- a/internal/runtime/firecracker/agent/pull.go
+++ b/internal/runtime/firecracker/agent/pull.go
@@ -1,0 +1,159 @@
+package agent
+
+// PullImage chain (implementation plan §3): SandboxSpec.Image -> index ->
+// manifest -> digest-verified download into
+// <StateRoot>/images/<sha256(image)>/.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+
+	"fast-sandbox/internal/registryconfig"
+	runtimecontract "fast-sandbox/internal/runtime/contract"
+)
+
+// Client pulls published Firecracker artifacts for an image reference into
+// the node-local cache. Stage 1 carries only the pure pull layer: the UDS
+// server, device leasing, and driver wiring arrive with the runtime-agent
+// work.
+type Client struct {
+	s3 *s3Client
+}
+
+// NewClient builds a pull client for a store root (s3://bucket/prefix) with
+// a read-only access key pair. The credential Host names the store endpoint
+// and Username/Password carry the access key pair.
+func NewClient(storeRoot string, credential registryconfig.Credential, options ...Option) (*Client, error) {
+	config := optionsConfig{}
+	for _, option := range options {
+		option(&config)
+	}
+	s3, err := newS3Client(storeRoot, credential, config.httpClient, config.region, config.endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{s3: s3}, nil
+}
+
+// Option configures the pull client.
+type Option func(*optionsConfig)
+
+type optionsConfig struct {
+	region     string
+	endpoint   string
+	httpClient *http.Client
+}
+
+// WithRegion overrides the SigV4 signing region (default us-east-1).
+func WithRegion(region string) Option {
+	return func(config *optionsConfig) { config.region = region }
+}
+
+// WithEndpoint overrides the store endpoint; by default the credential Host
+// is used.
+func WithEndpoint(endpoint string) Option {
+	return func(config *optionsConfig) { config.endpoint = endpoint }
+}
+
+// WithHTTPClient replaces the default HTTP client (5-minute request
+// timeout), e.g. to tune timeouts or the transport.
+func WithHTTPClient(client *http.Client) Option {
+	return func(config *optionsConfig) { config.httpClient = client }
+}
+
+// PullImage resolves the addressing chain for image and materializes the
+// native artifact set in the local cache:
+//
+//  1. validate the image reference;
+//  2. idempotency: a committed cache returns without any network request;
+//  3. GET the image reference index (404 -> ErrImageNotReady);
+//  4. GET the manifest it points at, verified against index.artifactDigest;
+//  5. download each native artifact into the per-build digest namespace,
+//     skipping files that already verify (resume) and re-pulling corrupt
+//     ones;
+//  6. write the local manifest as the commit point.
+//
+// The call is safe to race with a concurrent PullImage of the same image:
+// every write lands in a temporary file and renames into place only after
+// full verification, so no half-published state is ever observable.
+func (c *Client) PullImage(ctx context.Context, stateRoot, image string) error {
+	if strings.TrimSpace(image) == "" {
+		return fmt.Errorf("%w: image reference is required", runtimecontract.ErrInvalidConfig)
+	}
+	dir := imageDir(stateRoot, image)
+	if complete, err := cacheComplete(dir); err != nil {
+		return err
+	} else if complete {
+		return nil
+	}
+	if err := os.MkdirAll(dir, cacheDirMode); err != nil {
+		return fmt.Errorf("prepare image cache: %w", err)
+	}
+
+	index, err := fetchIndex(ctx, c.s3, image)
+	if err != nil {
+		if errors.Is(err, ErrObjectNotFound) {
+			return fmt.Errorf("%w: %q", runtimecontract.ErrImageNotReady, image)
+		}
+		return err
+	}
+	// The index image field must match the requested reference byte for
+	// byte: no normalization, no default tags (details doc §1.2).
+	if index.Image != image {
+		return fmt.Errorf("image index for %q belongs to %q: reference mismatch", image, index.Image)
+	}
+
+	manifestKey, err := c.s3.resolveRef(index.ManifestRef)
+	if err != nil {
+		return err
+	}
+	payload, err := c.fetchManifest(ctx, manifestKey, index.ArtifactDigest)
+	if err != nil {
+		return err
+	}
+	document, err := parseManifest(payload)
+	if err != nil {
+		return err
+	}
+	files, err := document.nativeFiles()
+	if err != nil {
+		return err
+	}
+
+	// Artifacts live in the same per-build digest namespace as the
+	// manifest, so their store keys derive from the manifest reference.
+	buildDir := path.Dir(manifestKey)
+	for _, file := range files {
+		if err := stageFile(ctx, c.s3, dir, path.Join(buildDir, file.publish), file); err != nil {
+			return err
+		}
+	}
+	return commitManifest(dir, payload)
+}
+
+// fetchManifest downloads the manifest and verifies its content against the
+// index artifactDigest, binding the whole artifact set to the index.
+func (c *Client) fetchManifest(ctx context.Context, manifestKey, artifactDigest string) ([]byte, error) {
+	body, err := c.s3.get(ctx, manifestKey)
+	if err != nil {
+		if errors.Is(err, ErrObjectNotFound) {
+			return nil, fmt.Errorf("published manifest %s not found: %w (index points at an incomplete build)", manifestKey, err)
+		}
+		return nil, fmt.Errorf("fetch published manifest: %w", err)
+	}
+	defer body.Close()
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("read published manifest: %w", err)
+	}
+	if sum := sha256Hex(payload); sum != artifactDigest {
+		return nil, fmt.Errorf("published manifest digest mismatch: got %s, want %s", sum, artifactDigest)
+	}
+	return payload, nil
+}

--- a/internal/runtime/firecracker/agent/pull_test.go
+++ b/internal/runtime/firecracker/agent/pull_test.go
@@ -224,10 +224,14 @@ func TestPullImageRepairsCorruptCache(t *testing.T) {
 	store, client, manifestPayload, artifacts := publishFixture(t)
 	root := t.TempDir()
 
-	// rootfs.img exists with the wrong content; the manifest was committed.
+	// rootfs.img exists with the same size but different content (silent
+	// corruption passes the stat fast path and must be caught by the
+	// digest); the manifest was committed.
 	dir := imageDir(root, testImage)
 	require.NoError(t, os.MkdirAll(dir, cacheDirMode))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "rootfs.img"), []byte("corrupt"), cacheFileMode))
+	corrupt := bytes.Repeat([]byte{0x00}, len(artifacts["rootfs.ext4"]))
+	require.NotEqual(t, artifacts["rootfs.ext4"], corrupt)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "rootfs.img"), corrupt, cacheFileMode))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, manifestName), manifestPayload, cacheFileMode))
 
 	require.NoError(t, (&Client{s3: client}).PullImage(context.Background(), root, testImage))

--- a/internal/runtime/firecracker/agent/pull_test.go
+++ b/internal/runtime/firecracker/agent/pull_test.go
@@ -370,6 +370,34 @@ func TestPullImageManifestMissingFile(t *testing.T) {
 	require.Contains(t, err.Error(), "missing the vmstate.snap artifact")
 }
 
+func TestPullImageRejectsOversizedManifest(t *testing.T) {
+	// A manifest larger than the read limit must be rejected instead of
+	// being read into memory unbounded.
+	document := map[string]any{}
+	require.NoError(t, json.Unmarshal(testManifest(map[string][]byte{"rootfs.ext4": []byte("rootfs")}), &document))
+	document["padding"] = strings.Repeat("x", maxManifestBytes+1024)
+	manifestPayload, err := json.Marshal(document)
+	require.NoError(t, err)
+	buildDir := sha256Hex(manifestPayload)[:16]
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{}, flaky: map[string]int{}}
+	store.objects[buildDir+"/manifest.json"] = manifestPayload
+	store.objects[buildDir+"/rootfs.ext4"] = []byte("rootfs")
+	index := imageIndex{
+		Image:          testImage,
+		ManifestRef:    "s3://" + testBucket + "/" + testPrefix + "/" + buildDir + "/manifest.json",
+		ArtifactDigest: sha256Hex(manifestPayload),
+		UpdatedAt:      "2026-08-27T00:00:00Z",
+	}
+	indexPayload, err := json.Marshal(index)
+	require.NoError(t, err)
+	store.objects["index/"+imageKey(testImage)+".json"] = indexPayload
+	client := testS3Client(t, store)
+
+	err = (&Client{s3: client}).PullImage(context.Background(), t.TempDir(), testImage)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds the")
+}
+
 func TestPullImageConcurrent(t *testing.T) {
 	_, client, _, _ := publishFixture(t)
 	root := t.TempDir()

--- a/internal/runtime/firecracker/agent/pull_test.go
+++ b/internal/runtime/firecracker/agent/pull_test.go
@@ -1,0 +1,393 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	runtimecontract "fast-sandbox/internal/runtime/contract"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testBucket = "sandbox-images"
+	testPrefix = "publish"
+	testImage  = "registry.example.com/sandbox:v1.0.21"
+)
+
+// fakeStore is an in-memory S3-compatible store serving path-style GETs at
+// /<bucket>/<prefix>/<key>. It records requests and injects transient 500s
+// by store-relative key, matching the s3Client's view of the store.
+type fakeStore struct {
+	mu       sync.Mutex
+	bucket   string
+	prefix   string
+	objects  map[string][]byte
+	requests []string
+	flaky    map[string]int // remaining 500 responses per key
+}
+
+func (s *fakeStore) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/"), "/", 2)
+	if len(parts) != 2 || parts[0] != s.bucket {
+		http.NotFound(w, r)
+		return
+	}
+	key := parts[1]
+	if s.prefix != "" {
+		if !strings.HasPrefix(key, s.prefix+"/") {
+			http.NotFound(w, r)
+			return
+		}
+		key = strings.TrimPrefix(key, s.prefix+"/")
+	}
+	s.mu.Lock()
+	s.requests = append(s.requests, key)
+	if s.flaky[key] > 0 {
+		s.flaky[key]--
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	content, ok := s.objects[key]
+	s.mu.Unlock()
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	_, _ = w.Write(content)
+}
+
+// requested returns a snapshot of the served keys.
+func (s *fakeStore) requested() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.requests...)
+}
+
+// countRequested returns how many requests matched key.
+func (s *fakeStore) countRequested(key string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	count := 0
+	for _, request := range s.requests {
+		if request == key {
+			count++
+		}
+	}
+	return count
+}
+
+// testS3Client builds a client wired to the fake store with a short retry
+// backoff and request timeout.
+func testS3Client(t *testing.T, store *fakeStore) *s3Client {
+	t.Helper()
+	server := httptest.NewServer(store)
+	t.Cleanup(server.Close)
+	return &s3Client{
+		endpoint: server.URL, region: "us-east-1", bucket: store.bucket, prefix: testPrefix,
+		accessKey: "test-access-key", secretKey: "test-secret-key",
+		http:       &http.Client{Timeout: time.Second},
+		retryDelay: time.Millisecond,
+	}
+}
+
+// testManifest assembles a manifest document in the publisher's shape for a
+// set of artifacts, returning the exact bytes a download would carry.
+func testManifest(artifacts map[string][]byte) []byte {
+	files := map[string]any{}
+	for name, content := range artifacts {
+		files[name] = map[string]any{
+			"sha256":    sha256Hex(content),
+			"sizeBytes": len(content),
+		}
+	}
+	document := map[string]any{
+		"schemaVersion": 1,
+		"runtime":       "firecracker",
+		"sourceImage":   testImage,
+		"files":         files,
+	}
+	payload, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}
+
+// publishFixture publishes a complete artifact set for testImage into a fake
+// store exactly like the builder does (details doc §1): artifacts first,
+// then the manifest, then the index. It returns the store, the s3 client,
+// the manifest bytes, and the artifact contents.
+func publishFixture(t *testing.T) (*fakeStore, *s3Client, []byte, map[string][]byte) {
+	t.Helper()
+	artifacts := map[string][]byte{
+		"rootfs.ext4":  bytes.Repeat([]byte{0xab}, 1<<16),
+		"vmstate.snap": []byte("vmstate-bytes"),
+		"memory.snap":  []byte("memory-bytes"),
+	}
+	manifestPayload := testManifest(artifacts)
+	buildDir := sha256Hex(manifestPayload)[:16]
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{}, flaky: map[string]int{}}
+	for name, content := range artifacts {
+		store.objects[buildDir+"/"+name] = content
+	}
+	store.objects[buildDir+"/manifest.json"] = manifestPayload
+	index := imageIndex{
+		Image:          testImage,
+		ManifestRef:    "s3://" + testBucket + "/" + testPrefix + "/" + buildDir + "/manifest.json",
+		ArtifactDigest: sha256Hex(manifestPayload),
+		UpdatedAt:      "2026-08-27T00:00:00Z",
+	}
+	indexPayload, err := json.Marshal(index)
+	require.NoError(t, err)
+	store.objects["index/"+imageKey(testImage)+".json"] = indexPayload
+	return store, testS3Client(t, store), manifestPayload, artifacts
+}
+
+func TestPullImageFullFlow(t *testing.T) {
+	store, client, manifestPayload, artifacts := publishFixture(t)
+	root := t.TempDir()
+
+	require.NoError(t, (&Client{s3: client}).PullImage(context.Background(), root, testImage))
+
+	// Cache layout matches the implementation plan: rootfs.ext4 renamed to
+	// rootfs.img, the rest keeping their names, plus the commit manifest.
+	dir := imageDir(root, testImage)
+	names := map[string]string{"rootfs.img": "rootfs.ext4", "vmstate.snap": "vmstate.snap", "memory.snap": "memory.snap"}
+	for cacheName, publishName := range names {
+		content, err := os.ReadFile(filepath.Join(dir, cacheName))
+		require.NoError(t, err, cacheName)
+		require.Equal(t, artifacts[publishName], content, cacheName)
+	}
+	committed, err := os.ReadFile(filepath.Join(dir, manifestName))
+	require.NoError(t, err)
+	require.Equal(t, manifestPayload, committed)
+
+	// The addressing chain hit index, manifest, and every artifact exactly
+	// once, all under the per-build digest namespace.
+	expected := []string{
+		"index/" + imageKey(testImage) + ".json",
+		sha256Hex(manifestPayload)[:16] + "/manifest.json",
+		sha256Hex(manifestPayload)[:16] + "/rootfs.ext4",
+		sha256Hex(manifestPayload)[:16] + "/vmstate.snap",
+		sha256Hex(manifestPayload)[:16] + "/memory.snap",
+	}
+	require.ElementsMatch(t, expected, store.requested())
+}
+
+func TestPullImageIdempotent(t *testing.T) {
+	store, client, _, _ := publishFixture(t)
+	root := t.TempDir()
+	pull := &Client{s3: client}
+
+	require.NoError(t, pull.PullImage(context.Background(), root, testImage))
+	require.NoError(t, pull.PullImage(context.Background(), root, testImage))
+
+	// A committed cache returns without a single request.
+	require.Len(t, store.requested(), 5, "second pull must not touch the store")
+}
+
+func TestPullImageResumeSkipsMatchingFiles(t *testing.T) {
+	store, client, manifestPayload, artifacts := publishFixture(t)
+	root := t.TempDir()
+
+	// A previous attempt already committed rootfs.img (content matches the
+	// published manifest) but crashed before the rest.
+	dir := imageDir(root, testImage)
+	require.NoError(t, os.MkdirAll(dir, cacheDirMode))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "rootfs.img"), artifacts["rootfs.ext4"], cacheFileMode))
+
+	require.NoError(t, (&Client{s3: client}).PullImage(context.Background(), root, testImage))
+
+	requested := store.requested()
+	require.NotContains(t, requested, sha256Hex(manifestPayload)[:16]+"/rootfs.ext4", "matching file must be skipped")
+	require.Contains(t, requested, sha256Hex(manifestPayload)[:16]+"/vmstate.snap")
+	require.Contains(t, requested, sha256Hex(manifestPayload)[:16]+"/memory.snap")
+	for _, name := range []string{"rootfs.img", "vmstate.snap", "memory.snap"} {
+		content, err := os.ReadFile(filepath.Join(dir, name))
+		require.NoError(t, err)
+		require.NotEmpty(t, content, name)
+	}
+}
+
+func TestPullImageRepairsCorruptCache(t *testing.T) {
+	store, client, manifestPayload, artifacts := publishFixture(t)
+	root := t.TempDir()
+
+	// rootfs.img exists with the wrong content; the manifest was committed.
+	dir := imageDir(root, testImage)
+	require.NoError(t, os.MkdirAll(dir, cacheDirMode))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "rootfs.img"), []byte("corrupt"), cacheFileMode))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, manifestName), manifestPayload, cacheFileMode))
+
+	require.NoError(t, (&Client{s3: client}).PullImage(context.Background(), root, testImage))
+
+	content, err := os.ReadFile(filepath.Join(dir, "rootfs.img"))
+	require.NoError(t, err)
+	require.Equal(t, artifacts["rootfs.ext4"], content, "corrupt file must be re-pulled")
+	require.Equal(t, 1, store.countRequested(sha256Hex(manifestPayload)[:16]+"/rootfs.ext4"))
+}
+
+func TestPullImageEmptyImageRejected(t *testing.T) {
+	_, client, _, _ := publishFixture(t)
+	root := t.TempDir()
+	err := (&Client{s3: client}).PullImage(context.Background(), root, "  ")
+	require.ErrorIs(t, err, runtimecontract.ErrInvalidConfig)
+}
+
+func TestPullImageIndexNotFound(t *testing.T) {
+	store, client, _, _ := publishFixture(t)
+	store.mu.Lock()
+	store.objects = map[string][]byte{}
+	store.mu.Unlock()
+	root := t.TempDir()
+
+	err := (&Client{s3: client}).PullImage(context.Background(), root, testImage)
+	require.ErrorIs(t, err, runtimecontract.ErrImageNotReady)
+	require.Equal(t, 1, store.countRequested("index/"+imageKey(testImage)+".json"), "404 must not be retried")
+}
+
+func TestPullImageIndexImageMismatch(t *testing.T) {
+	store, client, _, _ := publishFixture(t)
+	store.mu.Lock()
+	var index imageIndex
+	require.NoError(t, json.Unmarshal(store.objects["index/"+imageKey(testImage)+".json"], &index))
+	index.Image = "registry.example.com/other:v2"
+	payload, err := json.Marshal(index)
+	require.NoError(t, err)
+	store.objects["index/"+imageKey(testImage)+".json"] = payload
+	store.mu.Unlock()
+
+	err = (&Client{s3: client}).PullImage(context.Background(), t.TempDir(), testImage)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reference mismatch")
+}
+
+func TestPullImageManifestNotFound(t *testing.T) {
+	store, client, manifestPayload, _ := publishFixture(t)
+	store.mu.Lock()
+	delete(store.objects, sha256Hex(manifestPayload)[:16]+"/manifest.json")
+	store.mu.Unlock()
+
+	err := (&Client{s3: client}).PullImage(context.Background(), t.TempDir(), testImage)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "incomplete build")
+}
+
+func TestPullImageManifestDigestMismatch(t *testing.T) {
+	store, client, manifestPayload, _ := publishFixture(t)
+	store.mu.Lock()
+	var index imageIndex
+	require.NoError(t, json.Unmarshal(store.objects["index/"+imageKey(testImage)+".json"], &index))
+	index.ArtifactDigest = strings.Repeat("0", 64)
+	payload, err := json.Marshal(index)
+	require.NoError(t, err)
+	store.objects["index/"+imageKey(testImage)+".json"] = payload
+	store.mu.Unlock()
+
+	err = (&Client{s3: client}).PullImage(context.Background(), t.TempDir(), testImage)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "digest mismatch")
+	require.Contains(t, err.Error(), sha256Hex(manifestPayload))
+}
+
+func TestPullImageArtifactDigestMismatchCleansUp(t *testing.T) {
+	store, client, manifestPayload, _ := publishFixture(t)
+	store.mu.Lock()
+	document := map[string]any{}
+	require.NoError(t, json.Unmarshal(store.objects[sha256Hex(manifestPayload)[:16]+"/manifest.json"], &document))
+	files := document["files"].(map[string]any)
+	rootfs := files["rootfs.ext4"].(map[string]any)
+	rootfs["sha256"] = strings.Repeat("1", 64)
+	payload, err := json.Marshal(document)
+	require.NoError(t, err)
+	store.objects[sha256Hex(manifestPayload)[:16]+"/manifest.json"] = payload
+	// A tampered manifest is still bound by the index digest.
+	var index imageIndex
+	require.NoError(t, json.Unmarshal(store.objects["index/"+imageKey(testImage)+".json"], &index))
+	index.ArtifactDigest = sha256Hex(payload)
+	indexPayload, err := json.Marshal(index)
+	require.NoError(t, err)
+	store.objects["index/"+imageKey(testImage)+".json"] = indexPayload
+	store.mu.Unlock()
+
+	root := t.TempDir()
+	err = (&Client{s3: client}).PullImage(context.Background(), root, testImage)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "digest mismatch")
+	require.ErrorContains(t, err, "rootfs.ext4")
+
+	// The failed download leaves no temporary or partial file behind.
+	entries, err := os.ReadDir(imageDir(root, testImage))
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+func TestPullImageRetriesTransientFailures(t *testing.T) {
+	store, client, manifestPayload, _ := publishFixture(t)
+	store.mu.Lock()
+	store.flaky[sha256Hex(manifestPayload)[:16]+"/rootfs.ext4"] = 2
+	store.mu.Unlock()
+
+	require.NoError(t, (&Client{s3: client}).PullImage(context.Background(), t.TempDir(), testImage))
+	require.Equal(t, 3, store.countRequested(sha256Hex(manifestPayload)[:16]+"/rootfs.ext4"), "two 5xx then success")
+}
+
+func TestPullImageManifestMissingFile(t *testing.T) {
+	store, client, manifestPayload, _ := publishFixture(t)
+	store.mu.Lock()
+	document := map[string]any{}
+	require.NoError(t, json.Unmarshal(store.objects[sha256Hex(manifestPayload)[:16]+"/manifest.json"], &document))
+	files := document["files"].(map[string]any)
+	delete(files, "vmstate.snap")
+	payload, err := json.Marshal(document)
+	require.NoError(t, err)
+	store.objects[sha256Hex(manifestPayload)[:16]+"/manifest.json"] = payload
+	var index imageIndex
+	require.NoError(t, json.Unmarshal(store.objects["index/"+imageKey(testImage)+".json"], &index))
+	index.ArtifactDigest = sha256Hex(payload)
+	indexPayload, err := json.Marshal(index)
+	require.NoError(t, err)
+	store.objects["index/"+imageKey(testImage)+".json"] = indexPayload
+	store.mu.Unlock()
+
+	err = (&Client{s3: client}).PullImage(context.Background(), t.TempDir(), testImage)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing the vmstate.snap artifact")
+}
+
+func TestPullImageConcurrent(t *testing.T) {
+	_, client, _, _ := publishFixture(t)
+	root := t.TempDir()
+	pull := &Client{s3: client}
+
+	done := make(chan error, 8)
+	for range 8 {
+		go func() { done <- pull.PullImage(context.Background(), root, testImage) }()
+	}
+	for range 8 {
+		require.NoError(t, <-done)
+	}
+
+	// Every artifact downloaded exactly once: matching files are skipped
+	// after the first commit (or coalesced by the per-file hash check).
+	dir := imageDir(root, testImage)
+	for _, name := range []string{"rootfs.img", "vmstate.snap", "memory.snap", manifestName} {
+		_, err := os.Stat(filepath.Join(dir, name))
+		require.NoError(t, err, name)
+	}
+	// No temporary files survive concurrent pulls.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 4)
+}

--- a/internal/runtime/firecracker/agent/s3client.go
+++ b/internal/runtime/firecracker/agent/s3client.go
@@ -1,0 +1,282 @@
+package agent
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"fast-sandbox/internal/registryconfig"
+)
+
+// ErrObjectNotFound reports that the requested object does not exist in the
+// store (S3 404 / NoSuchKey).
+var ErrObjectNotFound = errors.New("object not found")
+
+// httpError carries an unexpected S3 response status with a bounded body.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	body := e.Body
+	if len(body) > 200 {
+		body = body[:200] + "..."
+	}
+	return fmt.Sprintf("S3 GET failed with status %d: %s", e.StatusCode, body)
+}
+
+const (
+	// defaultS3Region is the SigV4 signing region when none is configured.
+	// S3-compatible stores with endpoint overrides accept it regardless of
+	// their real region.
+	defaultS3Region = "us-east-1"
+	// defaultS3RequestTimeout bounds a single GET. Rootfs images are
+	// multi-GiB, so the default is generous.
+	defaultS3RequestTimeout = 5 * time.Minute
+	// s3RetryAttempts is how many times a transient GET failure is retried
+	// with exponential backoff (2s, 4s, 8s).
+	s3RetryAttempts = 3
+)
+
+// s3Client implements path-style, SigV4-signed GETs against an
+// S3-compatible store (AWS S3, Aliyun OSS, MinIO) with a read-only access
+// key pair. Only the GET verb needed by the pull layer is implemented;
+// range GETs arrive with the overlaybd stage.
+type s3Client struct {
+	endpoint  string // scheme://host[:port], e.g. https://oss-cn-hangzhou.aliyuncs.com
+	region    string
+	bucket    string
+	prefix    string // store key prefix under the bucket, "" when the root is the bucket
+	accessKey string
+	secretKey string
+	http      *http.Client
+	// retryDelay is the base of the exponential backoff for transient
+	// failures; it is a field (not a constant) so tests can shorten it.
+	retryDelay time.Duration
+}
+
+// newS3Client parses the store root (s3://bucket/prefix) and the read-only
+// credential into a GET client. The credential Host names the store
+// endpoint; Username/Password carry the access key pair.
+func newS3Client(storeRoot string, credential registryconfig.Credential, httpClient *http.Client, region, endpointOverride string) (*s3Client, error) {
+	bucket, prefix, err := parseStoreRoot(storeRoot)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := endpointOverride
+	if endpoint == "" {
+		endpoint = credential.Host
+	}
+	if strings.TrimSpace(endpoint) == "" {
+		return nil, errors.New("S3 endpoint is required (credential host or WithEndpoint)")
+	}
+	if !strings.Contains(endpoint, "://") {
+		endpoint = "https://" + endpoint
+	}
+	base, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid S3 endpoint %q: %w", endpoint, err)
+	}
+	if base.Host == "" {
+		return nil, fmt.Errorf("invalid S3 endpoint %q: missing host", endpoint)
+	}
+	if region == "" {
+		region = defaultS3Region
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultS3RequestTimeout}
+	}
+	return &s3Client{
+		endpoint: endpoint, region: region, bucket: bucket, prefix: strings.Trim(prefix, "/"),
+		accessKey: credential.Username, secretKey: credential.Password,
+		http: httpClient, retryDelay: 2 * time.Second,
+	}, nil
+}
+
+// parseStoreRoot splits "s3://bucket/prefix" into its bucket and key prefix.
+func parseStoreRoot(storeRoot string) (bucket, prefix string, err error) {
+	parsed, err := url.Parse(storeRoot)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid store root %q: %w", storeRoot, err)
+	}
+	if parsed.Scheme != "s3" {
+		return "", "", fmt.Errorf("invalid store root %q: scheme must be s3://", storeRoot)
+	}
+	if parsed.Host == "" {
+		return "", "", fmt.Errorf("invalid store root %q: bucket is required", storeRoot)
+	}
+	return parsed.Host, strings.Trim(parsed.Path, "/"), nil
+}
+
+// resolveRef converts a content-addressed object reference
+// (s3://bucket/prefix/...) from an index document into a store-relative key,
+// rejecting references outside the configured store root.
+func (c *s3Client) resolveRef(ref string) (string, error) {
+	parsed, err := url.Parse(ref)
+	if err != nil || parsed.Scheme != "s3" || parsed.Host == "" || parsed.Path == "" {
+		return "", fmt.Errorf("invalid object reference %q", ref)
+	}
+	if parsed.Host != c.bucket {
+		return "", fmt.Errorf("object reference %q points at bucket %q, expected %q", ref, parsed.Host, c.bucket)
+	}
+	key := strings.Trim(parsed.Path, "/")
+	if c.prefix != "" {
+		if key == c.prefix {
+			return "", fmt.Errorf("object reference %q has no object key", ref)
+		}
+		if !strings.HasPrefix(key, c.prefix+"/") {
+			return "", fmt.Errorf("object reference %q points outside store prefix %q", ref, c.prefix)
+		}
+		key = strings.TrimPrefix(key, c.prefix+"/")
+	}
+	if key == "" {
+		return "", fmt.Errorf("invalid object reference %q", ref)
+	}
+	return key, nil
+}
+
+// get streams the object at a store-relative key. The caller owns the
+// returned body and must close it. Transport errors and 5xx responses are
+// retried with exponential backoff; 4xx responses (including 404) are not.
+func (c *s3Client) get(ctx context.Context, storeKey string) (io.ReadCloser, error) {
+	key := storeKey
+	if c.prefix != "" {
+		key = c.prefix + "/" + storeKey
+	}
+	urlString, err := c.objectURL(key)
+	if err != nil {
+		return nil, err
+	}
+	backoff := c.retryDelay
+	var lastErr error
+	for attempt := 0; attempt <= s3RetryAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			backoff *= 2
+		}
+		body, err := c.getOnce(ctx, urlString, key)
+		if err == nil {
+			return body, nil
+		}
+		if errors.Is(err, ErrObjectNotFound) {
+			return nil, err
+		}
+		var status *httpError
+		if errors.As(err, &status) && status.StatusCode < http.StatusInternalServerError {
+			return nil, err
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("GET %s: %w", key, lastErr)
+}
+
+// getOnce performs a single signed GET and returns the response body on 200.
+func (c *s3Client) getOnce(ctx context.Context, urlString, key string) (io.ReadCloser, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, urlString, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.sign(request)
+	response, err := c.http.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 4096))
+		_ = response.Body.Close()
+		if response.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("%w: %s", ErrObjectNotFound, key)
+		}
+		return nil, &httpError{StatusCode: response.StatusCode, Body: string(body)}
+	}
+	return response.Body, nil
+}
+
+// objectURL returns the path-style URL of a store object.
+func (c *s3Client) objectURL(key string) (string, error) {
+	base, err := url.Parse(c.endpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid store endpoint %q: %w", c.endpoint, err)
+	}
+	base.Path = "/" + c.bucket + "/" + key
+	return base.String(), nil
+}
+
+// emptyPayloadHash is the SHA-256 of an empty payload, the fixed
+// X-Amz-Content-Sha256 of a bodyless GET.
+var emptyPayloadHash = sha256Hex(nil)
+
+// sign applies AWS Signature Version 4 to the request (service s3,
+// path-style). The payload hash is the empty-string digest: GETs carry no
+// body.
+func (c *s3Client) sign(request *http.Request) {
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	date := now.Format("20060102")
+
+	request.Header.Set("x-amz-date", amzDate)
+	request.Header.Set("x-amz-content-sha256", emptyPayloadHash)
+
+	canonicalURI := request.URL.EscapedPath()
+	if canonicalURI == "" {
+		canonicalURI = "/"
+	}
+	host := request.URL.Host
+	canonicalHeaders := "host:" + host + "\n" +
+		"x-amz-content-sha256:" + emptyPayloadHash + "\n" +
+		"x-amz-date:" + amzDate + "\n"
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+	canonicalRequest := strings.Join([]string{
+		http.MethodGet,
+		canonicalURI,
+		request.URL.RawQuery,
+		canonicalHeaders,
+		signedHeaders,
+		emptyPayloadHash,
+	}, "\n")
+	scope := date + "/" + c.region + "/s3/aws4_request"
+	stringToSign := "AWS4-HMAC-SHA256\n" + amzDate + "\n" + scope + "\n" + sha256Hex([]byte(canonicalRequest))
+
+	signingKey := deriveSigningKey(c.secretKey, date, c.region)
+	signature := hmacHex(signingKey, stringToSign)
+	request.Header.Set("Authorization",
+		"AWS4-HMAC-SHA256 Credential="+c.accessKey+"/"+scope+
+			", SignedHeaders="+signedHeaders+", Signature="+signature)
+}
+
+// deriveSigningKey builds the SigV4 per-request signing key.
+func deriveSigningKey(secretKey, date, region string) []byte {
+	key := hmacSHA256([]byte("AWS4"+secretKey), date)
+	key = hmacSHA256(key, region)
+	key = hmacSHA256(key, "s3")
+	return hmacSHA256(key, "aws4_request")
+}
+
+func hmacSHA256(key []byte, value string) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(value))
+	return mac.Sum(nil)
+}
+
+func hmacHex(key []byte, value string) string {
+	return hex.EncodeToString(hmacSHA256(key, value))
+}
+
+// sha256Hex returns the lowercase hex SHA-256 of a payload.
+func sha256Hex(payload []byte) string {
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:])
+}

--- a/internal/runtime/firecracker/agent/s3client_test.go
+++ b/internal/runtime/firecracker/agent/s3client_test.go
@@ -1,0 +1,191 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"fast-sandbox/internal/registryconfig"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseStoreRoot(t *testing.T) {
+	bucket, prefix, err := parseStoreRoot("s3://sandbox-images")
+	require.NoError(t, err)
+	require.Equal(t, "sandbox-images", bucket)
+	require.Empty(t, prefix)
+
+	bucket, prefix, err = parseStoreRoot("s3://sandbox-images/publish/v1")
+	require.NoError(t, err)
+	require.Equal(t, "sandbox-images", bucket)
+	require.Equal(t, "publish/v1", prefix)
+
+	_, _, err = parseStoreRoot("https://sandbox-images.s3.amazonaws.com")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "scheme must be s3://")
+
+	_, _, err = parseStoreRoot("s3:///no-bucket")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bucket is required")
+}
+
+func TestS3GetPathAndSigningHeaders(t *testing.T) {
+	var received *http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r
+		_, _ = w.Write([]byte("payload"))
+	}))
+	t.Cleanup(server.Close)
+	client := clientForEndpoint(t, server.URL, testPrefix)
+
+	body, err := client.get(context.Background(), "index/abc.json")
+	require.NoError(t, err)
+	content, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, "payload", string(content))
+	require.NoError(t, body.Close())
+
+	// Path-style request under the store prefix.
+	require.Equal(t, "/"+testBucket+"/"+testPrefix+"/index/abc.json", received.URL.Path)
+	// SigV4 headers: date, empty payload hash, and the authorization header.
+	require.NotEmpty(t, received.Header.Get("X-Amz-Date"))
+	require.Equal(t, emptyPayloadHash, received.Header.Get("X-Amz-Content-Sha256"))
+	authorization := received.Header.Get("Authorization")
+	require.True(t, strings.HasPrefix(authorization, "AWS4-HMAC-SHA256 Credential=test-access-key/"), authorization)
+	require.Contains(t, authorization, "/s3/aws4_request")
+	require.Contains(t, authorization, "SignedHeaders=host;x-amz-content-sha256;x-amz-date")
+	require.Contains(t, authorization, "Signature=")
+}
+
+func TestS3GetNotFound(t *testing.T) {
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{}}
+	client := testS3Client(t, store)
+
+	_, err := client.get(context.Background(), "index/missing.json")
+	require.ErrorIs(t, err, ErrObjectNotFound)
+	require.Equal(t, 1, store.countRequested("index/missing.json"), "404 must not be retried")
+}
+
+func TestS3GetRetriesOn5xx(t *testing.T) {
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{
+		"manifest.json": []byte("{}"),
+	}, flaky: map[string]int{"manifest.json": 2}}
+	client := testS3Client(t, store)
+
+	body, err := client.get(context.Background(), "manifest.json")
+	require.NoError(t, err)
+	require.NoError(t, body.Close())
+	require.Equal(t, 3, store.countRequested("manifest.json"), "two 5xx then success")
+}
+
+func TestS3GetExhaustsRetries(t *testing.T) {
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{
+		"manifest.json": []byte("{}"),
+	}, flaky: map[string]int{"manifest.json": 100}}
+	client := testS3Client(t, store)
+
+	_, err := client.get(context.Background(), "manifest.json")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "GET "+testPrefix+"/manifest.json")
+	require.Equal(t, s3RetryAttempts+1, store.countRequested("manifest.json"))
+}
+
+func TestS3GetClientErrorNotRetried(t *testing.T) {
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{}}
+	client := testS3Client(t, store)
+
+	// A forbidden object is a 403: it must fail fast, not retry.
+	client.http.Transport = roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusForbidden, Body: io.NopCloser(strings.NewReader("AccessDenied"))}, nil
+	})
+	_, err := client.get(context.Background(), "manifest.json")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "403")
+	require.Contains(t, err.Error(), "AccessDenied")
+}
+
+func TestS3GetContextCancellation(t *testing.T) {
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{}, flaky: map[string]int{"x": 100}}
+	client := testS3Client(t, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	_, err := client.get(ctx, "x")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestResolveRef(t *testing.T) {
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{}}
+	client := testS3Client(t, store)
+
+	key, err := client.resolveRef("s3://" + testBucket + "/" + testPrefix + "/abc123/manifest.json")
+	require.NoError(t, err)
+	require.Equal(t, "abc123/manifest.json", key)
+
+	// Prefix-less stores resolve against the bucket directly.
+	client.prefix = ""
+	key, err = client.resolveRef("s3://" + testBucket + "/abc123/manifest.json")
+	require.NoError(t, err)
+	require.Equal(t, "abc123/manifest.json", key)
+
+	// References outside the configured bucket or prefix are rejected.
+	_, err = client.resolveRef("s3://other-bucket/abc123/manifest.json")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "points at bucket")
+	client.prefix = testPrefix
+	_, err = client.resolveRef("s3://" + testBucket + "/elsewhere/abc.json")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "outside store prefix")
+	_, err = client.resolveRef("http://not-s3/abc.json")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid object reference")
+}
+
+func TestNewClient(t *testing.T) {
+	store := &fakeStore{bucket: testBucket, prefix: testPrefix, objects: map[string][]byte{}}
+	server := httptest.NewServer(store)
+	t.Cleanup(server.Close)
+
+	credential := registryconfig.Credential{
+		Host: server.URL, Username: "ak", Password: "sk",
+	}
+	client, err := NewClient("s3://"+testBucket+"/"+testPrefix, credential)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.Equal(t, server.URL, client.s3.endpoint)
+	require.Equal(t, "us-east-1", client.s3.region)
+
+	// The credential Host supplies the endpoint when no override is given.
+	client, err = NewClient("s3://"+testBucket+"/"+testPrefix, credential, WithRegion("oss-cn-hangzhou"))
+	require.NoError(t, err)
+	require.Equal(t, "oss-cn-hangzhou", client.s3.region)
+
+	// WithEndpoint overrides the credential host.
+	client, err = NewClient("s3://"+testBucket+"/"+testPrefix, registryconfig.Credential{},
+		WithEndpoint(server.URL))
+	require.NoError(t, err)
+	require.Equal(t, server.URL, client.s3.endpoint)
+
+	// A bare host gets the https scheme by default.
+	client, err = NewClient("s3://"+testBucket, registryconfig.Credential{Host: "minio.example.com:9000"})
+	require.NoError(t, err)
+	require.Equal(t, "https://minio.example.com:9000", client.s3.endpoint)
+
+	_, err = NewClient("nonsense", credential)
+	require.Error(t, err)
+	_, err = NewClient("s3://"+testBucket, registryconfig.Credential{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "endpoint is required")
+}
+
+// roundTripFunc adapts a function to http.RoundTripper for one-off clients.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}

--- a/internal/runtime/firecracker/agent_cache_integration_test.go
+++ b/internal/runtime/firecracker/agent_cache_integration_test.go
@@ -1,0 +1,100 @@
+package firecracker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"fast-sandbox/internal/registryconfig"
+	"fast-sandbox/internal/runtime/firecracker/agent"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAgentPullFeedsDriverCache wires the runtime-agent pull layer to the
+// driver's existing cache consumer: after PullImage, the cold-boot path
+// (resolveRootfsImage) resolves the pulled artifact without any driver
+// change, and the per-build digest namespace and file mapping
+// (rootfs.ext4 -> rootfs.img) match the published layout.
+func TestAgentPullFeedsDriverCache(t *testing.T) {
+	const (
+		image       = "registry.example.com/sandbox:v1.0.21"
+		bucket      = "sandbox-images"
+		storePrefix = "publish"
+	)
+	artifacts := map[string][]byte{
+		"rootfs.ext4":  []byte("rootfs-content"),
+		"vmstate.snap": []byte("vmstate-content"),
+		"memory.snap":  []byte("memory-content"),
+	}
+	files := map[string]any{}
+	for name, content := range artifacts {
+		files[name] = map[string]any{
+			"sha256":    sha256HexTest(content),
+			"sizeBytes": len(content),
+		}
+	}
+	manifestBytes, err := json.Marshal(map[string]any{"schemaVersion": 1, "runtime": "firecracker", "files": files})
+	require.NoError(t, err)
+	digest16 := sha256HexTest(manifestBytes)[:16]
+
+	objects := map[string][]byte{
+		digest16 + "/manifest.json": manifestBytes,
+	}
+	for name, content := range artifacts {
+		objects[digest16+"/"+name] = content
+	}
+	indexBytes, err := json.Marshal(map[string]string{
+		"image":          image,
+		"manifestRef":    "s3://" + bucket + "/" + storePrefix + "/" + digest16 + "/manifest.json",
+		"artifactDigest": sha256HexTest(manifestBytes),
+		"updatedAt":      "2026-08-27T00:00:00Z",
+	})
+	require.NoError(t, err)
+	objects["index/"+imageKey(image)+".json"] = indexBytes
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		content, ok := objects[strings.TrimPrefix(r.URL.Path, "/"+bucket+"/"+storePrefix+"/")]
+		if !ok {
+			http.NotFound(w, nil)
+			return
+		}
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	client, err := agent.NewClient("s3://"+bucket+"/"+storePrefix,
+		registryconfig.Credential{Host: server.URL, Username: "ak", Password: "sk"})
+	require.NoError(t, err)
+
+	stateRoot := t.TempDir()
+	require.NoError(t, client.PullImage(context.Background(), stateRoot, image))
+
+	// The driver's existing cold-boot consumer resolves the pulled rootfs
+	// image under the shared cache layout.
+	resolved, err := resolveRootfsImage(stateRoot, image)
+	require.NoError(t, err)
+	expected, err := imageCachePath(stateRoot, image)
+	require.NoError(t, err)
+	require.Equal(t, expected, resolved)
+	content, err := os.ReadFile(resolved)
+	require.NoError(t, err)
+	require.Equal(t, artifacts["rootfs.ext4"], content)
+
+	// A second pull is a no-op for the store, and the driver's idempotent
+	// PullImage also sees the image as ready.
+	require.NoError(t, client.PullImage(context.Background(), stateRoot, image))
+	driver := &Driver{config: firecrackerConfigForTest(t, stateRoot)}
+	require.NoError(t, driver.PullImage(context.Background(), image))
+}
+
+func sha256HexTest(payload []byte) string {
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:])
+}

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -170,7 +170,13 @@ func (d *Driver) imageGCLoop(interval time.Duration, stop <-chan struct{}) {
 func (d *Driver) gcImageCache() {
 	d.mu.RLock()
 	stateRoot := d.config.StateRoot
-	useCount := d.imageUseCount
+	// Snapshot the use counts under the lock: garbageCollectImages runs
+	// outside it while PullImage and boot (touchImage) keep writing the
+	// map, so the iteration must not touch the live map.
+	useCount := make(map[string]int64, len(d.imageUseCount))
+	for digest, uses := range d.imageUseCount {
+		useCount[digest] = uses
+	}
 	limitBytes := d.imageCacheLimitBytes
 	d.mu.RUnlock()
 	if limitBytes <= 0 {

--- a/internal/runtime/firecracker/images.go
+++ b/internal/runtime/firecracker/images.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	runtimecontract "fast-sandbox/internal/runtime/contract"
 )
 
 // imageCacheDir holds content-addressed rootfs images:
@@ -27,7 +29,9 @@ const rootfsImageName = "rootfs.img"
 
 // ErrImageNotReady reports that a rootfs image has not been converted and
 // cached yet; the conversion build job must run before the Sandbox can boot.
-var ErrImageNotReady = errors.New("rootfs image is not ready in the local cache")
+// The sentinel lives in the runtime contract so the firecracker runtime-agent
+// pull layer can reuse it; this alias keeps the driver's exported identity.
+var ErrImageNotReady = runtimecontract.ErrImageNotReady
 
 // imageKey derives the content-addressed cache key of an image reference.
 func imageKey(image string) string {

--- a/internal/runtime/firecracker/images_test.go
+++ b/internal/runtime/firecracker/images_test.go
@@ -161,7 +161,10 @@ func TestImageGCLoopRunsIndependently(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
 		require.NoError(t, os.WriteFile(path, []byte("rootfs"), 0o640))
 		digest := imageKey(image)
+		// The GC loop reads the map concurrently; mutate under the lock.
+		driver.mu.Lock()
 		driver.imageUseCount[digest] = 1
+		driver.mu.Unlock()
 		return digest
 	}
 	waitFor := func(image string, gone bool) {
@@ -180,15 +183,21 @@ func TestImageGCLoopRunsIndependently(t *testing.T) {
 
 	// The cache is over its limit, so the loop evicts the unreferenced
 	// low-frequency image without any Sandbox event.
+	driver.mu.Lock()
 	driver.imageCacheLimitBytes = 1
+	driver.mu.Unlock()
 	unused := seedImage("example.com/unused:v1")
 	waitFor(unused, true)
 
 	// Under its limit again, the loop leaves images alone even when
 	// unreferenced.
+	driver.mu.Lock()
 	driver.imageCacheLimitBytes = 6
+	driver.mu.Unlock()
 	hot := seedImage("example.com/hot:v1")
+	driver.mu.Lock()
 	driver.imageUseCount[hot] = 100
+	driver.mu.Unlock()
 	time.Sleep(3 * driver.imageGCInterval)
 	_, err = os.Stat(filepath.Join(root, imageCacheDir, hot))
 	require.NoError(t, err, "image under the cache limit must survive the loop")


### PR DESCRIPTION
Implements the consumer-side addressing chain from `docs/design/firecracker-pullimage-implementation-plan.md` (stage-1 task sheet of the on-demand loading design, #21): `SandboxSpec.Image → index → manifest → digest-verified pull → cache`.

## New package `internal/runtime/firecracker/agent/`

| File | Responsibility |
|------|----------------|
| `pull.go` | `Client` / `NewClient(storeRoot, credential, options...)` / `PullImage(ctx, stateRoot, image)` idempotent orchestration |
| `s3client.go` | Hand-rolled lightweight **SigV4 GET** client (option A, zero new deps): path-style, exponential backoff on 5xx/transport errors (2s/4s/8s), no retry on 404, 5min default request timeout |
| `index.go` | Image reference index resolution: 404 → `ErrImageNotReady`; byte-identical `image` match against the request; rejects incomplete documents |
| `manifest.go` | Manifest `files` parsing: `rootfs.ext4 → rootfs.img` mapping, native-set completeness check, digest format validation |
| `cache.go` | Cache staging: tmp file → streaming sha256 → verify → atomic rename; corrupt files deleted and re-pulled; manifest written last as the commit point; idempotency check (complete cache makes zero requests) |

## Known semantic gap: idempotency vs version refresh (deliberate)

A committed cache is returned with **zero requests and is never refreshed for the same image reference**, even when the publisher rebuilds it (last-writer-wins index, #22). Picking up a new build requires clearing the cache directory or using a new tag. This is the intended trade-off for warm-image preheating and is documented in `PullImage` and `cacheComplete` — do not "fix" it silently.

## Performance: stat-first size fast path

`cacheComplete` and the resume check compare the manifest `sizeBytes` via `stat` **before** hashing: the idempotency check no longer re-reads a multi-GiB rootfs on every warm preheat. The full sha256 runs only when the size matches (same-size corruption is still caught — covered by a test). `stageFile` also verifies the downloaded byte count.

## Implementation notes (plan §10 deliverables)

- **S3 client choice**: option A (hand-written SigV4, ~150 lines, no new deps). Credentials reuse `registryconfig.Credential` (Host = endpoint, Username/Password = read-only AK/SK); `WithRegion` / `WithEndpoint` / `WithHTTPClient` injection options; store root parsed as `s3://bucket/prefix`; range GET reserved for the overlaybd stage.
- **`ErrImageNotReady` reuse**: sentinel moved to `internal/runtime/contract`, re-exported as an alias from the driver package (identity preserved for `errors.Is`); the agent package does not depend on the heavy driver package.
- **`images.go` alignment**: cache key and file-name mapping match exactly (`<StateRoot>/images/<sha256(image)>/rootfs.img` + vmstate/memory/manifest.json), so `resolveRootfsImage` and GC work unchanged; `driver.PullImage` migration is deferred to the UDS wiring.
- **Artifact key derivation**: artifacts share the per-build digest namespace (`<digest16>/`) with the manifest, derived from the `manifestRef` directory — matching the publisher layout.
- **`imageKey` duplication (accepted, P2)**: two copies of the same derivation (agent + driver), pinned by comment; sharing into `contract` is deferred to the UDS wiring.
- **Drive-by fix**: `gcImageCache` now snapshots `imageUseCount` under the lock (pre-existing latent data race with `touchImage` writing the map concurrently, exposed by `-race`); the GC loop test mutates driver fields under the lock.

## Tests (26 cases)

Cover the plan §7 checklist: index normal / 404 / missing fields / image mismatch; manifest parse and digest validation; pull flow tmp → verify → rename ordering; idempotency with zero requests (httptest request-count assertions); resume skipping matching files; corrupt-cache delete-and-repull (same-size tampering); empty-image rejection; manifest 404 / manifest digest mismatch / artifact digest mismatch (no tmp leftovers); 5xx retry (two 500s then success, 403 not retried); 8-way concurrent PullImage; `fileMatches` size fast-path and `cacheComplete` predicate units; integration test proving the driver's `resolveRootfsImage` cold-boot consumer resolves pulled artifacts unchanged.

## Acceptance

- `go build ./...`, `go vet ./...`, `go test ./internal/runtime/firecracker/... -count=1` (including `-race` ×5) all green
- `go.mod` / `go.sum` unchanged (option A, zero new dependencies)

Prerequisite: #22 (publisher-side index + SHA256SUMS, merged); design doc #21 (draft).