### PR TITLE
feat(agent): node-level runtime-agent UDS API with driver wiring

### DIFF
--- a/cmd/fastlet/main.go
+++ b/cmd/fastlet/main.go
@@ -96,6 +96,15 @@ func main() {
 		}
 		configurable.SetNodeCleanupClient(nodecleanup.NewClient(getEnv("FAST_SANDBOX_NODE_CLEANUP_SOCKET", nodecleanup.DefaultSocketPath)))
 	}
+	// The firecracker driver optionally talks to the node-level
+	// firecracker-runtime-agent over its UDS socket (empty env = local
+	// mode: no remote pull, warm images and cold boots unchanged). The
+	// agent's deployment carrier is a pending decision, so the env is
+	// only injected by the deployer, never by the control plane.
+	if configurable, ok := rt.(agentClientConfigurable); ok {
+		configurable.SetFastletPodUID(podUID)
+		configurable.SetAgentSocket(getEnv("FAST_SANDBOX_RUNTIME_AGENT_SOCKET", ""))
+	}
 	registryProvider := registryconfig.NewFileProvider(getEnv("FAST_SANDBOX_REGISTRY_CONFIG_PATH", registryconfig.MountPath))
 	if revision, err := registryProvider.Refresh(); err != nil {
 		klog.ErrorS(err, "Failed to load Registry configuration")
@@ -208,6 +217,13 @@ type registryConfigurable interface {
 
 type nodeCleanupConfigurable interface {
 	SetNodeCleanupClient(nodecleanup.RuntimeProcessCleaner)
+}
+
+// agentClientConfigurable wires the optional firecracker runtime-agent
+// client into the driver (empty socket = local mode).
+type agentClientConfigurable interface {
+	SetFastletPodUID(podUID string)
+	SetAgentSocket(socketPath string)
 }
 
 func recoverUntilReady(ctx context.Context, manager *fastletsandbox.SandboxManager, proxyClient *fastletproxy.ControlClient) {

--- a/cmd/firecracker-runtime-agent/doc.go
+++ b/cmd/firecracker-runtime-agent/doc.go
@@ -1,0 +1,6 @@
+// Package firecracker-runtime-agent is the node-level runtime-agent entry
+// point (stage 1): a thin assembly of the pull client, the durable lease
+// state, and the UDS management server. Deployment carrier (DaemonSet vs
+// co-located container) is a pending decision; the binary is a standalone
+// process either way.
+package main

--- a/cmd/firecracker-runtime-agent/main.go
+++ b/cmd/firecracker-runtime-agent/main.go
@@ -1,0 +1,102 @@
+package main
+
+// firecracker-runtime-agent serves the node-level UDS management API of
+// the Firecracker on-demand loading design (implementation plan §8): the
+// pull chain (agent.Client) plus the durable lease/journal state, exposed
+// to fastlet drivers as JSON over a Unix socket.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"fast-sandbox/internal/registryconfig"
+	agentpull "fast-sandbox/internal/runtime/firecracker/agent"
+	agentserver "fast-sandbox/internal/runtime/firecracker/agent/server"
+	agentstate "fast-sandbox/internal/runtime/firecracker/agent/state"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// defaultSocketPath is the UDS socket served by this agent.
+	defaultSocketPath = "/run/fast-sandbox/firecracker/runtime.sock"
+	// defaultStateRoot mirrors the fastlet driver's StateRoot, so the
+	// shared cache (images/) and the driver's resolveRootfsImage agree.
+	defaultStateRoot = "/var/lib/fast-sandbox/firecracker"
+)
+
+func main() {
+	socketPath := getEnv("FAST_SANDBOX_RUNTIME_AGENT_SOCKET", defaultSocketPath)
+	storeRoot := getEnv("FAST_SANDBOX_ARTIFACT_STORE", "")
+	stateRoot := getEnv("FAST_SANDBOX_STATE_ROOT", defaultStateRoot)
+	registryPath := getEnv("FAST_SANDBOX_REGISTRY_CONFIG_PATH", registryconfig.MountPath)
+
+	if storeRoot == "" {
+		klog.ErrorS(errors.New("missing store root"), "FAST_SANDBOX_ARTIFACT_STORE is required (s3://bucket/prefix)")
+		os.Exit(1)
+	}
+
+	registryProvider := registryconfig.NewFileProvider(registryPath)
+	credential, err := resolveCredential(registryProvider, storeRoot)
+	if err != nil {
+		klog.ErrorS(err, "Failed to resolve the artifact store credential")
+		os.Exit(1)
+	}
+	pull, err := agentpull.NewClient(storeRoot, credential)
+	if err != nil {
+		klog.ErrorS(err, "Failed to build the artifact pull client")
+		os.Exit(1)
+	}
+	state, err := agentstate.New(stateRoot)
+	if err != nil {
+		klog.ErrorS(err, "Failed to open the lease state", "stateRoot", stateRoot)
+		os.Exit(1)
+	}
+	defer func() { _ = state.Close() }()
+
+	service := agentserver.NewService(pull, state, stateRoot)
+	server := agentserver.New(service, socketPath)
+	klog.InfoS("firecracker-runtime-agent starting",
+		"socket", socketPath, "store", storeRoot, "stateRoot", stateRoot, "registry", registryPath)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+	if err := server.Serve(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		klog.ErrorS(err, "firecracker-runtime-agent stopped")
+		os.Exit(1)
+	}
+	klog.InfoS("firecracker-runtime-agent stopped")
+}
+
+// resolveCredential matches the store endpoint host against the compiled
+// registry configuration; the credential carries the read-only access key
+// pair (Username/Password) and the store Host.
+func resolveCredential(provider registryconfig.Provider, storeRoot string) (registryconfig.Credential, error) {
+	parsed, err := url.Parse(storeRoot)
+	if err != nil {
+		return registryconfig.Credential{}, fmt.Errorf("parse store root %q: %w", storeRoot, err)
+	}
+	if parsed.Host == "" {
+		return registryconfig.Credential{}, fmt.Errorf("store root %q has no endpoint host", storeRoot)
+	}
+	credential, ok, err := provider.Credentials(parsed.Host)
+	if err != nil {
+		return registryconfig.Credential{}, err
+	}
+	if !ok {
+		return registryconfig.Credential{}, fmt.Errorf("no read-only credential configured for store endpoint %q", parsed.Host)
+	}
+	return credential, nil
+}
+
+func getEnv(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/cmd/firecracker-runtime-agent/main_test.go
+++ b/cmd/firecracker-runtime-agent/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"fast-sandbox/internal/registryconfig"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProvider mocks the registryconfig.Provider interface.
+type fakeProvider struct {
+	credential registryconfig.Credential
+	found      bool
+	err        error
+	lastRef    string
+}
+
+func (f *fakeProvider) Credentials(reference string) (registryconfig.Credential, bool, error) {
+	f.lastRef = reference
+	return f.credential, f.found, f.err
+}
+
+func (f *fakeProvider) Revision() string { return "" }
+
+func TestResolveCredentialMatchesStoreHost(t *testing.T) {
+	provider := &fakeProvider{
+		credential: registryconfig.Credential{
+			Host: "oss-cn-hangzhou.aliyuncs.com", Username: "readonly-ak", Password: "readonly-sk",
+		},
+		found: true,
+	}
+	credential, err := resolveCredential(provider, "s3://oss-cn-hangzhou.aliyuncs.com/sandbox-images/publish")
+	require.NoError(t, err)
+	require.Equal(t, "readonly-ak", credential.Username)
+	require.Equal(t, "readonly-sk", credential.Password)
+	// The provider is matched against the store endpoint host.
+	require.Equal(t, "oss-cn-hangzhou.aliyuncs.com", provider.lastRef)
+}
+
+func TestResolveCredentialNoMatch(t *testing.T) {
+	provider := &fakeProvider{found: false}
+	_, err := resolveCredential(provider, "s3://sandbox-images/publish")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no read-only credential")
+}
+
+func TestResolveCredentialProviderError(t *testing.T) {
+	provider := &fakeProvider{err: errors.New("config unreadable")}
+	_, err := resolveCredential(provider, "s3://sandbox-images/publish")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "config unreadable")
+}
+
+func TestResolveCredentialInvalidStoreRoot(t *testing.T) {
+	provider := &fakeProvider{found: true}
+	_, err := resolveCredential(provider, "not a url ://")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "store root")
+}
+
+func TestResolveCredentialMissingHost(t *testing.T) {
+	provider := &fakeProvider{found: true}
+	_, err := resolveCredential(provider, "s3:///only-path")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "endpoint host")
+}

--- a/internal/runtime/firecracker/agent/cache.go
+++ b/internal/runtime/firecracker/agent/cache.go
@@ -28,6 +28,12 @@ const (
 	manifestName  = "manifest.json"
 	cacheFileMode = 0o640
 	cacheDirMode  = 0o750
+
+	// nativeRootfsCacheName is the cache name of the published rootfs
+	// artifact (rootfs.ext4), kept byte-identical to the driver's
+	// rootfsImageName so the existing resolveRootfsImage consumer works
+	// on pulled artifacts unchanged.
+	nativeRootfsCacheName = "rootfs.img"
 )
 
 // imageKey derives the content-addressed cache key of an image reference.
@@ -39,6 +45,40 @@ func imageKey(image string) string {
 // imageDir returns the cache directory of an image reference.
 func imageDir(stateRoot, image string) string {
 	return filepath.Join(stateRoot, imageCacheDir, imageKey(image))
+}
+
+// ImageRootfsPath returns the cached native rootfs path of an image
+// reference. The derivation is byte-identical to the driver's image cache
+// key (internal/runtime/firecracker/images.go), so the runtime-agent server
+// and the driver resolve the same file.
+func ImageRootfsPath(stateRoot, image string) string {
+	return filepath.Join(imageDir(stateRoot, image), nativeRootfsCacheName)
+}
+
+// ImageReady reports whether the image reference has a committed pull in the
+// local cache: the commit-point manifest plus a native file set whose
+// digests match.
+func ImageReady(stateRoot, image string) (bool, error) {
+	return cacheComplete(imageDir(stateRoot, image))
+}
+
+// CachedManifestDigest returns the sha256 digest of the committed local
+// manifest of an image reference. The digest matches the index
+// artifactDigest the pull verified, so callers can trust it without a
+// network request. An image without a committed manifest reports false.
+func CachedManifestDigest(stateRoot, image string) (string, bool, error) {
+	dir := imageDir(stateRoot, image)
+	payload, err := os.ReadFile(filepath.Join(dir, manifestName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	if _, err := parseManifest(payload); err != nil {
+		return "", false, nil
+	}
+	return sha256Hex(payload), true, nil
 }
 
 // cacheComplete reports whether the image directory holds a committed pull:

--- a/internal/runtime/firecracker/agent/manifest.go
+++ b/internal/runtime/firecracker/agent/manifest.go
@@ -49,7 +49,7 @@ type nativeFile struct {
 // their published names. OverlayBD layers are deliberately absent: they
 // arrive with the overlaybd stage.
 var nativeArtifactNames = []struct{ publish, cache string }{
-	{"rootfs.ext4", "rootfs.img"},
+	{"rootfs.ext4", nativeRootfsCacheName},
 	{"vmstate.snap", "vmstate.snap"},
 	{"memory.snap", "memory.snap"},
 }

--- a/internal/runtime/firecracker/agent/protocol/types.go
+++ b/internal/runtime/firecracker/agent/protocol/types.go
@@ -1,0 +1,129 @@
+// Package protocol defines the versioned UDS API shared by the
+// firecracker-runtime-agent server and the fastlet driver client. Messages
+// are JSON over HTTP on a Unix socket (design docs §2.2).
+//
+// Stage 1 carries the startup flow RPCs only: PinImage / UnpinImage /
+// LeaseDevices / ReleaseDevices / ListLeases / Compatibility / Health.
+// Snapshot RPCs (PinSnapshot / LeaseSnapshotDevices / SealSnapshot) arrive
+// with stage 4.
+package protocol
+
+import "time"
+
+const ProtocolVersionV1 = "v1"
+
+// RPC routes.
+const (
+	RoutePinImage       = "/v1/pin-image"
+	RouteUnpinImage     = "/v1/unpin-image"
+	RouteLeaseDevices   = "/v1/lease-devices"
+	RouteReleaseDevices = "/v1/release-devices"
+	RouteListLeases     = "/v1/list-leases"
+	RouteCompatibility  = "/v1/compatibility"
+	RouteHealth         = "/v1/health"
+)
+
+// Identity is the caller identity carried by every request. The server
+// rejects empty PodUID (403) and binds idempotency keys and leases to the
+// PodUID so cross-pod replays or releases fail with Conflict.
+type Identity struct {
+	RequestID string `json:"requestId"`
+	Namespace string `json:"namespace,omitempty"`
+	PodUID    string `json:"podUid"`
+}
+
+// ErrorCode is a stable wire error classification the driver maps onto
+// runtime contract errors.
+type ErrorCode string
+
+const (
+	ErrorInvalidRequest ErrorCode = "InvalidRequest" // 400
+	ErrorUnauthorized   ErrorCode = "Unauthorized"   // 403 (identity header missing)
+	ErrorConflict       ErrorCode = "Conflict"       // 409 (idempotency key or ownership mismatch)
+	ErrorNotFound       ErrorCode = "NotFound"       // 404 (image not published)
+	ErrorInternal       ErrorCode = "Internal"       // 500
+)
+
+// ErrorResponse is the wire shape of a failed RPC.
+type ErrorResponse struct {
+	Code    ErrorCode `json:"code"`
+	Message string    `json:"message"`
+}
+
+// PinImageRequest pulls and keeps an image pinned on the node.
+type PinImageRequest struct {
+	Identity
+	Image string `json:"image"`
+}
+
+// PinImageResponse reports the pinned image manifest digest.
+type PinImageResponse struct {
+	ManifestDigest string `json:"manifestDigest"`
+	Ready          bool   `json:"ready"`
+}
+
+// UnpinImageRequest drops one pin reference of an image.
+type UnpinImageRequest struct {
+	Identity
+	Image string `json:"image"`
+}
+
+// LeaseDevicesRequest creates a device lease for one Sandbox. In the native
+// stage the lease returns the shared cache file paths; the device semantics
+// arrive with the overlaybd stage. MemSizeMiB and RootfsWritable are carried
+// now so the protocol is stable across stages.
+type LeaseDevicesRequest struct {
+	Identity
+	SandboxID      string `json:"sandboxId"`
+	Image          string `json:"image"`
+	MemSizeMiB     int    `json:"memSizeMiB"`
+	RootfsWritable bool   `json:"rootfsWritable"`
+}
+
+// LeaseDevicesResponse returns the lease handle and the device (or native
+// cache file) paths for the Sandbox.
+type LeaseDevicesResponse struct {
+	LeaseID        string `json:"leaseId"`
+	RootfsDev      string `json:"rootfsDev"`
+	MemDev         string `json:"memDev"`
+	ManifestDigest string `json:"manifestDigest"`
+}
+
+// ReleaseDevicesRequest drops a device lease.
+type ReleaseDevicesRequest struct {
+	Identity
+	LeaseID string `json:"leaseId"`
+}
+
+// Lease is the durable view of a device lease, shared between the state
+// journal and the protocol.
+type Lease struct {
+	LeaseID   string    `json:"leaseId"`
+	SandboxID string    `json:"sandboxId"`
+	Image     string    `json:"image"`
+	PodUID    string    `json:"podUid"`
+	Namespace string    `json:"namespace,omitempty"`
+	RootfsDev string    `json:"rootfsDev"`
+	MemDev    string    `json:"memDev,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// ListLeasesResponse returns every lease on the node (recovery/audit).
+type ListLeasesResponse struct {
+	Leases []Lease `json:"leases"`
+}
+
+// CompatibilityResponse returns the node compatibility class (stage 3
+// restore validation; a placeholder in the native stage).
+type CompatibilityResponse struct {
+	CompatibilityClass string `json:"compatibilityClass"`
+}
+
+// HealthResponse reports the agent's runtime health.
+type HealthResponse struct {
+	OK         bool  `json:"ok"`
+	CacheBytes int64 `json:"cacheBytes"`
+	LeaseCount int   `json:"leaseCount"`
+	PinCount   int   `json:"pinCount"`
+	ImageCount int   `json:"imageCount"`
+}

--- a/internal/runtime/firecracker/agent/protocol/types_test.go
+++ b/internal/runtime/firecracker/agent/protocol/types_test.go
@@ -1,0 +1,69 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestEncoding(t *testing.T) {
+	request := PinImageRequest{
+		Identity: Identity{RequestID: "req-1", Namespace: "tenant-a", PodUID: "pod-1"},
+		Image:    "registry.example.com/sandbox:v1",
+	}
+	payload, err := json.Marshal(request)
+	require.NoError(t, err)
+
+	var decoded PinImageRequest
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	require.Equal(t, request, decoded)
+
+	var fields map[string]any
+	require.NoError(t, json.Unmarshal(payload, &fields))
+	require.Equal(t, "req-1", fields["requestId"])
+	require.Equal(t, "pod-1", fields["podUid"])
+	require.Equal(t, "registry.example.com/sandbox:v1", fields["image"])
+}
+
+func TestLeaseEncoding(t *testing.T) {
+	lease := Lease{
+		LeaseID: "lease-1", SandboxID: "sandbox-1", Image: "img", PodUID: "pod-1",
+		Namespace: "ns", RootfsDev: "/cache/img/rootfs.img", MemDev: "",
+	}
+	payload, err := json.Marshal(lease)
+	require.NoError(t, err)
+	var decoded Lease
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	require.Equal(t, lease, decoded)
+}
+
+func TestErrorResponseEncoding(t *testing.T) {
+	response := ErrorResponse{Code: ErrorNotFound, Message: `image "x" not ready`}
+	payload, err := json.Marshal(response)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"code":"NotFound","message":"image \"x\" not ready"}`, string(payload))
+}
+
+func TestRoutesAreVersioned(t *testing.T) {
+	routes := []string{
+		RoutePinImage, RouteUnpinImage, RouteLeaseDevices, RouteReleaseDevices,
+		RouteListLeases, RouteCompatibility, RouteHealth,
+	}
+	for _, route := range routes {
+		require.Len(t, route, len("/v1/")+len(route)-len("/v1/"))
+		require.Contains(t, route, "/v1/")
+	}
+}
+
+func TestIdentityRequiresRequestID(t *testing.T) {
+	// The server enforces the required fields; the protocol layer only
+	// guarantees the wire shape. Empty values round-trip unchanged.
+	identity := Identity{}
+	payload, err := json.Marshal(identity)
+	require.NoError(t, err)
+	var decoded Identity
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	require.Equal(t, "", decoded.RequestID)
+	require.Equal(t, "", decoded.PodUID)
+}

--- a/internal/runtime/firecracker/agent/server/backend.go
+++ b/internal/runtime/firecracker/agent/server/backend.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	agentprotocol "fast-sandbox/internal/runtime/firecracker/agent/protocol"
+)
+
+// Backend implements the agent service logic behind the UDS HTTP transport.
+// The server layer enforces identity, idempotency, and error mapping; the
+// backend owns the pull and device-side effects.
+type Backend interface {
+	PinImage(context.Context, agentprotocol.PinImageRequest) (agentprotocol.PinImageResponse, error)
+	UnpinImage(context.Context, agentprotocol.UnpinImageRequest) error
+	LeaseDevices(context.Context, agentprotocol.LeaseDevicesRequest) (agentprotocol.LeaseDevicesResponse, error)
+	ReleaseDevices(context.Context, agentprotocol.ReleaseDevicesRequest) error
+	ListLeases(context.Context, agentprotocol.Identity) ([]agentprotocol.Lease, error)
+	Compatibility(context.Context) (string, error)
+	Health(context.Context) (agentprotocol.HealthResponse, error)
+}
+
+// Error is a wire-classified backend error; plain errors map to Internal.
+type Error struct {
+	Code    agentprotocol.ErrorCode
+	Message string
+	Cause   error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// invalidRequest builds a 400 backend error.
+func invalidRequest(format string, args ...any) *Error {
+	return &Error{Code: agentprotocol.ErrorInvalidRequest, Message: fmt.Sprintf(format, args...)}
+}
+
+// unauthorized builds a 403 backend error.
+func unauthorized(format string, args ...any) *Error {
+	return &Error{Code: agentprotocol.ErrorUnauthorized, Message: fmt.Sprintf(format, args...)}
+}

--- a/internal/runtime/firecracker/agent/server/health.go
+++ b/internal/runtime/firecracker/agent/server/health.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// cacheBytes sums the regular files under the image cache. It is a health
+// metric only: a failure (e.g. the directory is missing) reports zero
+// instead of failing the Health RPC.
+func cacheBytes(stateRoot string) int64 {
+	var total int64
+	root := filepath.Join(stateRoot, "images")
+	_ = filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return nil
+		}
+		info, err := os.Stat(path)
+		if err == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}

--- a/internal/runtime/firecracker/agent/server/server.go
+++ b/internal/runtime/firecracker/agent/server/server.go
@@ -1,0 +1,359 @@
+package server
+
+// Package server exposes the firecracker-runtime-agent management API as a
+// versioned JSON-over-HTTP service on a Unix socket (design docs §2.2).
+// The server layer enforces the caller identity (empty PodUID -> 403), the
+// idempotency key contract (requestId required on mutating RPCs), routes
+// the seven stage-1 RPCs, and maps backend errors onto stable wire codes;
+// idempotency and the journal live in the state package.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+	"time"
+
+	runtimecontract "fast-sandbox/internal/runtime/contract"
+	agentprotocol "fast-sandbox/internal/runtime/firecracker/agent/protocol"
+	agentstate "fast-sandbox/internal/runtime/firecracker/agent/state"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// socketMode is the Unix socket permission: group-fast-sandbox only.
+	socketMode = 0o660
+	// socketGroup is the owning group of the socket.
+	socketGroup = "fast-sandbox"
+	// maxRequestBytes bounds a decoded request body.
+	maxRequestBytes = 4 << 20
+)
+
+// Server is the UDS HTTP service. A nil Backend reports Unavailable.
+type Server struct {
+	Backend    Backend
+	socketPath string
+	http       *http.Server
+}
+
+// New builds the UDS service. The socket is created on Serve.
+func New(backend Backend, socketPath string) *Server {
+	return &Server{Backend: backend, socketPath: socketPath}
+}
+
+// SocketPath returns the configured socket path.
+func (s *Server) SocketPath() string {
+	return s.socketPath
+}
+
+// Serve listens on the Unix socket and blocks until the server stops or the
+// context is cancelled (then it shuts down gracefully). A stale socket file
+// is removed first. Socket permissions are tightened to the fast-sandbox
+// group; the group lookup is best effort (the daemon runs privileged, but a
+// misconfigured host must not prevent startup).
+func (s *Server) Serve(ctx context.Context) error {
+	if s.socketPath == "" {
+		return errors.New("runtime-agent socket path is required")
+	}
+	if err := os.Remove(s.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove stale runtime-agent socket: %w", err)
+	}
+	if err := os.MkdirAll(parentDir(s.socketPath), 0o750); err != nil {
+		return fmt.Errorf("prepare runtime-agent socket directory: %w", err)
+	}
+	listener, err := net.Listen("unix", s.socketPath)
+	if err != nil {
+		return fmt.Errorf("listen on runtime-agent socket %s: %w", s.socketPath, err)
+	}
+	defer listener.Close()
+	if err := os.Chmod(s.socketPath, socketMode); err != nil {
+		return fmt.Errorf("chmod runtime-agent socket: %w", err)
+	}
+	if group, err := user.LookupGroup(socketGroup); err == nil {
+		if gid, convErr := strconv.Atoi(group.Gid); convErr == nil {
+			if err := os.Chown(s.socketPath, -1, gid); err != nil {
+				klog.Warningf("runtime-agent socket group %q: %v", socketGroup, err)
+			}
+		}
+	} else {
+		klog.Warningf("runtime-agent socket group %q not found: %v", socketGroup, err)
+	}
+
+	s.http = &http.Server{Handler: s}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- s.http.Serve(listener) }()
+	select {
+	case err := <-serveErr:
+		return err
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.http.Shutdown(shutdownCtx)
+		return ctx.Err()
+	}
+}
+
+// Shutdown gracefully stops the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.http == nil {
+		return nil
+	}
+	return s.http.Shutdown(ctx)
+}
+
+// ServeHTTP routes the versioned RPCs. Every request carries the caller
+// identity in its body; an empty PodUID is rejected (403).
+func (s *Server) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	if s.Backend == nil {
+		writeError(writer, &Error{Code: agentprotocol.ErrorInternal, Message: "runtime-agent backend is not configured"})
+		return
+	}
+	switch request.URL.Path {
+	case agentprotocol.RoutePinImage:
+		s.handleMutating(writer, request, func(ctx context.Context, payload json.RawMessage) (any, error) {
+			var req agentprotocol.PinImageRequest
+			if err := decodeRequest(payload, &req); err != nil {
+				return nil, err
+			}
+			if err := validateIdentity(req.Identity, true); err != nil {
+				return nil, err
+			}
+			if strings.TrimSpace(req.Image) == "" {
+				return nil, invalidRequest("image reference is required")
+			}
+			return s.Backend.PinImage(ctx, req)
+		})
+	case agentprotocol.RouteUnpinImage:
+		s.handleMutating(writer, request, func(ctx context.Context, payload json.RawMessage) (any, error) {
+			var req agentprotocol.UnpinImageRequest
+			if err := decodeRequest(payload, &req); err != nil {
+				return nil, err
+			}
+			if err := validateIdentity(req.Identity, true); err != nil {
+				return nil, err
+			}
+			if strings.TrimSpace(req.Image) == "" {
+				return nil, invalidRequest("image reference is required")
+			}
+			return nil, s.Backend.UnpinImage(ctx, req)
+		})
+	case agentprotocol.RouteLeaseDevices:
+		s.handleMutating(writer, request, func(ctx context.Context, payload json.RawMessage) (any, error) {
+			var req agentprotocol.LeaseDevicesRequest
+			if err := decodeRequest(payload, &req); err != nil {
+				return nil, err
+			}
+			if err := validateIdentity(req.Identity, true); err != nil {
+				return nil, err
+			}
+			if strings.TrimSpace(req.SandboxID) == "" {
+				return nil, invalidRequest("sandboxId is required")
+			}
+			if strings.TrimSpace(req.Image) == "" {
+				return nil, invalidRequest("image reference is required")
+			}
+			return s.Backend.LeaseDevices(ctx, req)
+		})
+	case agentprotocol.RouteReleaseDevices:
+		s.handleMutating(writer, request, func(ctx context.Context, payload json.RawMessage) (any, error) {
+			var req agentprotocol.ReleaseDevicesRequest
+			if err := decodeRequest(payload, &req); err != nil {
+				return nil, err
+			}
+			if err := validateIdentity(req.Identity, true); err != nil {
+				return nil, err
+			}
+			if strings.TrimSpace(req.LeaseID) == "" {
+				return nil, invalidRequest("leaseId is required")
+			}
+			return nil, s.Backend.ReleaseDevices(ctx, req)
+		})
+	case agentprotocol.RouteListLeases:
+		s.handleRead(writer, request, func(ctx context.Context, identity agentprotocol.Identity) (any, error) {
+			leases, err := s.Backend.ListLeases(ctx, identity)
+			if err != nil {
+				return nil, err
+			}
+			return agentprotocol.ListLeasesResponse{Leases: leases}, nil
+		})
+	case agentprotocol.RouteCompatibility:
+		s.handleRead(writer, request, func(ctx context.Context, identity agentprotocol.Identity) (any, error) {
+			compatibility, err := s.Backend.Compatibility(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return agentprotocol.CompatibilityResponse{CompatibilityClass: compatibility}, nil
+		})
+	case agentprotocol.RouteHealth:
+		s.handleRead(writer, request, func(ctx context.Context, identity agentprotocol.Identity) (any, error) {
+			return s.Backend.Health(ctx)
+		})
+	default:
+		http.NotFound(writer, request)
+	}
+}
+
+// handleMutating runs a mutating RPC: POST only, bounded body, and a
+// non-empty idempotency key (validated per route on the decoded identity).
+func (s *Server) handleMutating(writer http.ResponseWriter, request *http.Request, run func(ctx context.Context, payload json.RawMessage) (any, error)) {
+	if request.Method != http.MethodPost {
+		methodNotAllowed(writer)
+		return
+	}
+	payload, err := readBody(request)
+	if err != nil {
+		writeError(writer, invalidRequest("%v", err))
+		return
+	}
+	result, err := run(request.Context(), payload)
+	if err != nil {
+		writeError(writer, err)
+		return
+	}
+	if result == nil {
+		writer.WriteHeader(http.StatusNoContent)
+		return
+	}
+	writeJSON(writer, http.StatusOK, result)
+}
+
+// handleRead runs a read-only RPC: POST only, bounded body, caller identity
+// required, no idempotency key.
+func (s *Server) handleRead(writer http.ResponseWriter, request *http.Request, run func(ctx context.Context, identity agentprotocol.Identity) (any, error)) {
+	if request.Method != http.MethodPost {
+		methodNotAllowed(writer)
+		return
+	}
+	payload, err := readBody(request)
+	if err != nil {
+		writeError(writer, invalidRequest("%v", err))
+		return
+	}
+	var identity agentprotocol.Identity
+	if err := decodeIdentity(payload, &identity); err != nil {
+		writeError(writer, err)
+		return
+	}
+	if err := validateIdentity(identity); err != nil {
+		writeError(writer, err)
+		return
+	}
+	result, err := run(request.Context(), identity)
+	if err != nil {
+		writeError(writer, err)
+		return
+	}
+	writeJSON(writer, http.StatusOK, result)
+}
+
+// decodeRequest decodes a full RPC request, rejecting unknown fields.
+func decodeRequest(payload json.RawMessage, destination any) error {
+	decoder := json.NewDecoder(strings.NewReader(string(payload)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return invalidRequest("decode request: %v", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return invalidRequest("multiple JSON values are not allowed")
+		}
+		return invalidRequest("decode request trailing data: %v", err)
+	}
+	return nil
+}
+
+// decodeIdentity parses the caller identity out of a request body.
+func decodeIdentity(payload json.RawMessage, identity *agentprotocol.Identity) error {
+	var envelope struct {
+		RequestID string `json:"requestId"`
+		Namespace string `json:"namespace,omitempty"`
+		PodUID    string `json:"podUid"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return invalidRequest("decode identity: %v", err)
+	}
+	identity.RequestID = envelope.RequestID
+	identity.Namespace = envelope.Namespace
+	identity.PodUID = envelope.PodUID
+	return nil
+}
+
+// validateIdentity enforces the caller identity contract: an empty PodUID
+// is rejected (403). Mutating RPCs additionally require the idempotency
+// key; the callers pass requireRequestID to demand it.
+func validateIdentity(identity agentprotocol.Identity, requireRequestID ...bool) error {
+	if strings.TrimSpace(identity.PodUID) == "" {
+		return unauthorized("caller podUid is required")
+	}
+	if len(requireRequestID) > 0 && requireRequestID[0] && strings.TrimSpace(identity.RequestID) == "" {
+		return invalidRequest("requestId is required for mutating RPCs")
+	}
+	return nil
+}
+
+// readBody reads and bounds the request body.
+func readBody(request *http.Request) (json.RawMessage, error) {
+	defer request.Body.Close()
+	payload, err := io.ReadAll(io.LimitReader(request.Body, maxRequestBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(payload) > maxRequestBytes {
+		return nil, fmt.Errorf("request body exceeds the %d-byte limit", maxRequestBytes)
+	}
+	return payload, nil
+}
+
+// writeError maps a backend error onto a stable wire code and status.
+func writeError(writer http.ResponseWriter, err error) {
+	classified := &Error{Code: agentprotocol.ErrorInternal, Message: err.Error(), Cause: err}
+	var typed *Error
+	if errors.As(err, &typed) {
+		classified = typed
+	} else if errors.Is(err, agentstate.ErrConflict) {
+		classified = &Error{Code: agentprotocol.ErrorConflict, Message: err.Error(), Cause: err}
+	} else if errors.Is(err, agentstate.ErrLeaseNotFound) {
+		classified = &Error{Code: agentprotocol.ErrorNotFound, Message: err.Error(), Cause: err}
+	} else if errors.Is(err, runtimecontract.ErrImageNotReady) {
+		classified = &Error{Code: agentprotocol.ErrorNotFound, Message: err.Error(), Cause: err}
+	}
+	status := http.StatusInternalServerError
+	switch classified.Code {
+	case agentprotocol.ErrorInvalidRequest:
+		status = http.StatusBadRequest
+	case agentprotocol.ErrorUnauthorized:
+		status = http.StatusForbidden
+	case agentprotocol.ErrorConflict:
+		status = http.StatusConflict
+	case agentprotocol.ErrorNotFound:
+		status = http.StatusNotFound
+	}
+	writeJSON(writer, status, agentprotocol.ErrorResponse{Code: classified.Code, Message: classified.Message})
+}
+
+func methodNotAllowed(writer http.ResponseWriter) {
+	writeJSON(writer, http.StatusMethodNotAllowed, agentprotocol.ErrorResponse{Code: agentprotocol.ErrorInvalidRequest, Message: "method not allowed"})
+}
+
+func writeJSON(writer http.ResponseWriter, status int, value any) {
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(status)
+	_ = json.NewEncoder(writer).Encode(value)
+}
+
+func parentDir(path string) string {
+	index := strings.LastIndexByte(path, '/')
+	if index <= 0 {
+		return "."
+	}
+	return path[:index]
+}

--- a/internal/runtime/firecracker/agent/server/server_test.go
+++ b/internal/runtime/firecracker/agent/server/server_test.go
@@ -1,0 +1,463 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	runtimecontract "fast-sandbox/internal/runtime/contract"
+	agentprotocol "fast-sandbox/internal/runtime/firecracker/agent/protocol"
+	agentstate "fast-sandbox/internal/runtime/firecracker/agent/state"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testImage = "registry.example.com/sandbox:v1.0.21"
+	testPod   = "pod-1"
+	testNS    = "tenant-a"
+)
+
+func imageKeyHex(image string) string {
+	digest := sha256.Sum256([]byte(image))
+	return hex.EncodeToString(digest[:])
+}
+
+// seedCache writes a committed pull (manifest + native artifacts with
+// matching digests) into the cache, byte-identical to the pull layer's
+// layout.
+func seedCache(stateRoot, image string) error {
+	dir := filepath.Join(stateRoot, "images", imageKeyHex(image))
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	rootfs := []byte("rootfs-content-for-tests")
+	vmstate := []byte("vmstate-content-for-tests")
+	memory := []byte("memory-content-for-tests")
+	if err := os.WriteFile(filepath.Join(dir, "rootfs.img"), rootfs, 0o640); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "vmstate.snap"), vmstate, 0o640); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "memory.snap"), memory, 0o640); err != nil {
+		return err
+	}
+	manifest := map[string]any{
+		"files": map[string]any{
+			"rootfs.ext4":  map[string]any{"sha256": hexSHA256(rootfs), "sizeBytes": len(rootfs)},
+			"vmstate.snap": map[string]any{"sha256": hexSHA256(vmstate), "sizeBytes": len(vmstate)},
+			"memory.snap":  map[string]any{"sha256": hexSHA256(memory), "sizeBytes": len(memory)},
+		},
+	}
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "manifest.json"), payload, 0o640)
+}
+
+func hexSHA256(payload []byte) string {
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:])
+}
+
+// fakePuller counts pulls per image and seeds the cache on demand.
+type fakePuller struct {
+	mu    sync.Mutex
+	pulls map[string]int
+	fail  map[string]error
+	seed  func(stateRoot, image string) error
+}
+
+func newFakePuller() *fakePuller {
+	return &fakePuller{pulls: make(map[string]int), fail: make(map[string]error), seed: seedCache}
+}
+
+func (f *fakePuller) PullImage(_ context.Context, stateRoot, image string) error {
+	f.mu.Lock()
+	f.pulls[image]++
+	fail := f.fail[image]
+	f.mu.Unlock()
+	if fail != nil {
+		return fail
+	}
+	return f.seed(stateRoot, image)
+}
+
+func (f *fakePuller) pullCount(image string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.pulls[image]
+}
+
+// newServerFixture wires the Service + state + Server over a real Unix socket.
+type serverFixture struct {
+	server     *Server
+	client     *http.Client
+	socketPath string
+	stateRoot  string
+	state      *agentstate.State
+	puller     *fakePuller
+}
+
+// socketCounter keeps test socket names unique; Unix socket paths are
+// bounded (104 bytes on macOS), so the file lives in the OS temp root with
+// a short name instead of under the long t.TempDir() path.
+var socketCounter int64
+
+func testSocketPath(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("fast-sandbox-agent-%d-%d.sock", os.Getpid(), atomic.AddInt64(&socketCounter, 1)))
+	t.Cleanup(func() { _ = os.Remove(path) })
+	return path
+}
+
+func newServerFixture(t *testing.T) *serverFixture {
+	t.Helper()
+	stateRoot := t.TempDir()
+	puller := newFakePuller()
+	state, err := agentstate.New(stateRoot)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = state.Close() })
+	socketPath := testSocketPath(t)
+	service := NewService(puller, state, stateRoot, WithServiceClock(func() time.Time { return time.Unix(1720000000, 0) }))
+	server := New(service, socketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = server.Serve(ctx) }()
+	t.Cleanup(cancel)
+	// Wait for the listener so dials never race socket creation.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("runtime-agent socket %s never appeared", socketPath)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+			},
+			ForceAttemptHTTP2: false,
+		},
+	}
+	fixture := &serverFixture{server: server, client: client, socketPath: socketPath, stateRoot: stateRoot, state: state, puller: puller}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	})
+	return fixture
+}
+
+func (f *serverFixture) do(t *testing.T, path string, body any) (int, agentprotocol.ErrorResponse, []byte) {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	require.NoError(t, err)
+	request, err := http.NewRequest(http.MethodPost, "http://agent"+path, bytes.NewReader(payload))
+	require.NoError(t, err)
+	response, err := f.client.Do(request)
+	require.NoError(t, err)
+	defer response.Body.Close()
+	raw, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	var wireError agentprotocol.ErrorResponse
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &wireError)
+	}
+	return response.StatusCode, wireError, raw
+}
+
+func identity(requestID string) agentprotocol.Identity {
+	return agentprotocol.Identity{RequestID: requestID, Namespace: testNS, PodUID: testPod}
+}
+
+func TestServerPinImagePullsAndIsIdempotent(t *testing.T) {
+	fixture := newServerFixture(t)
+
+	status, wireError, raw := fixture.do(t, agentprotocol.RoutePinImage, agentprotocol.PinImageRequest{
+		Identity: identity("req-1"), Image: testImage,
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.Empty(t, wireError.Code)
+	var response agentprotocol.PinImageResponse
+	require.NoError(t, json.Unmarshal(raw, &response))
+	require.True(t, response.Ready)
+	require.NotEmpty(t, response.ManifestDigest)
+	require.Equal(t, 1, fixture.puller.pullCount(testImage))
+	require.Equal(t, 1, fixture.state.Snapshot().PinCount)
+
+	// The same request id replays the recorded outcome without re-pulling.
+	status, wireError, raw = fixture.do(t, agentprotocol.RoutePinImage, agentprotocol.PinImageRequest{
+		Identity: identity("req-1"), Image: testImage,
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.Empty(t, wireError.Code)
+	var replayed agentprotocol.PinImageResponse
+	require.NoError(t, json.Unmarshal(raw, &replayed))
+	require.Equal(t, response, replayed)
+	require.Equal(t, 1, fixture.puller.pullCount(testImage))
+
+	// A second pin with a different request id pulls nothing (cache ready)
+	// but records another reference.
+	status, _, _ = fixture.do(t, agentprotocol.RoutePinImage, agentprotocol.PinImageRequest{
+		Identity: identity("req-2"), Image: testImage,
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, 1, fixture.puller.pullCount(testImage))
+	require.Equal(t, 2, fixture.state.Snapshot().PinCount)
+}
+
+func TestServerPinImageNotPublished(t *testing.T) {
+	fixture := newServerFixture(t)
+	fixture.puller.fail[testImage] = fmt.Errorf("%w: %q", runtimecontract.ErrImageNotReady, testImage)
+
+	status, wireError, _ := fixture.do(t, agentprotocol.RoutePinImage, agentprotocol.PinImageRequest{
+		Identity: identity("req-1"), Image: testImage,
+	})
+	require.Equal(t, http.StatusNotFound, status)
+	require.Equal(t, agentprotocol.ErrorNotFound, wireError.Code)
+}
+
+func TestServerIdentityEnforcement(t *testing.T) {
+	fixture := newServerFixture(t)
+
+	// Empty PodUID is rejected on every RPC.
+	status, wireError, _ := fixture.do(t, agentprotocol.RoutePinImage, agentprotocol.PinImageRequest{
+		Identity: agentprotocol.Identity{RequestID: "req-1"}, Image: testImage,
+	})
+	require.Equal(t, http.StatusForbidden, status)
+	require.Equal(t, agentprotocol.ErrorUnauthorized, wireError.Code)
+
+	status, wireError, _ = fixture.do(t, agentprotocol.RouteHealth, agentprotocol.Identity{})
+	require.Equal(t, http.StatusForbidden, status)
+	require.Equal(t, agentprotocol.ErrorUnauthorized, wireError.Code)
+
+	status, wireError, _ = fixture.do(t, agentprotocol.RouteCompatibility, agentprotocol.Identity{Namespace: testNS})
+	require.Equal(t, http.StatusForbidden, status)
+	require.Equal(t, agentprotocol.ErrorUnauthorized, wireError.Code)
+
+	// A mutating RPC without its idempotency key is rejected.
+	status, wireError, _ = fixture.do(t, agentprotocol.RoutePinImage, agentprotocol.PinImageRequest{
+		Identity: agentprotocol.Identity{PodUID: testPod}, Image: testImage,
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, agentprotocol.ErrorInvalidRequest, wireError.Code)
+}
+
+func TestServerCrossPodConflict(t *testing.T) {
+	fixture := newServerFixture(t)
+
+	status, _, _ := fixture.do(t, agentprotocol.RoutePinImage, agentprotocol.PinImageRequest{
+		Identity: identity("req-1"), Image: testImage,
+	})
+	require.Equal(t, http.StatusOK, status)
+
+	// Replaying pod-1's request id as pod-2 is a conflict.
+	status, wireError, _ := fixture.do(t, agentprotocol.RoutePinImage, agentprotocol.PinImageRequest{
+		Identity: agentprotocol.Identity{RequestID: "req-1", Namespace: testNS, PodUID: "pod-2"},
+		Image:    testImage,
+	})
+	require.Equal(t, http.StatusConflict, status)
+	require.Equal(t, agentprotocol.ErrorConflict, wireError.Code)
+}
+
+func TestServerLeaseDevicesFlow(t *testing.T) {
+	fixture := newServerFixture(t)
+
+	status, wireError, raw := fixture.do(t, agentprotocol.RouteLeaseDevices, agentprotocol.LeaseDevicesRequest{
+		Identity: identity("req-1"), SandboxID: "sandbox-1", Image: testImage, MemSizeMiB: 4096,
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.Empty(t, wireError.Code)
+	var response agentprotocol.LeaseDevicesResponse
+	require.NoError(t, json.Unmarshal(raw, &response))
+	require.NotEmpty(t, response.LeaseID)
+	require.Equal(t, filepath.Join(fixture.stateRoot, "images", imageKeyHex(testImage), "rootfs.img"), response.RootfsDev)
+	require.Equal(t, filepath.Join(fixture.stateRoot, "images", imageKeyHex(testImage), "memory.snap"), response.MemDev)
+	require.Equal(t, 1, fixture.state.Snapshot().LeaseCount)
+
+	// Business idempotency: a different request id for the same sandbox
+	// returns the same lease.
+	status, _, raw = fixture.do(t, agentprotocol.RouteLeaseDevices, agentprotocol.LeaseDevicesRequest{
+		Identity: identity("req-2"), SandboxID: "sandbox-1", Image: testImage, MemSizeMiB: 4096,
+	})
+	require.Equal(t, http.StatusOK, status)
+	var replayed agentprotocol.LeaseDevicesResponse
+	require.NoError(t, json.Unmarshal(raw, &replayed))
+	require.Equal(t, response.LeaseID, replayed.LeaseID)
+	require.Equal(t, 1, fixture.state.Snapshot().LeaseCount)
+
+	// Release by the owning pod.
+	status, wireError, _ = fixture.do(t, agentprotocol.RouteReleaseDevices, agentprotocol.ReleaseDevicesRequest{
+		Identity: identity("req-3"), LeaseID: response.LeaseID,
+	})
+	require.Equal(t, http.StatusNoContent, status)
+	require.Empty(t, wireError.Code)
+	require.Equal(t, 0, fixture.state.Snapshot().LeaseCount)
+
+	// Cross-pod release of another sandbox's lease is a conflict.
+	status, wireError, raw = fixture.do(t, agentprotocol.RouteLeaseDevices, agentprotocol.LeaseDevicesRequest{
+		Identity: identity("req-4"), SandboxID: "sandbox-2", Image: testImage, MemSizeMiB: 4096,
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.Empty(t, wireError.Code)
+	var second agentprotocol.LeaseDevicesResponse
+	require.NoError(t, json.Unmarshal(raw, &second))
+	status, wireError, _ = fixture.do(t, agentprotocol.RouteReleaseDevices, agentprotocol.ReleaseDevicesRequest{
+		Identity: agentprotocol.Identity{RequestID: "req-5", Namespace: testNS, PodUID: "pod-2"},
+		LeaseID:  second.LeaseID,
+	})
+	require.Equal(t, http.StatusConflict, status)
+	require.Equal(t, agentprotocol.ErrorConflict, wireError.Code)
+
+	// Releasing an unknown lease is an idempotent no-op, not an error.
+	status, wireError, _ = fixture.do(t, agentprotocol.RouteReleaseDevices, agentprotocol.ReleaseDevicesRequest{
+		Identity: identity("req-6"), LeaseID: "does-not-exist",
+	})
+	require.Equal(t, http.StatusNoContent, status)
+	require.Empty(t, wireError.Code)
+}
+
+func TestServerListLeasesAndHealth(t *testing.T) {
+	fixture := newServerFixture(t)
+	_, _, _ = fixture.do(t, agentprotocol.RouteLeaseDevices, agentprotocol.LeaseDevicesRequest{
+		Identity: identity("req-1"), SandboxID: "sandbox-1", Image: testImage, MemSizeMiB: 4096,
+	})
+
+	status, _, raw := fixture.do(t, agentprotocol.RouteListLeases, identity(""))
+	require.Equal(t, http.StatusOK, status)
+	var list agentprotocol.ListLeasesResponse
+	require.NoError(t, json.Unmarshal(raw, &list))
+	require.Len(t, list.Leases, 1)
+	require.Equal(t, "sandbox-1", list.Leases[0].SandboxID)
+	require.Equal(t, testPod, list.Leases[0].PodUID)
+
+	status, _, raw = fixture.do(t, agentprotocol.RouteHealth, identity(""))
+	require.Equal(t, http.StatusOK, status)
+	var health agentprotocol.HealthResponse
+	require.NoError(t, json.Unmarshal(raw, &health))
+	require.True(t, health.OK)
+	require.Equal(t, 1, health.LeaseCount)
+	require.Equal(t, 1, health.ImageCount)
+	require.True(t, health.CacheBytes > 0)
+}
+
+func TestServerCompatibilityPlaceholder(t *testing.T) {
+	fixture := newServerFixture(t)
+	status, _, raw := fixture.do(t, agentprotocol.RouteCompatibility, identity(""))
+	require.Equal(t, http.StatusOK, status)
+	var response agentprotocol.CompatibilityResponse
+	require.NoError(t, json.Unmarshal(raw, &response))
+	require.Equal(t, compatibilityPlaceholder, response.CompatibilityClass)
+}
+
+func TestServerUnpinLifecycle(t *testing.T) {
+	fixture := newServerFixture(t)
+	_, _, _ = fixture.do(t, agentprotocol.RoutePinImage, agentprotocol.PinImageRequest{
+		Identity: identity("req-1"), Image: testImage,
+	})
+	require.Equal(t, 1, fixture.state.Snapshot().PinCount)
+
+	status, wireError, _ := fixture.do(t, agentprotocol.RouteUnpinImage, agentprotocol.UnpinImageRequest{
+		Identity: identity("req-2"), Image: testImage,
+	})
+	require.Equal(t, http.StatusNoContent, status)
+	require.Empty(t, wireError.Code)
+	require.Equal(t, 0, fixture.state.Snapshot().PinCount)
+
+	// Replaying the unpin request id stays a no-op (no negative count).
+	status, _, _ = fixture.do(t, agentprotocol.RouteUnpinImage, agentprotocol.UnpinImageRequest{
+		Identity: identity("req-2"), Image: testImage,
+	})
+	require.Equal(t, http.StatusNoContent, status)
+	require.Equal(t, 0, fixture.state.Snapshot().PinCount)
+}
+
+func TestServerUnknownRouteAndMethod(t *testing.T) {
+	fixture := newServerFixture(t)
+
+	response, err := fixture.client.Post("http://agent"+agentprotocol.RouteHealth, "application/json", nil)
+	require.NoError(t, err)
+	response.Body.Close()
+	require.Equal(t, http.StatusBadRequest, response.StatusCode) // missing identity
+
+	request, err := http.NewRequest(http.MethodGet, "http://agent"+agentprotocol.RouteHealth, nil)
+	require.NoError(t, err)
+	response, err = fixture.client.Do(request)
+	require.NoError(t, err)
+	response.Body.Close()
+	require.Equal(t, http.StatusMethodNotAllowed, response.StatusCode)
+
+	request, err = http.NewRequest(http.MethodPost, "http://agent/unknown", bytes.NewReader([]byte(`{}`)))
+	require.NoError(t, err)
+	response, err = fixture.client.Do(request)
+	require.NoError(t, err)
+	response.Body.Close()
+	require.Equal(t, http.StatusNotFound, response.StatusCode)
+}
+
+func TestServerRejectsUnknownFields(t *testing.T) {
+	fixture := newServerFixture(t)
+	status, wireError, _ := fixture.doRaw(t, agentprotocol.RoutePinImage, `{
+		"requestId":"req-1","podUid":"pod-1","namespace":"ns",
+		"image":"img","unexpected":true
+	}`)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, agentprotocol.ErrorInvalidRequest, wireError.Code)
+}
+
+func (f *serverFixture) doRaw(t *testing.T, path, body string) (int, agentprotocol.ErrorResponse, []byte) {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodPost, "http://agent"+path, bytes.NewReader([]byte(body)))
+	require.NoError(t, err)
+	response, err := f.client.Do(request)
+	require.NoError(t, err)
+	defer response.Body.Close()
+	raw, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	var wireError agentprotocol.ErrorResponse
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &wireError)
+	}
+	return response.StatusCode, wireError, raw
+}
+
+func TestServerConcurrentSameRequestID(t *testing.T) {
+	fixture := newServerFixture(t)
+
+	var wg sync.WaitGroup
+	results := make([]int, 6)
+	for index := 0; index < len(results); index++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			results[index], _, _ = fixture.do(t, agentprotocol.RoutePinImage, agentprotocol.PinImageRequest{
+				Identity: identity("req-1"), Image: testImage,
+			})
+		}(index)
+	}
+	wg.Wait()
+	for _, status := range results {
+		require.Equal(t, http.StatusOK, status)
+	}
+	require.Equal(t, 1, fixture.puller.pullCount(testImage))
+	require.Equal(t, 1, fixture.state.Snapshot().PinCount)
+}

--- a/internal/runtime/firecracker/agent/server/service.go
+++ b/internal/runtime/firecracker/agent/server/service.go
@@ -1,0 +1,189 @@
+package server
+
+// Service implements the Backend interface for stage 1: it ties the pull
+// layer (agent.Client), the durable state (agent/state), and the shared
+// node cache (<StateRoot>/images/<sha256(image)>/) together. The native
+// stage returns cache file paths as devices; overlaybd ublk devices arrive
+// with stage 3.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	runtimecontract "fast-sandbox/internal/runtime/contract"
+	agentpull "fast-sandbox/internal/runtime/firecracker/agent"
+	agentprotocol "fast-sandbox/internal/runtime/firecracker/agent/protocol"
+	agentstate "fast-sandbox/internal/runtime/firecracker/agent/state"
+)
+
+// imagePuller pulls a published image into the node cache. The pull client
+// satisfies it; tests inject a fake.
+type imagePuller interface {
+	PullImage(ctx context.Context, stateRoot, image string) error
+}
+
+// compatibilityPlaceholder is the stage-1 compatibility class. The full
+// class (CPU/kernel/Firecracker digests, design doc §8) arrives with the
+// snapshot stages.
+const compatibilityPlaceholder = "native-stage-1"
+
+// Service is the concrete agent backend.
+type Service struct {
+	pull      imagePuller
+	state     *agentstate.State
+	stateRoot string
+	now       func() time.Time
+}
+
+// NewService assembles the stage-1 backend.
+func NewService(pull imagePuller, state *agentstate.State, stateRoot string, options ...ServiceOption) *Service {
+	service := &Service{pull: pull, state: state, stateRoot: stateRoot, now: time.Now}
+	for _, option := range options {
+		option(service)
+	}
+	return service
+}
+
+// ServiceOption configures the service (tests).
+type ServiceOption func(*Service)
+
+// WithServiceClock overrides the clock.
+func WithServiceClock(now func() time.Time) ServiceOption {
+	return func(service *Service) { service.now = now }
+}
+
+// PinImage pulls the image (if not already cached) and records one pin.
+// The side effect runs inside the state's journaled two-phase execution,
+// so replays return the recorded digest without re-pulling.
+func (s *Service) PinImage(ctx context.Context, request agentprotocol.PinImageRequest) (agentprotocol.PinImageResponse, error) {
+	digest, err := s.state.PinImage(request.Identity, request.Image, func() (string, error) {
+		if err := s.ensureImage(ctx, request.Image); err != nil {
+			return "", err
+		}
+		manifestDigest, ok, err := agentpull.CachedManifestDigest(s.stateRoot, request.Image)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", fmt.Errorf("image %q committed without a local manifest", request.Image)
+		}
+		return manifestDigest, nil
+	})
+	if err != nil {
+		return agentprotocol.PinImageResponse{}, err
+	}
+	return agentprotocol.PinImageResponse{ManifestDigest: digest, Ready: true}, nil
+}
+
+// UnpinImage drops one pin reference.
+func (s *Service) UnpinImage(_ context.Context, request agentprotocol.UnpinImageRequest) error {
+	return s.state.UnpinImage(request.Identity, request.Image)
+}
+
+// LeaseDevices returns the native cache file paths as the device lease of
+// one Sandbox. The image is ensured (pulled if needed) before the lease is
+// committed.
+func (s *Service) LeaseDevices(ctx context.Context, request agentprotocol.LeaseDevicesRequest) (agentprotocol.LeaseDevicesResponse, error) {
+	lease, err := s.state.LeaseDevices(
+		request.Identity, request.SandboxID, request.Image,
+		request.MemSizeMiB, request.RootfsWritable,
+		func(leaseID string) (agentprotocol.Lease, error) {
+			if err := s.ensureImage(ctx, request.Image); err != nil {
+				return agentprotocol.Lease{}, err
+			}
+			if _, ok, err := agentpull.CachedManifestDigest(s.stateRoot, request.Image); err != nil {
+				return agentprotocol.Lease{}, err
+			} else if !ok {
+				return agentprotocol.Lease{}, fmt.Errorf("image %q committed without a local manifest", request.Image)
+			}
+			return agentprotocol.Lease{
+				LeaseID: leaseID, SandboxID: request.SandboxID, Image: request.Image,
+				PodUID: request.PodUID, Namespace: request.Namespace,
+				RootfsDev: agentpull.ImageRootfsPath(s.stateRoot, request.Image),
+				MemDev:    imageMemoryPath(s.stateRoot, request.Image),
+				CreatedAt: s.now(),
+			}, nil
+		},
+	)
+	if err != nil {
+		return agentprotocol.LeaseDevicesResponse{}, err
+	}
+	return agentprotocol.LeaseDevicesResponse{
+		LeaseID: lease.LeaseID, RootfsDev: lease.RootfsDev, MemDev: lease.MemDev,
+		ManifestDigest: s.manifestDigestFor(lease.Image),
+	}, nil
+}
+
+// ReleaseDevices drops a device lease.
+func (s *Service) ReleaseDevices(_ context.Context, request agentprotocol.ReleaseDevicesRequest) error {
+	return s.state.ReleaseDevices(request.Identity, request.LeaseID)
+}
+
+// ListLeases returns every lease on the node.
+func (s *Service) ListLeases(_ context.Context, _ agentprotocol.Identity) ([]agentprotocol.Lease, error) {
+	return s.state.Snapshot().Leases, nil
+}
+
+// Compatibility returns the stage-1 placeholder compatibility class.
+func (s *Service) Compatibility(_ context.Context) (string, error) {
+	return compatibilityPlaceholder, nil
+}
+
+// Health reports the agent state and the cache footprint.
+func (s *Service) Health(_ context.Context) (agentprotocol.HealthResponse, error) {
+	snapshot := s.state.Snapshot()
+	return agentprotocol.HealthResponse{
+		OK:         true,
+		CacheBytes: cacheBytes(s.stateRoot),
+		LeaseCount: snapshot.LeaseCount,
+		PinCount:   snapshot.PinCount,
+		ImageCount: snapshot.ImageCount,
+	}, nil
+}
+
+// manifestDigestFor re-reads the committed manifest digest of an image.
+func (s *Service) manifestDigestFor(image string) string {
+	digest, ok, err := agentpull.CachedManifestDigest(s.stateRoot, image)
+	if err != nil || !ok {
+		return ""
+	}
+	return digest
+}
+
+// ensureImage pulls the image unless the cache already holds a committed
+// pull. A missing published index maps to ErrImageNotReady for the driver.
+func (s *Service) ensureImage(ctx context.Context, image string) error {
+	ready, err := agentpull.ImageReady(s.stateRoot, image)
+	if err != nil {
+		return err
+	}
+	if ready {
+		return nil
+	}
+	if err := s.pull.PullImage(ctx, s.stateRoot, image); err != nil {
+		return err
+	}
+	ready, err = agentpull.ImageReady(s.stateRoot, image)
+	if err != nil {
+		return err
+	}
+	if !ready {
+		return fmt.Errorf("%w: %q", runtimecontract.ErrImageNotReady, image)
+	}
+	return nil
+}
+
+// imageMemoryPath returns the cached native memory snapshot path of an
+// image, or "" when the artifact set has none.
+func imageMemoryPath(stateRoot, image string) string {
+	path := filepath.Join(filepath.Dir(agentpull.ImageRootfsPath(stateRoot, image)), "memory.snap")
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		return path
+	}
+	return ""
+}
+
+var _ Backend = (*Service)(nil)

--- a/internal/runtime/firecracker/agent/server/service.go
+++ b/internal/runtime/firecracker/agent/server/service.go
@@ -91,13 +91,12 @@ func (s *Service) LeaseDevices(ctx context.Context, request agentprotocol.LeaseD
 		request.Identity, request.SandboxID, request.Image,
 		request.MemSizeMiB, request.RootfsWritable,
 		func(leaseID string) (agentprotocol.Lease, error) {
+			// ensureImage verifies a committed pull (cacheComplete checks
+			// the manifest and every artifact digest), so the manifest is
+			// known to exist here; the response reads its digest once
+			// below.
 			if err := s.ensureImage(ctx, request.Image); err != nil {
 				return agentprotocol.Lease{}, err
-			}
-			if _, ok, err := agentpull.CachedManifestDigest(s.stateRoot, request.Image); err != nil {
-				return agentprotocol.Lease{}, err
-			} else if !ok {
-				return agentprotocol.Lease{}, fmt.Errorf("image %q committed without a local manifest", request.Image)
 			}
 			return agentprotocol.Lease{
 				LeaseID: leaseID, SandboxID: request.SandboxID, Image: request.Image,

--- a/internal/runtime/firecracker/agent/state/journal.go
+++ b/internal/runtime/firecracker/agent/state/journal.go
@@ -1,0 +1,137 @@
+package state
+
+// The journal is an append-only JSON line log ordering every mutating RPC:
+// an intent line is fsynced before the side effect runs, a result line
+// after it commits. Recovery replays completed pairs in file order and
+// drops intents without results (crashes mid-execution). The only
+// legitimate malformed content is a trailing partial line from a crash
+// mid-append, which is truncated; mid-file corruption fails recovery.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// journalEntry is the wire shape of both line kinds: an intent carries
+// Args (and no Result), a result carries Result (and no Args). The pair is
+// matched by RequestID.
+type journalEntry struct {
+	RequestID string          `json:"requestId"`
+	Op        string          `json:"op"`
+	PodUID    string          `json:"podUid,omitempty"`
+	Namespace string          `json:"namespace,omitempty"`
+	Args      json.RawMessage `json:"args,omitempty"`
+	Result    json.RawMessage `json:"result,omitempty"`
+	At        time.Time       `json:"at,omitempty"`
+}
+
+// emptyResultJSON is the result payload of ops without an outcome value.
+var emptyResultJSON = json.RawMessage("{}")
+
+// Op-specific argument and result documents.
+type pinImageArgs struct {
+	Image string `json:"image"`
+}
+
+type pinImageResult struct {
+	ManifestDigest string `json:"manifestDigest"`
+}
+
+type unpinImageArgs struct {
+	Image string `json:"image"`
+}
+
+type leaseDevicesArgs struct {
+	SandboxID      string `json:"sandboxId"`
+	Image          string `json:"image"`
+	MemSizeMiB     int    `json:"memSizeMiB"`
+	RootfsWritable bool   `json:"rootfsWritable"`
+}
+
+type releaseDevicesArgs struct {
+	LeaseID string `json:"leaseId"`
+}
+
+// journal is the append-only JSON line log.
+type journal struct {
+	path string
+	file *os.File
+}
+
+// openJournal creates the journal directory and opens the log for appending.
+func openJournal(path string) (*journal, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("prepare agent journal directory: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		return nil, fmt.Errorf("open agent journal: %w", err)
+	}
+	return &journal{path: path, file: file}, nil
+}
+
+// append writes one line and flushes it to disk before returning.
+func (j *journal) append(entry journalEntry) error {
+	payload, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	if _, err := j.file.Write(payload); err != nil {
+		return err
+	}
+	return j.file.Sync()
+}
+
+// replay reads the log and visits every complete line in order. A trailing
+// line without a newline (a crash mid-append) is reported so the caller can
+// truncate it; a malformed line elsewhere is a genuine corruption and fails
+// the replay.
+func (j *journal) replay(visit func(journalEntry) error) (truncateLength int64, err error) {
+	payload, err := os.ReadFile(j.path)
+	if err != nil {
+		return 0, err
+	}
+	complete := payload
+	if len(payload) > 0 && payload[len(payload)-1] != '\n' {
+		// A final segment without a newline: a partial write from a
+		// crash. It is dropped and the log is truncated below.
+		truncateLength = int64(bytes.LastIndexByte(payload, '\n') + 1)
+		complete = payload[:truncateLength]
+	}
+	for _, line := range bytes.Split(complete, []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var entry journalEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			return 0, fmt.Errorf("agent journal %s: corrupt line: %w", j.path, err)
+		}
+		if err := visit(entry); err != nil {
+			return 0, err
+		}
+	}
+	return truncateLength, nil
+}
+
+// truncate resizes the log to length, dropping a trailing partial line.
+func (j *journal) truncate(length int64) error {
+	if length <= 0 {
+		length = 0
+	}
+	return os.Truncate(j.path, length)
+}
+
+func (j *journal) close() error {
+	if j.file == nil {
+		return nil
+	}
+	err := j.file.Close()
+	j.file = nil
+	return err
+}

--- a/internal/runtime/firecracker/agent/state/leases.go
+++ b/internal/runtime/firecracker/agent/state/leases.go
@@ -319,6 +319,14 @@ func (s *State) GetLease(leaseID string) (agentprotocol.Lease, bool) {
 // run is the generic two-phase journaled execution shared by the mutating
 // RPCs: completed-request replay, in-flight dedup, intent journal, side
 // effect, in-memory apply, result journal, completion record.
+//
+// Self-healing window: the in-memory apply runs before the result line is
+// durable. If that result write fails (disk failure), the process memory is
+// changed but the journal holds only the intent — after a crash the op is
+// dropped, its idempotency key with it, and a replay re-executes the side
+// effect. Re-execution is safe: pulls are idempotent, leases are rebuilt
+// under a fresh lease id, and the in-memory counts die with the process.
+// The failed caller still sees an error and can retry.
 func (s *State) run(id agentprotocol.Identity, op Op, args any, do func() (any, error), apply func(result any)) (any, error) {
 	s.mu.Lock()
 	if entry, ok := s.completed[id.RequestID]; ok {

--- a/internal/runtime/firecracker/agent/state/leases.go
+++ b/internal/runtime/firecracker/agent/state/leases.go
@@ -1,0 +1,578 @@
+// Package state implements the durable lease and reference-count state of
+// the firecracker-runtime-agent (implementation plan §5):
+//
+//   - per-Sandbox device leases (native stage: cache file paths);
+//   - per-image reference counts (pin count + active lease count);
+//   - an append-only JSON journal that orders every mutating RPC — the
+//     intent line is durable before the side effect runs, the result line
+//     after it commits (two-phase commit) — so replays return the first
+//     execution's outcome exactly once and crash recovery rebuilds the
+//     lease table and the idempotency cache.
+//
+// Every completed mutating RPC is bound to the caller PodUID: a replay of
+// the same request id, or a release of a foreign lease, by a different pod
+// fails with ErrConflict.
+package state
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	agentprotocol "fast-sandbox/internal/runtime/firecracker/agent/protocol"
+)
+
+// Op identifies a journaled mutating RPC.
+type Op string
+
+const (
+	OpPinImage       Op = "pin-image"
+	OpUnpinImage     Op = "unpin-image"
+	OpLeaseDevices   Op = "lease-devices"
+	OpReleaseDevices Op = "release-devices"
+)
+
+// JournalFileName is the append-only journal under the StateRoot.
+const JournalFileName = "journal.log"
+
+// Sentinel errors the server maps onto protocol error codes.
+var (
+	// ErrConflict reports an idempotency key or ownership mismatch: the
+	// request id was already committed by a different pod, or the op
+	// collides with state owned by another pod.
+	ErrConflict = errors.New("conflict")
+	// ErrLeaseNotFound reports that a release or lookup targeted a lease
+	// the agent does not know.
+	ErrLeaseNotFound = errors.New("lease not found")
+)
+
+// Options configures the state for tests.
+type Options struct {
+	Now  func() time.Time
+	UUID func() (string, error)
+}
+
+// Option is a functional state option.
+type Option func(*Options)
+
+// WithNow overrides the clock.
+func WithNow(now func() time.Time) Option {
+	return func(options *Options) { options.Now = now }
+}
+
+// WithUUID overrides the lease id generator.
+func WithUUID(uuid func() (string, error)) Option {
+	return func(options *Options) { options.UUID = uuid }
+}
+
+// imageRefs tracks how many independent references keep an image cached.
+type imageRefs struct {
+	pinCount   int
+	leaseCount int
+}
+
+// completed is the cached outcome of a committed mutating RPC.
+type completed struct {
+	op        Op
+	podUID    string
+	namespace string
+	pinDigest string
+	lease     *agentprotocol.Lease
+}
+
+// inflight deduplicates concurrent calls with the same request id: the
+// first caller runs the side effect, the rest wait for its outcome.
+type inflight struct {
+	done   chan struct{}
+	result any
+	err    error
+}
+
+// State owns the lease table, the image reference counts, and the journal.
+type State struct {
+	mu         sync.Mutex
+	now        func() time.Time
+	uuid       func() (string, error)
+	journal    *journal
+	leases     map[string]agentprotocol.Lease
+	bySandbox  map[string]string
+	sandboxKey map[string]*sync.Mutex
+	images     map[string]*imageRefs
+	completed  map[string]completed
+	inflight   map[string]*inflight
+}
+
+// New loads (or creates) the journal under stateRoot and rebuilds the lease
+// table, reference counts, and idempotency cache from its completed entries.
+func New(stateRoot string, options ...Option) (*State, error) {
+	config := Options{}
+	for _, option := range options {
+		option(&config)
+	}
+	if config.Now == nil {
+		config.Now = time.Now
+	}
+	if config.UUID == nil {
+		config.UUID = newUUID
+	}
+	journalDir := filepath.Join(stateRoot, "agent")
+	journal, err := openJournal(filepath.Join(journalDir, JournalFileName))
+	if err != nil {
+		return nil, err
+	}
+	state := &State{
+		now: config.Now, uuid: config.UUID, journal: journal,
+		leases: make(map[string]agentprotocol.Lease), bySandbox: make(map[string]string),
+		sandboxKey: make(map[string]*sync.Mutex), images: make(map[string]*imageRefs),
+		completed: make(map[string]completed), inflight: make(map[string]*inflight),
+	}
+	if err := state.recover(); err != nil {
+		_ = journal.close()
+		return nil, err
+	}
+	return state, nil
+}
+
+// Close flushes and closes the journal.
+func (s *State) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.journal.close()
+}
+
+// HealthSnapshot is the read-only view of the agent state.
+type HealthSnapshot struct {
+	Leases     []agentprotocol.Lease
+	LeaseCount int
+	PinCount   int
+	ImageCount int
+}
+
+// Snapshot returns the current leases and reference-count totals.
+func (s *State) Snapshot() HealthSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot := HealthSnapshot{
+		Leases:     make([]agentprotocol.Lease, 0, len(s.leases)),
+		LeaseCount: len(s.leases),
+		ImageCount: len(s.images),
+	}
+	for _, lease := range s.leases {
+		snapshot.Leases = append(snapshot.Leases, lease)
+	}
+	for _, refs := range s.images {
+		snapshot.PinCount += refs.pinCount
+	}
+	return snapshot
+}
+
+// PinImage records one pin reference for an image. Replaying a completed
+// request id returns the recorded manifest digest without re-executing the
+// side effect; a concurrent duplicate waits for the in-flight execution.
+// The do callback runs outside the state lock (a multi-GiB pull must not
+// block other RPCs) and must return the pinned manifest digest.
+func (s *State) PinImage(id agentprotocol.Identity, image string, do func() (string, error)) (string, error) {
+	result, err := s.run(id, OpPinImage, pinImageArgs{Image: image}, func() (any, error) {
+		digest, err := do()
+		if err != nil {
+			return nil, err
+		}
+		return pinImageResult{ManifestDigest: digest}, nil
+	}, func(result any) {
+		if s.images[image] == nil {
+			s.images[image] = &imageRefs{}
+		}
+		s.images[image].pinCount++
+	})
+	if err != nil {
+		return "", err
+	}
+	digest, _ := result.(pinImageResult)
+	return digest.ManifestDigest, nil
+}
+
+// UnpinImage drops one pin reference of an image. The count is clamped at
+// zero; unpinning an unknown or unpinned image is a no-op (but still
+// journaled so the request id stays idempotent).
+func (s *State) UnpinImage(id agentprotocol.Identity, image string) error {
+	_, err := s.run(id, OpUnpinImage, unpinImageArgs{Image: image}, func() (any, error) {
+		return nil, nil
+	}, func(result any) {
+		if refs := s.images[image]; refs != nil {
+			refs.pinCount--
+			if refs.pinCount < 0 {
+				refs.pinCount = 0
+			}
+		}
+	})
+	return err
+}
+
+// LeaseDevices leases the devices (native stage: cache file paths) of an
+// image for one Sandbox. The same request id replays the recorded lease;
+// a different request id for the same sandbox id returns the existing
+// lease (business idempotency, matching the driver's EnsureSandbox). The
+// do callback runs outside the state lock and receives the generated lease
+// id; it must return the complete lease record (paths, manifest digest).
+func (s *State) LeaseDevices(id agentprotocol.Identity, sandboxID, image string, memSizeMiB int, rootfsWritable bool, do func(leaseID string) (agentprotocol.Lease, error)) (agentprotocol.Lease, error) {
+	// The sandbox business key serializes concurrent leases of the same
+	// Sandbox: exactly one lease is created and every later request (any
+	// request id) returns it.
+	key := s.sandboxLock(sandboxID)
+	key.Lock()
+	defer key.Unlock()
+
+	s.mu.Lock()
+	if existing, ok := s.bySandbox[sandboxID]; ok {
+		lease := s.leases[existing]
+		s.mu.Unlock()
+		if lease.PodUID != id.PodUID {
+			return agentprotocol.Lease{}, conflictf("sandbox %q is leased by pod %s", sandboxID, lease.PodUID)
+		}
+		if err := s.rememberCompleted(id, OpLeaseDevices, &lease); err != nil {
+			return agentprotocol.Lease{}, err
+		}
+		return lease, nil
+	}
+	s.mu.Unlock()
+
+	result, err := s.run(id, OpLeaseDevices, leaseDevicesArgs{
+		SandboxID: sandboxID, Image: image, MemSizeMiB: memSizeMiB, RootfsWritable: rootfsWritable,
+	}, func() (any, error) {
+		leaseID, err := s.uuid()
+		if err != nil {
+			return nil, err
+		}
+		return do(leaseID)
+	}, func(result any) {
+		lease := result.(agentprotocol.Lease)
+		s.leases[lease.LeaseID] = lease
+		s.bySandbox[lease.SandboxID] = lease.LeaseID
+		if s.images[lease.Image] == nil {
+			s.images[lease.Image] = &imageRefs{}
+		}
+		s.images[lease.Image].leaseCount++
+	})
+	if err != nil {
+		return agentprotocol.Lease{}, err
+	}
+	lease, _ := result.(agentprotocol.Lease)
+	return lease, nil
+}
+
+// sandboxLock returns (creating as needed) the per-Sandbox serialization
+// lock.
+func (s *State) sandboxLock(sandboxID string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := s.sandboxKey[sandboxID]
+	if key == nil {
+		key = &sync.Mutex{}
+		s.sandboxKey[sandboxID] = key
+	}
+	return key
+}
+
+// ReleaseDevices drops a device lease. The caller must own the lease: a
+// release by a different pod fails with ErrConflict.
+func (s *State) ReleaseDevices(id agentprotocol.Identity, leaseID string) error {
+	s.mu.Lock()
+	lease, ok := s.leases[leaseID]
+	if ok && lease.PodUID != id.PodUID {
+		s.mu.Unlock()
+		return conflictf("lease %q is owned by pod %s", leaseID, lease.PodUID)
+	}
+	s.mu.Unlock()
+
+	_, err := s.run(id, OpReleaseDevices, releaseDevicesArgs{LeaseID: leaseID}, func() (any, error) {
+		return nil, nil
+	}, func(result any) {
+		lease, ok := s.leases[leaseID]
+		if !ok {
+			return
+		}
+		delete(s.leases, leaseID)
+		delete(s.bySandbox, lease.SandboxID)
+		if refs := s.images[lease.Image]; refs != nil {
+			refs.leaseCount--
+			if refs.leaseCount < 0 {
+				refs.leaseCount = 0
+			}
+		}
+	})
+	return err
+}
+
+// GetLease returns a lease by id (for ListLeases and ownership checks).
+func (s *State) GetLease(leaseID string) (agentprotocol.Lease, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lease, ok := s.leases[leaseID]
+	return lease, ok
+}
+
+// run is the generic two-phase journaled execution shared by the mutating
+// RPCs: completed-request replay, in-flight dedup, intent journal, side
+// effect, in-memory apply, result journal, completion record.
+func (s *State) run(id agentprotocol.Identity, op Op, args any, do func() (any, error), apply func(result any)) (any, error) {
+	s.mu.Lock()
+	if entry, ok := s.completed[id.RequestID]; ok {
+		s.mu.Unlock()
+		if entry.op != op {
+			return nil, conflictf("request id %q was already committed as %s", id.RequestID, entry.op)
+		}
+		if entry.podUID != id.PodUID {
+			return nil, conflictf("request id %q was committed by pod %s", id.RequestID, entry.podUID)
+		}
+		return entry.result(), nil
+	}
+	if pending, ok := s.inflight[id.RequestID]; ok {
+		s.mu.Unlock()
+		<-pending.done
+		return pending.result, pending.err
+	}
+	if err := s.journalAppendLocked(journalEntry{
+		RequestID: id.RequestID, Op: string(op), PodUID: id.PodUID, Namespace: id.Namespace,
+		Args: mustJSON(args), At: s.now(),
+	}); err != nil {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("journal %s intent: %w", op, err)
+	}
+	pending := &inflight{done: make(chan struct{})}
+	s.inflight[id.RequestID] = pending
+	s.mu.Unlock()
+
+	result, err := do()
+	if err != nil {
+		s.finish(id.RequestID, pending, nil, err)
+		return nil, err
+	}
+
+	// The apply must never leave the state lock held, even on a panic.
+	s.mu.Lock()
+	committed := false
+	defer func() {
+		if !committed {
+			s.mu.Unlock()
+		}
+	}()
+	apply(result)
+	entry := completed{op: op, podUID: id.PodUID, namespace: id.Namespace}
+	entry.setResult(result)
+	s.completed[id.RequestID] = entry
+	resultPayload := mustJSON(result)
+	if result == nil {
+		resultPayload = emptyResultJSON
+	}
+	if err := s.journalAppendLocked(journalEntry{
+		RequestID: id.RequestID, Op: string(op), Result: resultPayload, At: s.now(),
+	}); err != nil {
+		committed = true
+		s.mu.Unlock()
+		s.finish(id.RequestID, pending, nil, fmt.Errorf("journal %s result: %w", op, err))
+		return nil, err
+	}
+	committed = true
+	s.mu.Unlock()
+	s.finish(id.RequestID, pending, result, nil)
+	return result, nil
+}
+
+// finish removes the in-flight marker and wakes waiters.
+func (s *State) finish(requestID string, pending *inflight, result any, err error) {
+	s.mu.Lock()
+	delete(s.inflight, requestID)
+	s.mu.Unlock()
+	pending.result = result
+	pending.err = err
+	close(pending.done)
+}
+
+// rememberCompleted records an idempotent replay of an existing lease so a
+// later retry of the same request id returns the same lease without
+// touching the journal.
+func (s *State) rememberCompleted(id agentprotocol.Identity, op Op, lease *agentprotocol.Lease) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.completed[id.RequestID]; ok {
+		if existing.podUID != id.PodUID {
+			return conflictf("request id %q was committed by pod %s", id.RequestID, existing.podUID)
+		}
+		return nil
+	}
+	s.completed[id.RequestID] = completed{op: op, podUID: id.PodUID, namespace: id.Namespace, lease: lease}
+	return nil
+}
+
+// recover replays the journal in file order: an intent line with a
+// following result line is a committed op and its effect is rebuilt; an
+// intent without a result is a crash mid-execution and is dropped. A
+// trailing partial line (crash mid-append) truncates the log.
+func (s *State) recover() error {
+	intents := make(map[string]journalEntry)
+	truncateLength, err := s.journal.replay(func(entry journalEntry) error {
+		if len(entry.Result) == 0 {
+			if entry.RequestID == "" {
+				return nil
+			}
+			intents[entry.RequestID] = entry
+			return nil
+		}
+		intent, ok := intents[entry.RequestID]
+		delete(intents, entry.RequestID)
+		if !ok {
+			return nil
+		}
+		return s.replayApply(intent, entry)
+	})
+	if err != nil {
+		return err
+	}
+	if truncateLength > 0 {
+		if err := s.journal.truncate(truncateLength); err != nil {
+			return fmt.Errorf("truncate agent journal tail: %w", err)
+		}
+	}
+	return nil
+}
+
+// replayApply rebuilds the effect of one committed journal entry pair.
+func (s *State) replayApply(intent, result journalEntry) error {
+	op := Op(intent.Op)
+	completed := completed{op: op, podUID: intent.PodUID, namespace: intent.Namespace}
+	switch op {
+	case OpPinImage:
+		var args pinImageArgs
+		if err := json.Unmarshal(intent.Args, &args); err != nil {
+			return fmt.Errorf("journal: decode %s intent: %w", op, err)
+		}
+		if err := s.bumpPin(args.Image, 1); err != nil {
+			return err
+		}
+		var response pinImageResult
+		if err := json.Unmarshal(result.Result, &response); err != nil {
+			return fmt.Errorf("journal: decode %s result: %w", op, err)
+		}
+		completed.pinDigest = response.ManifestDigest
+	case OpUnpinImage:
+		var args unpinImageArgs
+		if err := json.Unmarshal(intent.Args, &args); err != nil {
+			return fmt.Errorf("journal: decode %s intent: %w", op, err)
+		}
+		if err := s.bumpPin(args.Image, -1); err != nil {
+			return err
+		}
+	case OpLeaseDevices:
+		var lease agentprotocol.Lease
+		if err := json.Unmarshal(result.Result, &lease); err != nil {
+			return fmt.Errorf("journal: decode %s result: %w", op, err)
+		}
+		s.leases[lease.LeaseID] = lease
+		s.bySandbox[lease.SandboxID] = lease.LeaseID
+		if s.images[lease.Image] == nil {
+			s.images[lease.Image] = &imageRefs{}
+		}
+		s.images[lease.Image].leaseCount++
+		completed.lease = &lease
+	case OpReleaseDevices:
+		var args releaseDevicesArgs
+		if err := json.Unmarshal(intent.Args, &args); err != nil {
+			return fmt.Errorf("journal: decode %s intent: %w", op, err)
+		}
+		lease, ok := s.leases[args.LeaseID]
+		if ok {
+			delete(s.leases, args.LeaseID)
+			delete(s.bySandbox, lease.SandboxID)
+			if refs := s.images[lease.Image]; refs != nil {
+				refs.leaseCount--
+			}
+		}
+	default:
+		return fmt.Errorf("journal: unknown op %q", op)
+	}
+	s.completed[intent.RequestID] = completed
+	return nil
+}
+
+// bumpPin adjusts an image's pin count, creating the entry as needed and
+// clamping at zero.
+func (s *State) bumpPin(image string, delta int) error {
+	if image == "" {
+		return fmt.Errorf("journal: pin op without image")
+	}
+	refs := s.images[image]
+	if refs == nil {
+		refs = &imageRefs{}
+		s.images[image] = refs
+	}
+	refs.pinCount += delta
+	if refs.pinCount < 0 {
+		refs.pinCount = 0
+	}
+	return nil
+}
+
+// journalAppendLocked writes one line and fsyncs it. The caller holds the
+// state lock, so the intent/result pair stays ordered relative to every
+// other state mutation.
+func (s *State) journalAppendLocked(entry journalEntry) error {
+	return s.journal.append(entry)
+}
+
+// completedResult returns the typed outcome of a completed op for replay.
+func (c completed) result() any {
+	switch c.op {
+	case OpPinImage:
+		return pinImageResult{ManifestDigest: c.pinDigest}
+	case OpLeaseDevices:
+		if c.lease != nil {
+			return *c.lease
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+// setResult stores the typed outcome of a completed op.
+func (c *completed) setResult(result any) {
+	switch c.op {
+	case OpPinImage:
+		if pin, ok := result.(pinImageResult); ok {
+			c.pinDigest = pin.ManifestDigest
+		}
+	case OpLeaseDevices:
+		if lease, ok := result.(agentprotocol.Lease); ok {
+			c.lease = &lease
+		}
+	}
+}
+
+// newUUID returns a random UUID v4 without external dependencies.
+func newUUID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	raw[6] = (raw[6] & 0x0f) | 0x40
+	raw[8] = (raw[8] & 0x3f) | 0x80
+	hexed := hex.EncodeToString(raw[:])
+	return hexed[0:8] + "-" + hexed[8:12] + "-" + hexed[12:16] + "-" + hexed[16:20] + "-" + hexed[20:32], nil
+}
+
+func conflictf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrConflict, fmt.Sprintf(format, args...))
+}
+
+func mustJSON(value any) []byte {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}

--- a/internal/runtime/firecracker/agent/state/leases_test.go
+++ b/internal/runtime/firecracker/agent/state/leases_test.go
@@ -1,0 +1,407 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	agentprotocol "fast-sandbox/internal/runtime/firecracker/agent/protocol"
+
+	"github.com/stretchr/testify/require"
+)
+
+var fixedTime = time.Unix(1720000000, 0)
+
+func newTestState(t *testing.T) *State {
+	t.Helper()
+	state, err := New(t.TempDir(), WithNow(func() time.Time { return fixedTime }))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = state.Close() })
+	return state
+}
+
+func identity(requestID, podUID string) agentprotocol.Identity {
+	return agentprotocol.Identity{RequestID: requestID, Namespace: "tenant-a", PodUID: podUID}
+}
+
+func pinDigest(image string) string { return "sha256:" + image }
+
+func TestPinImageLifecycleAndReplay(t *testing.T) {
+	state := newTestState(t)
+
+	calls := 0
+	digest, err := state.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		calls++
+		return pinDigest("img-a"), nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, pinDigest("img-a"), digest)
+
+	// Replay of the same request id returns the recorded digest without
+	// re-executing the side effect.
+	digest, err = state.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		calls++
+		return "", errors.New("must not run")
+	})
+	require.NoError(t, err)
+	require.Equal(t, pinDigest("img-a"), digest)
+	require.Equal(t, 1, calls)
+
+	snapshot := state.Snapshot()
+	require.Equal(t, 1, snapshot.PinCount)
+	require.Equal(t, 1, snapshot.ImageCount)
+
+	require.NoError(t, state.UnpinImage(identity("req-2", "pod-1"), "img-a"))
+	require.Equal(t, 0, state.Snapshot().PinCount)
+}
+
+func TestPinImageIdempotentReplayAcrossRestart(t *testing.T) {
+	root := t.TempDir()
+	first, err := New(root, WithNow(func() time.Time { return fixedTime }))
+	require.NoError(t, err)
+	digest, err := first.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		return pinDigest("img-a"), nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	recovered, err := New(root, WithNow(func() time.Time { return fixedTime }))
+	require.NoError(t, err)
+	defer recovered.Close()
+	calls := 0
+	replayed, err := recovered.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		calls++
+		return "", errors.New("must not run")
+	})
+	require.NoError(t, err)
+	require.Equal(t, digest, replayed)
+	require.Equal(t, 0, calls)
+	require.Equal(t, 1, recovered.Snapshot().PinCount)
+}
+
+func TestPinImageReplayCrossPodConflict(t *testing.T) {
+	state := newTestState(t)
+	_, err := state.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		return pinDigest("img-a"), nil
+	})
+	require.NoError(t, err)
+
+	_, err = state.PinImage(identity("req-1", "pod-2"), "img-a", func() (string, error) {
+		return "", errors.New("must not run")
+	})
+	require.ErrorIs(t, err, ErrConflict)
+}
+
+func TestPinImageReplayDifferentOpConflict(t *testing.T) {
+	state := newTestState(t)
+	_, err := state.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		return pinDigest("img-a"), nil
+	})
+	require.NoError(t, err)
+	require.ErrorIs(t, state.UnpinImage(identity("req-1", "pod-1"), "img-a"), ErrConflict)
+}
+
+func TestPinImageConcurrentDedup(t *testing.T) {
+	state := newTestState(t)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls int
+	var callsMu sync.Mutex
+	var wg sync.WaitGroup
+	results := make([]string, 8)
+	errorsSeen := make([]error, 8)
+	for index := 0; index < len(results); index++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			results[index], errorsSeen[index] = state.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+				callsMu.Lock()
+				calls++
+				callsMu.Unlock()
+				close(started)
+				<-release
+				return pinDigest("img-a"), nil
+			})
+		}(index)
+	}
+	<-started
+	close(release)
+	wg.Wait()
+
+	for index := 0; index < len(results); index++ {
+		require.NoError(t, errorsSeen[index])
+		require.Equal(t, pinDigest("img-a"), results[index])
+	}
+	require.Equal(t, 1, calls)
+	require.Equal(t, 1, state.Snapshot().PinCount)
+}
+
+func TestUnpinImageClampsAtZero(t *testing.T) {
+	root := t.TempDir()
+	state, err := New(root)
+	require.NoError(t, err)
+	require.NoError(t, state.UnpinImage(identity("req-1", "pod-1"), "img-a"))
+	require.NoError(t, state.UnpinImage(identity("req-2", "pod-1"), "img-a"))
+	require.Equal(t, 0, state.Snapshot().PinCount)
+	require.NoError(t, state.Close())
+
+	recovered, err := New(root)
+	require.NoError(t, err)
+	defer recovered.Close()
+	require.Equal(t, 0, recovered.Snapshot().PinCount)
+}
+
+func TestLeaseDevicesLifecycle(t *testing.T) {
+	state := newTestState(t)
+	do := func(leaseID string) (agentprotocol.Lease, error) {
+		return agentprotocol.Lease{
+			LeaseID: leaseID, SandboxID: "sandbox-1", Image: "img-a", PodUID: "pod-1",
+			Namespace: "tenant-a", RootfsDev: "/cache/img-a/rootfs.img", CreatedAt: fixedTime,
+		}, nil
+	}
+	lease, err := state.LeaseDevices(identity("req-1", "pod-1"), "sandbox-1", "img-a", 4096, false, do)
+	require.NoError(t, err)
+	require.NotEmpty(t, lease.LeaseID)
+	require.Equal(t, "sandbox-1", lease.SandboxID)
+
+	// Business idempotency: a different request id for the same sandbox
+	// returns the existing lease without creating a second one.
+	replayed, err := state.LeaseDevices(identity("req-2", "pod-1"), "sandbox-1", "img-a", 4096, false, do)
+	require.NoError(t, err)
+	require.Equal(t, lease, replayed)
+	require.Equal(t, 1, state.Snapshot().LeaseCount)
+	require.Equal(t, 1, state.Snapshot().PinCount+1) // leaseCount contributes 1
+
+	require.NoError(t, state.ReleaseDevices(identity("req-3", "pod-1"), lease.LeaseID))
+	require.Equal(t, 0, state.Snapshot().LeaseCount)
+}
+
+func TestLeaseDevicesCrossPodSandboxConflict(t *testing.T) {
+	state := newTestState(t)
+	do := func(leaseID string) (agentprotocol.Lease, error) {
+		return agentprotocol.Lease{
+			LeaseID: leaseID, SandboxID: "sandbox-1", Image: "img-a", PodUID: "pod-1", RootfsDev: "/r", CreatedAt: fixedTime,
+		}, nil
+	}
+	_, err := state.LeaseDevices(identity("req-1", "pod-1"), "sandbox-1", "img-a", 4096, false, do)
+	require.NoError(t, err)
+	_, err = state.LeaseDevices(identity("req-2", "pod-2"), "sandbox-1", "img-a", 4096, false, do)
+	require.ErrorIs(t, err, ErrConflict)
+}
+
+func TestReleaseDevicesOwnershipConflict(t *testing.T) {
+	state := newTestState(t)
+	do := func(leaseID string) (agentprotocol.Lease, error) {
+		return agentprotocol.Lease{
+			LeaseID: leaseID, SandboxID: "sandbox-1", Image: "img-a", PodUID: "pod-1", RootfsDev: "/r", CreatedAt: fixedTime,
+		}, nil
+	}
+	lease, err := state.LeaseDevices(identity("req-1", "pod-1"), "sandbox-1", "img-a", 4096, false, do)
+	require.NoError(t, err)
+	require.ErrorIs(t, state.ReleaseDevices(identity("req-2", "pod-2"), lease.LeaseID), ErrConflict)
+	require.Equal(t, 1, state.Snapshot().LeaseCount)
+}
+
+func TestReleaseDevicesUnknownLeaseIsNoOp(t *testing.T) {
+	state := newTestState(t)
+	require.NoError(t, state.ReleaseDevices(identity("req-1", "pod-1"), "missing"))
+	require.NoError(t, state.ReleaseDevices(identity("req-1", "pod-1"), "missing"))
+	require.Equal(t, 0, state.Snapshot().LeaseCount)
+}
+
+func TestJournalWritesIntentBeforeExecution(t *testing.T) {
+	root := t.TempDir()
+	state, err := New(root, WithNow(func() time.Time { return fixedTime }))
+	require.NoError(t, err)
+	defer func() { _ = state.Close() }()
+	journalPath := filepath.Join(root, "agent", JournalFileName)
+	_, err = state.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		payload, readErr := os.ReadFile(journalPath)
+		require.NoError(t, readErr)
+		require.Contains(t, string(payload), `"op":"pin-image"`)
+		require.Contains(t, string(payload), `"requestId":"req-1"`)
+		require.NotContains(t, string(payload), `"result"`)
+		return pinDigest("img-a"), nil
+	})
+	require.NoError(t, err)
+	payload, err := os.ReadFile(journalPath)
+	require.NoError(t, err)
+	require.Contains(t, string(payload), `"result"`)
+	require.Contains(t, string(payload), pinDigest("img-a"))
+}
+
+func TestRecoverRebuildsLeasesAndCounts(t *testing.T) {
+	root := t.TempDir()
+	state, err := New(root, WithNow(func() time.Time { return fixedTime }), WithUUID(func() (string, error) { return "lease-1", nil }))
+	require.NoError(t, err)
+	_, err = state.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		return pinDigest("img-a"), nil
+	})
+	require.NoError(t, err)
+	_, err = state.PinImage(identity("req-2", "pod-1"), "img-b", func() (string, error) {
+		return pinDigest("img-b"), nil
+	})
+	require.NoError(t, err)
+	lease, err := state.LeaseDevices(identity("req-3", "pod-1"), "sandbox-1", "img-a", 4096, false, func(leaseID string) (agentprotocol.Lease, error) {
+		return agentprotocol.Lease{
+			LeaseID: leaseID, SandboxID: "sandbox-1", Image: "img-a", PodUID: "pod-1",
+			Namespace: "tenant-a", RootfsDev: "/cache/img-a/rootfs.img", CreatedAt: fixedTime,
+		}, nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Close())
+
+	recovered, err := New(root, WithNow(func() time.Time { return fixedTime }))
+	require.NoError(t, err)
+	defer recovered.Close()
+
+	snapshot := recovered.Snapshot()
+	require.Equal(t, 1, snapshot.LeaseCount)
+	require.Equal(t, 2, snapshot.PinCount)
+	require.Equal(t, 2, snapshot.ImageCount)
+	recoveredLease, ok := recovered.GetLease(lease.LeaseID)
+	require.True(t, ok)
+	require.Equal(t, "sandbox-1", recoveredLease.SandboxID)
+	require.Equal(t, "/cache/img-a/rootfs.img", recoveredLease.RootfsDev)
+	// The lease pins its image on top of the pin count.
+	require.Equal(t, 3, snapshot.PinCount+snapshot.LeaseCount)
+
+	// Release after recovery works against the rebuilt lease.
+	require.NoError(t, recovered.ReleaseDevices(identity("req-4", "pod-1"), lease.LeaseID))
+	require.Equal(t, 0, recovered.Snapshot().LeaseCount)
+	require.Equal(t, 2, recovered.Snapshot().PinCount)
+}
+
+func TestRecoverDropsInFlightIntent(t *testing.T) {
+	root := t.TempDir()
+	state, err := New(root)
+	require.NoError(t, err)
+	journalPath := filepath.Join(root, "agent", JournalFileName)
+	// Simulate a crash after the intent line of a pin that never completed.
+	require.NoError(t, os.WriteFile(journalPath, []byte(
+		`{"requestId":"req-1","op":"pin-image","podUid":"pod-1","namespace":"tenant-a","args":{"image":"img-a"},"at":"2026-08-27T00:00:00Z"}`+"\n",
+	), 0o640))
+	require.NoError(t, state.Close())
+
+	recovered, err := New(root)
+	require.NoError(t, err)
+	defer recovered.Close()
+	require.Equal(t, 0, recovered.Snapshot().PinCount)
+	// The dropped intent is not idempotent: the op can run again.
+	digest, err := recovered.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		return pinDigest("img-a"), nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, pinDigest("img-a"), digest)
+}
+
+func TestRecoverTruncatesPartialTail(t *testing.T) {
+	root := t.TempDir()
+	state, err := New(root)
+	require.NoError(t, err)
+	journalPath := filepath.Join(root, "agent", JournalFileName)
+	complete := `{"requestId":"req-1","op":"pin-image","podUid":"pod-1","args":{"image":"img-a"},"at":"2026-08-27T00:00:00Z"}` + "\n" +
+		`{"requestId":"req-1","op":"pin-image","podUid":"pod-1","result":{"manifestDigest":"d"},"at":"2026-08-27T00:00:00Z"}` + "\n"
+	partial := `{"requestId":"req-2","op":"unpin-image","podUid":"pod-1","args":{"image":"img-`
+	require.NoError(t, os.WriteFile(journalPath, []byte(complete+partial), 0o640))
+	require.NoError(t, state.Close())
+
+	recovered, err := New(root)
+	require.NoError(t, err)
+	defer recovered.Close()
+	require.Equal(t, 1, recovered.Snapshot().PinCount)
+	require.Equal(t, 1, recovered.Snapshot().ImageCount)
+	payload, err := os.ReadFile(journalPath)
+	require.NoError(t, err)
+	require.Equal(t, complete, string(payload))
+}
+
+func TestRecoverFailsOnMidFileCorruption(t *testing.T) {
+	root := t.TempDir()
+	state, err := New(root)
+	require.NoError(t, err)
+	journalPath := filepath.Join(root, "agent", JournalFileName)
+	require.NoError(t, os.WriteFile(journalPath, []byte(
+		`{"requestId":"req-1","op":"pin-image","podUid":"pod-1","args":{"image":"img-a"},"at":"2026-08-27T00:00:00Z"}`+"\n"+
+			"this is not json\n"+
+			`{"requestId":"req-2","op":"pin-image","podUid":"pod-1","args":{"image":"img-b"},"at":"2026-08-27T00:00:00Z"}`+"\n",
+	), 0o640))
+	require.NoError(t, state.Close())
+
+	_, err = New(root)
+	require.Error(t, err)
+}
+
+func TestSnapshotHealthCounts(t *testing.T) {
+	state := newTestState(t)
+	_, err := state.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		return pinDigest("img-a"), nil
+	})
+	require.NoError(t, err)
+	_, err = state.PinImage(identity("req-2", "pod-1"), "img-a", func() (string, error) {
+		return pinDigest("img-a"), nil
+	})
+	require.NoError(t, err)
+	_, err = state.LeaseDevices(identity("req-3", "pod-1"), "sandbox-1", "img-a", 4096, false, func(leaseID string) (agentprotocol.Lease, error) {
+		return agentprotocol.Lease{
+			LeaseID: leaseID, SandboxID: "sandbox-1", Image: "img-a", PodUID: "pod-1", RootfsDev: "/r", CreatedAt: fixedTime,
+		}, nil
+	})
+	require.NoError(t, err)
+
+	snapshot := state.Snapshot()
+	require.Equal(t, 1, snapshot.ImageCount)
+	require.Equal(t, 1, snapshot.LeaseCount)
+	require.Equal(t, 2, snapshot.PinCount)
+	require.Len(t, snapshot.Leases, 1)
+}
+
+func TestFailedSideEffectIsRetryable(t *testing.T) {
+	state := newTestState(t)
+	calls := 0
+	_, err := state.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		calls++
+		return "", fmt.Errorf("transient failure")
+	})
+	require.Error(t, err)
+	require.Equal(t, 0, state.Snapshot().PinCount)
+
+	digest, err := state.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		calls++
+		return pinDigest("img-a"), nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, pinDigest("img-a"), digest)
+	require.Equal(t, 2, calls)
+	require.Equal(t, 1, state.Snapshot().PinCount)
+}
+
+func TestJournalReplayOrderingAcrossOps(t *testing.T) {
+	root := t.TempDir()
+	state, err := New(root, WithUUID(func() (string, error) { return "lease-1", nil }))
+	require.NoError(t, err)
+	_, err = state.PinImage(identity("req-1", "pod-1"), "img-a", func() (string, error) {
+		return pinDigest("img-a"), nil
+	})
+	require.NoError(t, err)
+	lease, err := state.LeaseDevices(identity("req-2", "pod-1"), "sandbox-1", "img-a", 4096, false, func(leaseID string) (agentprotocol.Lease, error) {
+		return agentprotocol.Lease{
+			LeaseID: leaseID, SandboxID: "sandbox-1", Image: "img-a", PodUID: "pod-1", RootfsDev: "/r", CreatedAt: fixedTime,
+		}, nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.ReleaseDevices(identity("req-3", "pod-1"), lease.LeaseID))
+	require.NoError(t, state.Close())
+
+	recovered, err := New(root)
+	require.NoError(t, err)
+	defer recovered.Close()
+	snapshot := recovered.Snapshot()
+	require.Equal(t, 0, snapshot.LeaseCount)
+	require.Equal(t, 1, snapshot.PinCount)
+}

--- a/internal/runtime/firecracker/agent_client.go
+++ b/internal/runtime/firecracker/agent_client.go
@@ -1,0 +1,200 @@
+package firecracker
+
+// agent_client.go is the driver's view of the node-level
+// firecracker-runtime-agent (implementation plan §6): a JSON-over-HTTP
+// client over the UDS socket. The driver stays in "local mode" (no agent,
+// no remote pull) when no socket is configured, and falls back to the
+// local cache check when the agent is unreachable — warmImages and cold
+// boots must not depend on agent availability.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	fastletapi "fast-sandbox/internal/protocol/fastlet"
+	runtimecontract "fast-sandbox/internal/runtime/contract"
+	agentprotocol "fast-sandbox/internal/runtime/firecracker/agent/protocol"
+)
+
+// Lease is the driver-side view of a runtime-agent device lease.
+type Lease = agentprotocol.Lease
+
+// errAgentUnreachable marks transport-level failures (socket missing,
+// dial/read errors) of the agent client; the driver treats them as "agent
+// absent" and falls back to local behavior.
+var errAgentUnreachable = errors.New("runtime-agent unreachable")
+
+// maxAgentResponseBytes bounds a decoded agent response body.
+const maxAgentResponseBytes = 4 << 20
+
+// AgentClient is the driver's view of the runtime-agent (testable via fake
+// injection).
+type AgentClient interface {
+	// PinImage pulls and pins an image on the node, returning its manifest
+	// digest. Replays of requestID are idempotent.
+	PinImage(ctx context.Context, requestID, image string) (string, error)
+	// UnpinImage drops one pin reference of an image.
+	UnpinImage(ctx context.Context, requestID, image string) error
+	// LeaseDevices creates a device lease for a Sandbox. The native stage
+	// returns the shared cache file paths.
+	LeaseDevices(ctx context.Context, requestID string, spec *fastletapi.SandboxSpec) (Lease, error)
+	// ReleaseDevices drops a device lease owned by this pod.
+	ReleaseDevices(ctx context.Context, requestID, leaseID string) error
+	// ListLeases returns every lease on the node.
+	ListLeases(ctx context.Context) ([]Lease, error)
+	// Compatibility returns the node compatibility class.
+	Compatibility(ctx context.Context) (string, error)
+	// Health verifies the agent is serving.
+	Health(ctx context.Context) error
+}
+
+// agentHTTPClient implements AgentClient over the UDS socket.
+type agentHTTPClient struct {
+	client    *http.Client
+	namespace string
+	podUID    string
+}
+
+// NewAgentClient builds the UDS HTTP client of the runtime-agent. The
+// caller identity (namespace + podUID) is attached to every request.
+func NewAgentClient(socketPath, namespace, podUID string) (AgentClient, error) {
+	if socketPath == "" {
+		return nil, fmt.Errorf("runtime-agent socket path is required")
+	}
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+		},
+		ForceAttemptHTTP2: false,
+		IdleConnTimeout:   90 * time.Second,
+	}
+	return &agentHTTPClient{
+		client:    &http.Client{Transport: transport},
+		namespace: namespace,
+		podUID:    podUID,
+	}, nil
+}
+
+func (c *agentHTTPClient) PinImage(ctx context.Context, requestID, image string) (string, error) {
+	var response agentprotocol.PinImageResponse
+	if err := c.doJSON(ctx, agentprotocol.RoutePinImage, agentprotocol.PinImageRequest{
+		Identity: c.identity(requestID), Image: image,
+	}, &response); err != nil {
+		return "", err
+	}
+	return response.ManifestDigest, nil
+}
+
+func (c *agentHTTPClient) UnpinImage(ctx context.Context, requestID, image string) error {
+	return c.doJSON(ctx, agentprotocol.RouteUnpinImage, agentprotocol.UnpinImageRequest{
+		Identity: c.identity(requestID), Image: image,
+	}, nil)
+}
+
+func (c *agentHTTPClient) LeaseDevices(ctx context.Context, requestID string, spec *fastletapi.SandboxSpec) (Lease, error) {
+	if spec == nil {
+		return Lease{}, fmt.Errorf("%w: sandbox spec is required", runtimecontract.ErrInvalidConfig)
+	}
+	var response agentprotocol.LeaseDevicesResponse
+	if err := c.doJSON(ctx, agentprotocol.RouteLeaseDevices, agentprotocol.LeaseDevicesRequest{
+		Identity: c.identity(requestID), SandboxID: spec.SandboxID, Image: spec.Image,
+		MemSizeMiB: defaultMemoryMiB(spec.Memory), RootfsWritable: false,
+	}, &response); err != nil {
+		return Lease{}, err
+	}
+	return Lease{
+		LeaseID: response.LeaseID, SandboxID: spec.SandboxID, Image: spec.Image,
+		PodUID: c.podUID, Namespace: c.namespace,
+		RootfsDev: response.RootfsDev, MemDev: response.MemDev, CreatedAt: time.Now(),
+	}, nil
+}
+
+func (c *agentHTTPClient) ReleaseDevices(ctx context.Context, requestID, leaseID string) error {
+	return c.doJSON(ctx, agentprotocol.RouteReleaseDevices, agentprotocol.ReleaseDevicesRequest{
+		Identity: c.identity(requestID), LeaseID: leaseID,
+	}, nil)
+}
+
+func (c *agentHTTPClient) ListLeases(ctx context.Context) ([]Lease, error) {
+	var response agentprotocol.ListLeasesResponse
+	if err := c.doJSON(ctx, agentprotocol.RouteListLeases, c.identity(""), &response); err != nil {
+		return nil, err
+	}
+	return append([]Lease(nil), response.Leases...), nil
+}
+
+func (c *agentHTTPClient) Compatibility(ctx context.Context) (string, error) {
+	var response agentprotocol.CompatibilityResponse
+	if err := c.doJSON(ctx, agentprotocol.RouteCompatibility, c.identity(""), &response); err != nil {
+		return "", err
+	}
+	return response.CompatibilityClass, nil
+}
+
+func (c *agentHTTPClient) Health(ctx context.Context) error {
+	var response agentprotocol.HealthResponse
+	if err := c.doJSON(ctx, agentprotocol.RouteHealth, c.identity(""), &response); err != nil {
+		return err
+	}
+	if !response.OK {
+		return fmt.Errorf("runtime-agent reports unhealthy: leases=%d images=%d", response.LeaseCount, response.ImageCount)
+	}
+	return nil
+}
+
+func (c *agentHTTPClient) identity(requestID string) agentprotocol.Identity {
+	return agentprotocol.Identity{RequestID: requestID, Namespace: c.namespace, PodUID: c.podUID}
+}
+
+// doJSON performs one RPC and maps the wire errors onto runtime contract
+// errors: NotFound -> ErrImageNotReady, Unauthorized/Conflict -> invalid
+// config, transport failures -> errAgentUnreachable.
+func (c *agentHTTPClient) doJSON(ctx context.Context, path string, input, output any) error {
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://firecracker-agent"+path, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := c.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("%w: %v", errAgentUnreachable, err)
+	}
+	defer response.Body.Close()
+	limited := io.LimitReader(response.Body, maxAgentResponseBytes)
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		var wireError agentprotocol.ErrorResponse
+		_ = json.NewDecoder(limited).Decode(&wireError)
+		if wireError.Message == "" {
+			wireError.Message = response.Status
+		}
+		switch {
+		case response.StatusCode == http.StatusNotFound:
+			return fmt.Errorf("%w: %s", runtimecontract.ErrImageNotReady, wireError.Message)
+		case response.StatusCode == http.StatusUnauthorized, response.StatusCode == http.StatusForbidden:
+			return fmt.Errorf("%w: runtime-agent rejected the caller: %s", runtimecontract.ErrInvalidConfig, wireError.Message)
+		case response.StatusCode == http.StatusConflict:
+			return fmt.Errorf("%w: runtime-agent conflict: %s", runtimecontract.ErrInvalidConfig, wireError.Message)
+		default:
+			return fmt.Errorf("runtime-agent %s failed: %s: %s", path, wireError.Code, wireError.Message)
+		}
+	}
+	if output == nil || response.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	if err := json.NewDecoder(limited).Decode(output); err != nil {
+		return fmt.Errorf("decode runtime-agent response: %w", err)
+	}
+	return nil
+}

--- a/internal/runtime/firecracker/agent_client_test.go
+++ b/internal/runtime/firecracker/agent_client_test.go
@@ -1,0 +1,224 @@
+package firecracker
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	fastletapi "fast-sandbox/internal/protocol/fastlet"
+	runtimecontract "fast-sandbox/internal/runtime/contract"
+	agentprotocol "fast-sandbox/internal/runtime/firecracker/agent/protocol"
+
+	"github.com/stretchr/testify/require"
+)
+
+var agentSocketCounter int64
+
+// testAgentSocketPath returns a short Unix socket path (sun_path is
+// bounded) under the OS temp root.
+func testAgentSocketPath(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(os.TempDir(), "fast-sandbox-driver-"+strconv.Itoa(int(atomic.AddInt64(&agentSocketCounter, 1)))+".sock")
+	t.Cleanup(func() { _ = os.Remove(path) })
+	return path
+}
+
+// fakeAgentServer speaks the runtime-agent protocol over a Unix socket and
+// records the decoded requests.
+type fakeAgentServer struct {
+	mu        sync.Mutex
+	socket    string
+	requests  []string
+	responses map[string]func(w http.ResponseWriter, payload []byte)
+}
+
+func newFakeAgentServer(t *testing.T) *fakeAgentServer {
+	t.Helper()
+	server := &fakeAgentServer{socket: testAgentSocketPath(t), responses: make(map[string]func(w http.ResponseWriter, payload []byte))}
+	listener, err := net.Listen("unix", server.socket)
+	require.NoError(t, err)
+	httpServer := &http.Server{Handler: server}
+	go func() { _ = httpServer.Serve(listener) }()
+	t.Cleanup(func() { _ = httpServer.Close() })
+	return server
+}
+
+func (s *fakeAgentServer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	payload, _ := io.ReadAll(request.Body)
+	s.mu.Lock()
+	s.requests = append(s.requests, request.URL.Path+" "+string(payload))
+	handler := s.responses[request.URL.Path]
+	s.mu.Unlock()
+	if handler != nil {
+		handler(writer, payload)
+		return
+	}
+	writer.WriteHeader(http.StatusNoContent)
+}
+
+func (s *fakeAgentServer) recorded() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.requests...)
+}
+
+// wireAgent connects the fake server to the driver fields.
+func (f *driverFixture) wireAgent(t *testing.T, server *fakeAgentServer) {
+	t.Helper()
+	f.driver.newAgentClient = func(string) (AgentClient, error) {
+		return NewAgentClient(server.socket, "tenant-a", "pod-1")
+	}
+	f.driver.agentSocket = server.socket
+}
+
+func TestAgentClientPinImageRequestAndResponse(t *testing.T) {
+	server := newFakeAgentServer(t)
+	server.responses[agentprotocol.RoutePinImage] = func(writer http.ResponseWriter, _ []byte) {
+		_ = json.NewEncoder(writer).Encode(agentprotocol.PinImageResponse{ManifestDigest: "sha256:abc", Ready: true})
+	}
+	client, err := NewAgentClient(server.socket, "tenant-a", "pod-1")
+	require.NoError(t, err)
+
+	digest, err := client.PinImage(context.Background(), "req-1", "registry.example.com/sandbox:v1")
+	require.NoError(t, err)
+	require.Equal(t, "sha256:abc", digest)
+
+	recorded := server.recorded()
+	require.Len(t, recorded, 1)
+	var request agentprotocol.PinImageRequest
+	require.NoError(t, json.Unmarshal([]byte(recorded[0][len(agentprotocol.RoutePinImage)+1:]), &request))
+	require.Equal(t, "req-1", request.RequestID)
+	require.Equal(t, "pod-1", request.PodUID)
+	require.Equal(t, "tenant-a", request.Namespace)
+	require.Equal(t, "registry.example.com/sandbox:v1", request.Image)
+}
+
+func TestAgentClientNotFoundMapsToImageNotReady(t *testing.T) {
+	server := newFakeAgentServer(t)
+	server.responses[agentprotocol.RoutePinImage] = func(writer http.ResponseWriter, _ []byte) {
+		writer.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(writer).Encode(agentprotocol.ErrorResponse{Code: agentprotocol.ErrorNotFound, Message: `image "x" not ready`})
+	}
+	client, err := NewAgentClient(server.socket, "tenant-a", "pod-1")
+	require.NoError(t, err)
+	_, err = client.PinImage(context.Background(), "req-1", "x")
+	require.ErrorIs(t, err, runtimecontract.ErrImageNotReady)
+}
+
+func TestAgentClientAuthFailuresMapToInvalidConfig(t *testing.T) {
+	cases := []struct {
+		status int
+		code   agentprotocol.ErrorCode
+	}{
+		{http.StatusForbidden, agentprotocol.ErrorUnauthorized},
+		{http.StatusConflict, agentprotocol.ErrorConflict},
+	}
+	for _, test := range cases {
+		server := newFakeAgentServer(t)
+		server.responses[agentprotocol.RouteUnpinImage] = func(writer http.ResponseWriter, _ []byte) {
+			writer.WriteHeader(test.status)
+			_ = json.NewEncoder(writer).Encode(agentprotocol.ErrorResponse{Code: test.code, Message: "ownership mismatch"})
+		}
+		client, err := NewAgentClient(server.socket, "tenant-a", "pod-1")
+		require.NoError(t, err)
+		err = client.UnpinImage(context.Background(), "req-1", "x")
+		require.ErrorIs(t, err, runtimecontract.ErrInvalidConfig)
+	}
+}
+
+func TestAgentClientUnreachableSocket(t *testing.T) {
+	client, err := NewAgentClient(testAgentSocketPath(t), "tenant-a", "pod-1")
+	require.NoError(t, err)
+	err = client.Health(context.Background())
+	require.ErrorIs(t, err, errAgentUnreachable)
+}
+
+func TestAgentClientHealthNotOK(t *testing.T) {
+	server := newFakeAgentServer(t)
+	server.responses[agentprotocol.RouteHealth] = func(writer http.ResponseWriter, _ []byte) {
+		_ = json.NewEncoder(writer).Encode(agentprotocol.HealthResponse{OK: false})
+	}
+	client, err := NewAgentClient(server.socket, "tenant-a", "pod-1")
+	require.NoError(t, err)
+	err = client.Health(context.Background())
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errAgentUnreachable)
+}
+
+func TestAgentClientLeaseDevicesBuildsRequestFromSpec(t *testing.T) {
+	server := newFakeAgentServer(t)
+	server.responses[agentprotocol.RouteLeaseDevices] = func(writer http.ResponseWriter, _ []byte) {
+		_ = json.NewEncoder(writer).Encode(agentprotocol.LeaseDevicesResponse{
+			LeaseID: "lease-1", RootfsDev: "/cache/rootfs.img", MemDev: "/cache/memory.snap",
+			ManifestDigest: "sha256:abc",
+		})
+	}
+	client, err := NewAgentClient(server.socket, "tenant-a", "pod-1")
+	require.NoError(t, err)
+
+	lease, err := client.LeaseDevices(context.Background(), "req-1", &fastletapi.SandboxSpec{
+		SandboxID: "sandbox-1", Image: "img", Memory: "2Gi",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "lease-1", lease.LeaseID)
+	require.Equal(t, "/cache/rootfs.img", lease.RootfsDev)
+
+	recorded := server.recorded()
+	require.Len(t, recorded, 1)
+	var request agentprotocol.LeaseDevicesRequest
+	require.NoError(t, json.Unmarshal([]byte(recorded[0][len(agentprotocol.RouteLeaseDevices)+1:]), &request))
+	require.Equal(t, "sandbox-1", request.SandboxID)
+	require.Equal(t, "img", request.Image)
+	require.Equal(t, 2048, request.MemSizeMiB)
+
+	_, err = client.LeaseDevices(context.Background(), "req-2", nil)
+	require.ErrorIs(t, err, runtimecontract.ErrInvalidConfig)
+}
+
+func TestAgentClientListLeasesAndCompatibility(t *testing.T) {
+	server := newFakeAgentServer(t)
+	server.responses[agentprotocol.RouteListLeases] = func(writer http.ResponseWriter, _ []byte) {
+		_ = json.NewEncoder(writer).Encode(agentprotocol.ListLeasesResponse{Leases: []agentprotocol.Lease{{
+			LeaseID: "lease-1", SandboxID: "sandbox-1", Image: "img", PodUID: "pod-1", RootfsDev: "/r",
+		}}})
+	}
+	server.responses[agentprotocol.RouteCompatibility] = func(writer http.ResponseWriter, _ []byte) {
+		_ = json.NewEncoder(writer).Encode(agentprotocol.CompatibilityResponse{CompatibilityClass: "native-stage-1"})
+	}
+	client, err := NewAgentClient(server.socket, "tenant-a", "pod-1")
+	require.NoError(t, err)
+
+	leases, err := client.ListLeases(context.Background())
+	require.NoError(t, err)
+	require.Len(t, leases, 1)
+	require.Equal(t, "lease-1", leases[0].LeaseID)
+
+	compatibility, err := client.Compatibility(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "native-stage-1", compatibility)
+}
+
+func TestAgentClientTimeoutBounded(t *testing.T) {
+	server := newFakeAgentServer(t)
+	server.responses[agentprotocol.RouteHealth] = func(writer http.ResponseWriter, _ []byte) {
+		time.Sleep(5 * time.Second)
+		writer.WriteHeader(http.StatusNoContent)
+	}
+	client, err := NewAgentClient(server.socket, "tenant-a", "pod-1")
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err = client.Health(ctx)
+	require.Error(t, err)
+	require.Less(t, time.Since(started), 2*time.Second)
+}

--- a/internal/runtime/firecracker/agent_e2e_test.go
+++ b/internal/runtime/firecracker/agent_e2e_test.go
@@ -1,0 +1,201 @@
+package firecracker
+
+// End-to-end stage-1 chain: driver client -> UDS server -> Service ->
+// real pull client -> fake S3 store, landing a committed cache that the
+// driver's resolveRootfsImage path consumes unchanged.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"fast-sandbox/internal/registryconfig"
+	agentpull "fast-sandbox/internal/runtime/firecracker/agent"
+	agentserver "fast-sandbox/internal/runtime/firecracker/agent/server"
+	agentstate "fast-sandbox/internal/runtime/firecracker/agent/state"
+
+	"github.com/stretchr/testify/require"
+)
+
+const e2eImage = "registry.example.com/sandbox:v1.0.21"
+
+// fakeS3Store serves path-style GETs at /<bucket>/<prefix>/<key>.
+type fakeS3Store struct {
+	mu       sync.Mutex
+	objects  map[string][]byte
+	requests []string
+	server   *httptest.Server
+}
+
+func (s *fakeS3Store) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	key := strings.TrimPrefix(request.URL.Path, "/"+e2eBucket+"/"+e2ePrefix+"/")
+	s.mu.Lock()
+	s.requests = append(s.requests, key)
+	payload, ok := s.objects[key]
+	s.mu.Unlock()
+	if !ok {
+		writer.WriteHeader(http.StatusNotFound)
+		return
+	}
+	_, _ = writer.Write(payload)
+}
+
+const (
+	e2eBucket = "sandbox-images"
+	e2ePrefix = "publish"
+)
+
+func hexSHA256Bytes(payload []byte) string {
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:])
+}
+
+// publishE2EFixture publishes index + manifest + artifacts into the store,
+// mirroring the builder's publish order (files -> manifest -> index).
+func publishE2EFixture(store *fakeS3Store, image string) {
+	rootfs := []byte("e2e-rootfs-content")
+	vmstate := []byte("e2e-vmstate-content")
+	memory := []byte("e2e-memory-content")
+	manifestPayload, _ := json.Marshal(map[string]any{
+		"files": map[string]any{
+			"rootfs.ext4":  map[string]any{"sha256": hexSHA256Bytes(rootfs), "sizeBytes": len(rootfs)},
+			"vmstate.snap": map[string]any{"sha256": hexSHA256Bytes(vmstate), "sizeBytes": len(vmstate)},
+			"memory.snap":  map[string]any{"sha256": hexSHA256Bytes(memory), "sizeBytes": len(memory)},
+		},
+	})
+	manifestRef := "s3://" + e2eBucket + "/" + e2ePrefix + "/" + hexSHA256Bytes(manifestPayload)[:16] + "/manifest.json"
+	index, _ := json.Marshal(map[string]any{
+		"image": image, "manifestRef": manifestRef,
+		"artifactDigest": hexSHA256Bytes(manifestPayload), "updatedAt": "2026-08-27T00:00:00Z",
+	})
+	key := func(parts ...string) string { return path.Join(parts...) }
+	store.objects[key("index", hexSHA256Bytes([]byte(image))+".json")] = index
+	store.objects[key(strings.TrimPrefix(strings.TrimPrefix(manifestRef, "s3://"+e2eBucket+"/"), e2ePrefix+"/"))] = manifestPayload
+	store.objects[key(hexSHA256Bytes(manifestPayload)[:16], "rootfs.ext4")] = rootfs
+	store.objects[key(hexSHA256Bytes(manifestPayload)[:16], "vmstate.snap")] = vmstate
+	store.objects[key(hexSHA256Bytes(manifestPayload)[:16], "memory.snap")] = memory
+}
+
+// startE2EAgent wires the full agent stack over a Unix socket and returns
+// the socket path.
+func startE2EAgent(t *testing.T, stateRoot string, store *fakeS3Store) string {
+	t.Helper()
+	endpoint := store.serverURL(t)
+	credential := registryconfig.Credential{Host: endpoint, Username: "readonly-ak", Password: "readonly-sk"}
+	pull, err := agentpull.NewClient("s3://"+e2eBucket+"/"+e2ePrefix, credential,
+		agentpull.WithHTTPClient(store.httpClient(t)))
+	require.NoError(t, err)
+	state, err := agentstate.New(stateRoot)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = state.Close() })
+	service := agentserver.NewService(pull, state, stateRoot)
+	socketPath := testAgentSocketPath(t)
+	server := agentserver.New(service, socketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = server.Serve(ctx) }()
+	t.Cleanup(cancel)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("agent socket %s never appeared", socketPath)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return socketPath
+}
+
+func (s *fakeS3Store) serverURL(t *testing.T) string {
+	t.Helper()
+	if s.server != nil {
+		return s.server.URL
+	}
+	s.server = httptest.NewServer(s)
+	t.Cleanup(s.server.Close)
+	return s.server.URL
+}
+
+func (s *fakeS3Store) httpClient(t *testing.T) *http.Client {
+	t.Helper()
+	_ = s.serverURL(t)
+	return s.server.Client()
+}
+
+func TestPullImageFullChainE2E(t *testing.T) {
+	store := &fakeS3Store{objects: make(map[string][]byte)}
+	publishE2EFixture(store, e2eImage)
+	stateRoot := t.TempDir()
+	socketPath := startE2EAgent(t, stateRoot, store)
+
+	driver := newDriverFixture(t)
+	driver.driver.newAgentClient = func(string) (AgentClient, error) {
+		return NewAgentClient(socketPath, "tenant-a", "pod-1")
+	}
+	driver.driver.agentSocket = socketPath
+
+	require.NoError(t, driver.driver.PullImage(context.Background(), e2eImage))
+
+	// The driver's existing resolveRootfsImage path consumes the pulled
+	// cache without any change.
+	rootfs, err := resolveRootfsImage(stateRoot, e2eImage)
+	require.NoError(t, err)
+	payload, err := os.ReadFile(rootfs)
+	require.NoError(t, err)
+	require.Equal(t, "e2e-rootfs-content", string(payload))
+
+	// The idempotency contract: pulling again performs no network request.
+	store.mu.Lock()
+	requestsBefore := len(store.requests)
+	store.mu.Unlock()
+	require.NoError(t, driver.driver.PullImage(context.Background(), e2eImage))
+	store.mu.Lock()
+	require.Equal(t, requestsBefore, len(store.requests))
+	store.mu.Unlock()
+}
+
+func TestPullImageE2ENotPublished(t *testing.T) {
+	store := &fakeS3Store{objects: make(map[string][]byte)}
+	stateRoot := t.TempDir()
+	socketPath := startE2EAgent(t, stateRoot, store)
+
+	driver := newDriverFixture(t)
+	driver.driver.newAgentClient = func(string) (AgentClient, error) {
+		return NewAgentClient(socketPath, "tenant-a", "pod-1")
+	}
+	driver.driver.agentSocket = socketPath
+
+	err := driver.driver.PullImage(context.Background(), "registry.example.com/not-published:v1")
+	require.ErrorIs(t, err, ErrImageNotReady)
+}
+
+// Ensure the fake store shape compiles against the agent's expected S3
+// client by exercising a direct pull (the real signing path).
+func TestDirectPullReachesStore(t *testing.T) {
+	store := &fakeS3Store{objects: make(map[string][]byte)}
+	publishE2EFixture(store, e2eImage)
+	stateRoot := t.TempDir()
+	credential := registryconfig.Credential{Host: store.serverURL(t), Username: "ak", Password: "sk"}
+	client, err := agentpull.NewClient("s3://"+e2eBucket+"/"+e2ePrefix, credential,
+		agentpull.WithHTTPClient(store.httpClient(t)))
+	require.NoError(t, err)
+	require.NoError(t, client.PullImage(context.Background(), stateRoot, e2eImage))
+	ready, err := agentpull.ImageReady(stateRoot, e2eImage)
+	require.NoError(t, err)
+	require.True(t, ready)
+}
+
+var _ = io.Discard
+var _ = net.Listen

--- a/internal/runtime/firecracker/agent_wiring.go
+++ b/internal/runtime/firecracker/agent_wiring.go
@@ -1,0 +1,134 @@
+package firecracker
+
+// agent_wiring.go connects the driver to the node-level
+// firecracker-runtime-agent (implementation plan §7): PullImage proxies to
+// PinImage, ProbeCapabilities gates on the agent Health, and DeleteSandbox
+// releases the lease and unpins the image. When no socket is configured the
+// driver stays in local mode; when the agent is unreachable the driver
+// falls back to the local cache (the agent being absent must not break
+// warmImages or cold boots).
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// SetFastletPodUID records the pod identity attached to runtime-agent
+// requests (identity headers).
+func (d *Driver) SetFastletPodUID(podUID string) {
+	d.mu.Lock()
+	d.podUID = podUID
+	d.mu.Unlock()
+}
+
+// SetAgentSocket configures the runtime-agent UDS socket. An empty path
+// switches the driver back to local mode (no remote pulls, no lease RPCs).
+func (d *Driver) SetAgentSocket(socketPath string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.agentSocket = socketPath
+	if socketPath == "" {
+		d.newAgentClient = nil
+		d.agentClient = nil
+		return
+	}
+	d.newAgentClient = func(path string) (AgentClient, error) {
+		d.mu.RLock()
+		namespace := d.namespace
+		podUID := d.podUID
+		d.mu.RUnlock()
+		return NewAgentClient(path, namespace, podUID)
+	}
+}
+
+// agentClientOrNil returns the lazily built agent client, or nil in local
+// mode. The build runs once; the cached instance is reused.
+func (d *Driver) agentClientOrNil() (AgentClient, error) {
+	d.mu.RLock()
+	client := d.agentClient
+	newClient := d.newAgentClient
+	socketPath := d.agentSocket
+	d.mu.RUnlock()
+	if client != nil {
+		return client, nil
+	}
+	if newClient == nil {
+		return nil, nil
+	}
+	built, err := newClient(socketPath)
+	if err != nil {
+		return nil, err
+	}
+	d.mu.Lock()
+	if d.agentClient == nil {
+		d.agentClient = built
+	}
+	client = d.agentClient
+	d.mu.Unlock()
+	return client, nil
+}
+
+// warmPullRequestID is the stable idempotency key of the warm pull of an
+// image: retries and repeated warm pulls of the same reference replay the
+// first pin instead of double-counting.
+func warmPullRequestID(image string) string {
+	return "warm-pull-" + imageKey(image)
+}
+
+// rememberLease records the runtime-agent lease of a Sandbox (populated
+// when a later phase wires LeaseDevices into EnsureSandbox).
+func (d *Driver) rememberLease(sandboxID, leaseID string) {
+	d.mu.Lock()
+	if d.sandboxLeases == nil {
+		d.sandboxLeases = make(map[string]string)
+	}
+	d.sandboxLeases[sandboxID] = leaseID
+	d.mu.Unlock()
+}
+
+// leaseForSandbox returns the recorded lease of a Sandbox.
+func (d *Driver) leaseForSandbox(sandboxID string) (string, bool) {
+	d.mu.RLock()
+	leaseID, ok := d.sandboxLeases[sandboxID]
+	d.mu.RUnlock()
+	return leaseID, ok
+}
+
+// forgetLease drops the recorded lease of a Sandbox.
+func (d *Driver) forgetLease(sandboxID string) {
+	d.mu.Lock()
+	delete(d.sandboxLeases, sandboxID)
+	d.mu.Unlock()
+}
+
+// releaseAgentSandbox unpins the Sandbox image and releases its lease (if
+// any) on the runtime-agent. Failures never fail the delete; an unreachable
+// agent leaves the lease to the agent's journaled recovery.
+func (d *Driver) releaseAgentSandbox(ctx context.Context, sandboxID, image string) {
+	client, err := d.agentClientOrNil()
+	if err != nil || client == nil {
+		return
+	}
+	if leaseID, ok := d.leaseForSandbox(sandboxID); ok {
+		if err := client.ReleaseDevices(ctx, "release-"+leaseID, leaseID); err != nil && !errorsIsAgentUnreachable(err) {
+			klog.V(2).InfoS("firecracker agent ReleaseDevices failed", "sandboxId", sandboxID, "err", err)
+		}
+		d.forgetLease(sandboxID)
+	}
+	if image != "" {
+		if err := client.UnpinImage(ctx, "unpin-"+sandboxID, image); err != nil && !errorsIsAgentUnreachable(err) {
+			klog.V(2).InfoS("firecracker agent UnpinImage failed", "sandboxId", sandboxID, "err", err)
+		}
+	}
+}
+
+// agentHealthTimeout bounds the ProbeCapabilities health call: a stuck
+// agent must not hang the capability probe.
+const agentHealthTimeout = 10 * time.Second
+
+func errorsIsAgentUnreachable(err error) bool {
+	return err != nil && errors.Is(err, errAgentUnreachable)
+}

--- a/internal/runtime/firecracker/agent_wiring_test.go
+++ b/internal/runtime/firecracker/agent_wiring_test.go
@@ -1,0 +1,187 @@
+package firecracker
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	fastletapi "fast-sandbox/internal/protocol/fastlet"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeAgentClient is a scriptable AgentClient for wiring tests.
+type fakeAgentClient struct {
+	mu        sync.Mutex
+	pins      []string
+	pinReqs   []string
+	unpins    []string
+	unpinReqs []string
+	releases  []string
+	healthErr error
+	digest    string
+}
+
+func (f *fakeAgentClient) PinImage(_ context.Context, requestID, image string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pins = append(f.pins, image)
+	f.pinReqs = append(f.pinReqs, requestID)
+	if f.digest == "" {
+		return "sha256:" + image, nil
+	}
+	return f.digest, nil
+}
+
+func (f *fakeAgentClient) UnpinImage(_ context.Context, requestID, image string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.unpins = append(f.unpins, image)
+	f.unpinReqs = append(f.unpinReqs, requestID)
+	return nil
+}
+
+func (f *fakeAgentClient) LeaseDevices(context.Context, string, *fastletapi.SandboxSpec) (Lease, error) {
+	return Lease{}, nil
+}
+
+func (f *fakeAgentClient) ReleaseDevices(_ context.Context, _, leaseID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.releases = append(f.releases, leaseID)
+	return nil
+}
+
+func (f *fakeAgentClient) ListLeases(context.Context) ([]Lease, error) { return nil, nil }
+func (f *fakeAgentClient) Compatibility(context.Context) (string, error) {
+	return "native-stage-1", nil
+}
+func (f *fakeAgentClient) Health(context.Context) error {
+	return f.healthErr
+}
+
+func (f *fakeAgentClient) snapshot() (pins, unpins, releases []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.pins...), append([]string(nil), f.unpins...), append([]string(nil), f.releases...)
+}
+
+// installAgent wires a fake agent into a driver fixture.
+func (f *driverFixture) installAgent(agent *fakeAgentClient) {
+	f.driver.newAgentClient = func(string) (AgentClient, error) { return agent, nil }
+	f.driver.agentSocket = "/run/fast-sandbox/firecracker/runtime.sock"
+	f.driver.podUID = "pod-1"
+}
+
+func TestPullImageProxiesToPinImage(t *testing.T) {
+	fixture := newDriverFixture(t)
+	agent := &fakeAgentClient{}
+	fixture.installAgent(agent)
+
+	require.NoError(t, fixture.driver.PullImage(context.Background(), fixture.sandboxSpec.Image))
+
+	pins, _, _ := agent.snapshot()
+	require.Equal(t, []string{fixture.sandboxSpec.Image}, pins)
+	// The request id is the stable warm-pull key of the image, so retries
+	// replay the first pin instead of double-counting.
+	require.Equal(t, "warm-pull-"+imageKey(fixture.sandboxSpec.Image), agent.pinReqs[0])
+}
+
+func TestPullImageIdempotentAcrossCalls(t *testing.T) {
+	fixture := newDriverFixture(t)
+	agent := &fakeAgentClient{}
+	fixture.installAgent(agent)
+
+	require.NoError(t, fixture.driver.PullImage(context.Background(), fixture.sandboxSpec.Image))
+	require.NoError(t, fixture.driver.PullImage(context.Background(), fixture.sandboxSpec.Image))
+
+	pins, _, _ := agent.snapshot()
+	require.Len(t, pins, 2)
+	require.Equal(t, agent.pinReqs[0], agent.pinReqs[1])
+}
+
+func TestPullImageLocalModeWithoutAgent(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	require.NoError(t, fixture.driver.PullImage(context.Background(), fixture.sandboxSpec.Image))
+
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+	missing := fixture.sandboxSpec.Image + "-missing"
+	require.ErrorIs(t, fixture.driver.PullImage(context.Background(), missing), ErrImageNotReady)
+}
+
+func TestPullImageAgentUnreachableFallsBackToLocal(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	// The agent socket exists but nothing listens: dial fails with
+	// errAgentUnreachable and the driver falls back to the local cache.
+	fixture.driver.newAgentClient = func(socket string) (AgentClient, error) {
+		return NewAgentClient(testAgentSocketPath(t), "tenant-a", "pod-1")
+	}
+	fixture.driver.agentSocket = "/unused"
+
+	require.NoError(t, fixture.driver.PullImage(context.Background(), fixture.sandboxSpec.Image))
+}
+
+func TestProbeCapabilitiesAgentHealthFailureDegrades(t *testing.T) {
+	fixture := newDriverFixture(t)
+	agent := &fakeAgentClient{healthErr: errAgentUnreachable}
+	fixture.installAgent(agent)
+
+	report := fixture.driver.ProbeCapabilities(context.Background())
+	require.Equal(t, "Degraded", string(report.State))
+	require.Equal(t, "AgentUnavailable", report.Reason)
+}
+
+func TestProbeCapabilitiesAgentReadyKeepsHostChecks(t *testing.T) {
+	fixture := newDriverFixture(t)
+	agent := &fakeAgentClient{}
+	fixture.installAgent(agent)
+
+	report := fixture.driver.ProbeCapabilities(context.Background())
+	require.Equal(t, "Ready", string(report.State))
+	require.Equal(t, "RuntimeDriverReady", report.Reason)
+}
+
+func TestProbeCapabilitiesLocalModeUnchanged(t *testing.T) {
+	fixture := newDriverFixture(t)
+	report := fixture.driver.ProbeCapabilities(context.Background())
+	require.Equal(t, "Ready", string(report.State))
+	require.Equal(t, "RuntimeDriverReady", report.Reason)
+}
+
+func TestDeleteSandboxReleasesAndUnpins(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	agent := &fakeAgentClient{}
+	fixture.installAgent(agent)
+	_, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+	fixture.driver.rememberLease(fixture.sandboxSpec.SandboxID, "lease-1")
+
+	require.NoError(t, fixture.driver.DeleteSandbox(context.Background(), fixture.sandboxSpec.SandboxID))
+
+	pins, unpins, releases := agent.snapshot()
+	require.Empty(t, pins)
+	require.Equal(t, []string{fixture.sandboxSpec.Image}, unpins)
+	require.Equal(t, []string{"lease-1"}, releases)
+	_, ok := fixture.driver.leaseForSandbox(fixture.sandboxSpec.SandboxID)
+	require.False(t, ok)
+}
+
+func TestDeleteSandboxLocalModeSkipsAgent(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Image)
+	_, err := fixture.driver.EnsureSandbox(context.Background(), &fixture.sandboxSpec)
+	require.NoError(t, err)
+	require.NoError(t, fixture.driver.DeleteSandbox(context.Background(), fixture.sandboxSpec.SandboxID))
+}
+
+func TestSetAgentSocketEmptySwitchesToLocalMode(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.installAgent(&fakeAgentClient{})
+	fixture.driver.SetAgentSocket("")
+	client, err := fixture.driver.agentClientOrNil()
+	require.NoError(t, err)
+	require.Nil(t, client)
+}

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -39,6 +39,7 @@ type Driver struct {
 	profile        runtimecatalog.RuntimeProfile
 	config         runtimecatalog.FirecrackerConfig
 	namespace      string
+	podUID         string
 	initialized    bool
 	runner         fastletnetwork.CommandRunner
 	launcher       ProcessRunner
@@ -51,6 +52,16 @@ type Driver struct {
 	infraMgr       *fastletinfra.Manager
 	prepareInfra   func(ctx context.Context, spec *fastletapi.SandboxSpec) (fastletinfra.PreparedInstance, error)
 	processes      map[string]Process
+	// agentSocket, newAgentClient, and agentClient wire the node-level
+	// runtime-agent (agent_wiring.go): an empty socket means local mode, a
+	// nil newAgentClient disables the agent client, and agentClient is the
+	// lazily built cached client.
+	agentSocket    string
+	newAgentClient func(socketPath string) (AgentClient, error)
+	agentClient    AgentClient
+	// sandboxLeases records the runtime-agent lease of each Sandbox that
+	// requested one (populated by LeaseDevices; empty in the native stage).
+	sandboxLeases map[string]string
 	// imageGCInterval is the period of the independent cache GC loop; it is a
 	// field (not a constant) so tests can shorten it.
 	imageGCInterval time.Duration
@@ -227,9 +238,9 @@ func (d *Driver) SetInfraManager(manager *fastletinfra.Manager) {
 }
 
 // ProbeCapabilities reports host dependencies (KVM, tap device, binary,
-// kernel). The profile gate keeps the runtime fail-closed until the KVM E2E
-// suite passes.
-func (d *Driver) ProbeCapabilities(_ context.Context) CapabilityReport {
+// kernel) and the runtime-agent health when one is configured. The profile
+// gate keeps the runtime fail-closed until the KVM E2E suite passes.
+func (d *Driver) ProbeCapabilities(ctx context.Context) CapabilityReport {
 	d.mu.RLock()
 	profile := d.profile
 	config := d.config
@@ -264,6 +275,23 @@ func (d *Driver) ProbeCapabilities(_ context.Context) CapabilityReport {
 		report.State = runtimecatalog.CapabilityDegraded
 		report.Message = fmt.Sprintf("firecracker runtime dependencies are unavailable: %v", report.Missing)
 		return report
+	}
+	agent, err := d.agentClientOrNil()
+	if err != nil {
+		report.State = runtimecatalog.CapabilityDegraded
+		report.Reason = "AgentUnavailable"
+		report.Message = fmt.Sprintf("firecracker runtime-agent client error: %v", err)
+		return report
+	}
+	if agent != nil {
+		healthCtx, cancel := context.WithTimeout(ctx, agentHealthTimeout)
+		defer cancel()
+		if err := agent.Health(healthCtx); err != nil {
+			report.State = runtimecatalog.CapabilityDegraded
+			report.Reason = "AgentUnavailable"
+			report.Message = err.Error()
+			return report
+		}
 	}
 	report.Reason = "RuntimeDriverReady"
 	report.Message = "firecracker runtime host dependencies are ready"
@@ -524,6 +552,7 @@ func (d *Driver) DeleteSandbox(ctx context.Context, sandboxID string) (resultErr
 	if infraMgr != nil {
 		_ = infraMgr.RemoveSandboxInstances(sandboxID)
 	}
+	d.releaseAgentSandbox(ctx, sandboxID, state.Spec.Image)
 	_ = removeSandboxDir(directory)
 	klog.Infof("firecracker sandbox %s deleted", sandboxID)
 	return nil
@@ -613,6 +642,8 @@ func (d *Driver) Close() error {
 		close(d.gcStop)
 		d.gcStop = nil
 	}
+	d.agentClient = nil
+	d.sandboxLeases = nil
 	d.initialized = false
 	return nil
 }

--- a/internal/runtime/firecracker/images.go
+++ b/internal/runtime/firecracker/images.go
@@ -239,13 +239,30 @@ func (d *Driver) ListImages(_ context.Context) ([]string, error) {
 	return listCachedImages(d.config.StateRoot)
 }
 
-// PullImage ensures the converted rootfs image is present in the local cache.
-// Conversion is out of band; an unconverted reference is reported as
-// ErrImageNotReady instead of blocking the create path.
-func (d *Driver) PullImage(_ context.Context, image string) error {
+// PullImage ensures the rootfs image is present in the local cache. With a
+// runtime-agent configured, the pull proxies to the agent's PinImage (the
+// node-level pull chain image -> index -> manifest -> digest-verified
+// cache); an unreachable agent degrades to the local cache check so warm
+// images and cold boots never depend on agent availability. Conversion is
+// out of band; an unconverted reference is reported as ErrImageNotReady
+// instead of blocking the create path.
+func (d *Driver) PullImage(ctx context.Context, image string) error {
 	d.mu.RLock()
 	stateRoot := d.config.StateRoot
 	d.mu.RUnlock()
+	client, err := d.agentClientOrNil()
+	if err == nil && client != nil {
+		if _, err := client.PinImage(ctx, warmPullRequestID(image), image); err != nil {
+			if errors.Is(err, errAgentUnreachable) {
+				// The agent is absent: fall through to the local cache.
+			} else {
+				return err
+			}
+		} else {
+			d.touchImage(image)
+			return nil
+		}
+	}
 	if _, err := resolveRootfsImage(stateRoot, image); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Overview

Implements the stage-1 construction plan **"runtime-agent UDS wiring (PinImage/LeaseDevices + driver client)"** from [PR #21](https://github.com/opensandbox-group/fast-sandbox/pull/21). Prerequisite #23 (the pull layer) is already merged.

## Deliverables

### Agent (L2, `internal/runtime/firecracker/agent/`)

- **`protocol/`**: versioned UDS protocol — 7 RPCs (PinImage / UnpinImage / LeaseDevices / ReleaseDevices / ListLeases / Compatibility / Health), stable error codes (InvalidRequest/Unauthorized/Conflict/NotFound/Internal), and the `requestId/namespace/podUid` identity fields;
- **`state/`**: lease table + per-image reference counts (pin/lease) + an **append-only JSON journal** (intent fsynced before execution, result after — two-phase commit); crash recovery replays committed ops, tolerates and truncates a partial tail write, and drops uncompleted intents; `sandbox_id` business idempotency (same sandbox returns the existing lease), cross-PodUID replay/release -> Conflict, counts clamped at zero;
- **`server/`**: UDS HTTP server (socket 0660 + `fast-sandbox` group; missing group only warns), identity enforcement (empty podUid -> 403, idempotency key required on mutating RPCs), error classification; the `Service` backend reuses the pull-layer `Client.PullImage` and the shared cache (`ImageRootfsPath` stays byte-identical to the driver `imageKey`; native-stage `LeaseDevices` returns cache file paths).

### Driver (L1)

- **`agent_client.go`**: UDS client (error mapping: NotFound -> `ErrImageNotReady`, Unauthorized/Conflict -> `ErrInvalidConfig`, transport failure -> `errAgentUnreachable`);
- **driver wiring**: `PullImage` -> `PinImage` proxy (stable requestID `warm-pull-<imageKey>` for idempotent retries; falls back to the local cache when the agent is unreachable); `ProbeCapabilities` gated on agent Health (failure -> `CapabilityDegraded(AgentUnavailable)`; local mode unchanged); `DeleteSandbox` -> `ReleaseDevices` (if leased) + `UnpinImage`; `SetAgentSocket`/`SetFastletPodUID` injection (mirrors the `newClient` pattern).

### Entry points

- **`cmd/firecracker-runtime-agent/`**: thin assembly, env-driven config (socket / artifact store / state root / registry credential matched by Host), graceful shutdown on SIGTERM/SIGINT;
- **`cmd/fastlet/main.go`**: wires `FAST_SANDBOX_RUNTIME_AGENT_SOCKET` (empty default = local mode, existing behavior unchanged).

## Tests

- `go build ./...`, `go vet ./...`, `gofmt` clean; `internal/runtime/firecracker/...` green incl. `-race`;
- Coverage: protocol encoding, journal ordering / crash recovery / partial-tail truncation / mid-file corruption rejection, reference-count boundaries, lease idempotency and ownership, server routing / identity / concurrent dedup, driver proxy and degradation, and a **real UDS server + client + real pull chain + fake S3 store E2E** (cold-cache pull -> `resolveRootfsImage` hit; re-pull issues zero network requests);
- No new third-party dependencies.

## Pending decisions (do not block this PR)

- **Agent deployment carrier** (standalone DaemonSet vs co-located container) is undecided: the control plane therefore does not inject `FAST_SANDBOX_RUNTIME_AGENT_SOCKET` yet (a dead socket would make the fastlet report `AgentUnavailable` and block admission); the env is injected by the deployer;
- Native-stage `LeaseDevices` returns cache file paths (device semantics arrive with stage 3 overlaybd/ublk); the driver `EnsureSandbox` keeps the `resolveRootfsImage` path as the main path.

## Relation to the design docs

Implementation follows `docs/design/firecracker-agent-uds-implementation-plan.md` and `firecracker-on-demand-loading-details.md` §2/§3/§5 (protocol routes, journal-based idempotency, degradation semantics).