### PR TITLE
feat(e2e): full-chain E2E wiring builder -> S3 -> runtime-agent -> restore (stage-1 closeout)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,7 @@ generated/
 # Local build artifacts
 /sandboxtemplate-builder
 /sandboxtemplate-snapshot-stage
+
+# Local E2E workspaces and helpers
+/.firecracker-chain-e2e/
+/.chain-e2e-gen/

--- a/build/Dockerfile.sandboxtemplate-builder
+++ b/build/Dockerfile.sandboxtemplate-builder
@@ -73,7 +73,7 @@ ENV OCI2ROOTFS_REV=${OCI2ROOTFS_REV}
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates coreutils curl e2fsprogs jq libaio1 libzstd1 \
+        ca-certificates coreutils curl e2fsprogs iproute2 jq libaio1 libzstd1 \
         mount procps tar unzip util-linux \
     && rm -rf /var/lib/apt/lists/*
 

--- a/cmd/firecracker-runtime-agent/main.go
+++ b/cmd/firecracker-runtime-agent/main.go
@@ -35,6 +35,10 @@ func main() {
 	storeRoot := getEnv("FAST_SANDBOX_ARTIFACT_STORE", "")
 	stateRoot := getEnv("FAST_SANDBOX_STATE_ROOT", defaultStateRoot)
 	registryPath := getEnv("FAST_SANDBOX_REGISTRY_CONFIG_PATH", registryconfig.MountPath)
+	// The artifact store endpoint is usually derived from the credential
+	// Host; an explicit endpoint overrides the matching key and the
+	// connection address (e.g. a local MinIO: http://127.0.0.1:9000).
+	endpoint := getEnv("FAST_SANDBOX_ARTIFACT_ENDPOINT", "")
 
 	if storeRoot == "" {
 		klog.ErrorS(errors.New("missing store root"), "FAST_SANDBOX_ARTIFACT_STORE is required (s3://bucket/prefix)")
@@ -42,7 +46,7 @@ func main() {
 	}
 
 	registryProvider := registryconfig.NewFileProvider(registryPath)
-	credential, err := resolveCredential(registryProvider, storeRoot)
+	credential, err := resolveCredential(registryProvider, storeRoot, endpoint)
 	if err != nil {
 		klog.ErrorS(err, "Failed to resolve the artifact store credential")
 		os.Exit(1)
@@ -75,21 +79,42 @@ func main() {
 
 // resolveCredential matches the store endpoint host against the compiled
 // registry configuration; the credential carries the read-only access key
-// pair (Username/Password) and the store Host.
-func resolveCredential(provider registryconfig.Provider, storeRoot string) (registryconfig.Credential, error) {
+// pair (Username/Password) and the store endpoint. When endpointEnv is set,
+// its host is the matching key (an explicit artifact store endpoint such as
+// a MinIO address); otherwise the store root host (the bucket) is matched.
+// The match is a normalized host comparison (CredentialsForHost), not an
+// image-reference match: a bare endpoint host like "127.0.0.1:9000" has no
+// repository component for the reference-splitting rules to parse.
+func resolveCredential(provider registryconfig.Provider, storeRoot, endpointEnv string) (registryconfig.Credential, error) {
 	parsed, err := url.Parse(storeRoot)
 	if err != nil {
 		return registryconfig.Credential{}, fmt.Errorf("parse store root %q: %w", storeRoot, err)
 	}
-	if parsed.Host == "" {
+	matchHost := parsed.Host
+	if endpointEnv != "" {
+		parsedEndpoint, parseErr := url.Parse(endpointEnv)
+		if parseErr != nil || parsedEndpoint.Host == "" {
+			return registryconfig.Credential{}, fmt.Errorf("invalid artifact store endpoint %q", endpointEnv)
+		}
+		matchHost = parsedEndpoint.Host
+	}
+	if matchHost == "" {
 		return registryconfig.Credential{}, fmt.Errorf("store root %q has no endpoint host", storeRoot)
 	}
-	credential, ok, err := provider.Credentials(parsed.Host)
+	var credential registryconfig.Credential
+	var ok bool
+	if hostMatcher, supports := provider.(interface {
+		CredentialsForHost(string) (registryconfig.Credential, bool, error)
+	}); supports {
+		credential, ok, err = hostMatcher.CredentialsForHost(matchHost)
+	} else {
+		credential, ok, err = provider.Credentials(matchHost)
+	}
 	if err != nil {
 		return registryconfig.Credential{}, err
 	}
 	if !ok {
-		return registryconfig.Credential{}, fmt.Errorf("no read-only credential configured for store endpoint %q", parsed.Host)
+		return registryconfig.Credential{}, fmt.Errorf("no read-only credential configured for store endpoint %q", matchHost)
 	}
 	return credential, nil
 }

--- a/cmd/firecracker-runtime-agent/main_test.go
+++ b/cmd/firecracker-runtime-agent/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"fast-sandbox/internal/registryconfig"
@@ -31,7 +33,7 @@ func TestResolveCredentialMatchesStoreHost(t *testing.T) {
 		},
 		found: true,
 	}
-	credential, err := resolveCredential(provider, "s3://oss-cn-hangzhou.aliyuncs.com/sandbox-images/publish")
+	credential, err := resolveCredential(provider, "s3://oss-cn-hangzhou.aliyuncs.com/sandbox-images/publish", "")
 	require.NoError(t, err)
 	require.Equal(t, "readonly-ak", credential.Username)
 	require.Equal(t, "readonly-sk", credential.Password)
@@ -39,30 +41,75 @@ func TestResolveCredentialMatchesStoreHost(t *testing.T) {
 	require.Equal(t, "oss-cn-hangzhou.aliyuncs.com", provider.lastRef)
 }
 
+func TestResolveCredentialMatchesExplicitEndpoint(t *testing.T) {
+	provider := &fakeProvider{
+		credential: registryconfig.Credential{
+			Host: "127.0.0.1:9000", Username: "chain-test", Password: "chain-test-secret",
+			Endpoint: "http://127.0.0.1:9000",
+		},
+		found: true,
+	}
+	credential, err := resolveCredential(provider, "s3://sandbox-images/publish", "http://127.0.0.1:9000")
+	require.NoError(t, err)
+	require.Equal(t, "chain-test", credential.Username)
+	require.Equal(t, "http://127.0.0.1:9000", credential.Endpoint)
+	require.Equal(t, "127.0.0.1:9000", provider.lastRef)
+}
+
+// TestResolveCredentialHostMatchAgainstFile exercises the real compiled
+// configuration through FileProvider: a bare endpoint host (no "/") must
+// match by host, not by the image-reference rules of Match (which would
+// parse "127.0.0.1:9000" as repository "127.0.0.1:9000" under docker.io).
+func TestResolveCredentialHostMatchAgainstFile(t *testing.T) {
+	compiled, err := registryconfig.NewCompiled([]registryconfig.Credential{{
+		Host: "127.0.0.1:9000", Username: "chain-test", Password: "chain-test-secret",
+		Endpoint: "http://127.0.0.1:9000",
+	}})
+	require.NoError(t, err)
+	payload, err := compiled.Marshal()
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "registry.json")
+	require.NoError(t, os.WriteFile(path, payload, 0o640))
+
+	provider := registryconfig.NewFileProvider(path)
+	credential, err := resolveCredential(provider, "s3://sandbox-images/publish", "http://127.0.0.1:9000")
+	require.NoError(t, err)
+	require.Equal(t, "chain-test", credential.Username)
+	require.Equal(t, "chain-test-secret", credential.Password)
+	require.Equal(t, "http://127.0.0.1:9000", credential.Endpoint)
+}
+
+func TestResolveCredentialInvalidEndpoint(t *testing.T) {
+	provider := &fakeProvider{found: true}
+	_, err := resolveCredential(provider, "s3://sandbox-images/publish", "://not-a-url")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "endpoint")
+}
+
 func TestResolveCredentialNoMatch(t *testing.T) {
 	provider := &fakeProvider{found: false}
-	_, err := resolveCredential(provider, "s3://sandbox-images/publish")
+	_, err := resolveCredential(provider, "s3://sandbox-images/publish", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no read-only credential")
 }
 
 func TestResolveCredentialProviderError(t *testing.T) {
 	provider := &fakeProvider{err: errors.New("config unreadable")}
-	_, err := resolveCredential(provider, "s3://sandbox-images/publish")
+	_, err := resolveCredential(provider, "s3://sandbox-images/publish", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "config unreadable")
 }
 
 func TestResolveCredentialInvalidStoreRoot(t *testing.T) {
 	provider := &fakeProvider{found: true}
-	_, err := resolveCredential(provider, "not a url ://")
+	_, err := resolveCredential(provider, "not a url ://", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "store root")
 }
 
 func TestResolveCredentialMissingHost(t *testing.T) {
 	provider := &fakeProvider{found: true}
-	_, err := resolveCredential(provider, "s3:///only-path")
+	_, err := resolveCredential(provider, "s3:///only-path", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "endpoint host")
 }

--- a/cmd/sandboxtemplate-builder/manifest.go
+++ b/cmd/sandboxtemplate-builder/manifest.go
@@ -89,6 +89,16 @@ func buildManifest(spec apiv1alpha2.SandboxTemplateSpec, sourceDigest, kernel, r
 			"vcpu":   spec.Machine.VCPU,
 			"memory": spec.Machine.Memory,
 		},
+		// The guest network baked into the snapshot (clone networking
+		// model): the restored guest owns a static eth0 address/MAC; the
+		// consumer replaces only the host tap via network_overrides.
+		"guestNetwork": map[string]any{
+			"iface":   "eth0",
+			"mac":     bakedGuestMAC,
+			"ip":      bakedGuestIP,
+			"gateway": bakedGuestGateway,
+			"netmask": bakedGuestNetmask,
+		},
 		"entrypoint": spec.Entrypoint,
 		"init":       spec.Init,
 		// Note: envs are published verbatim into the manifest — do not place

--- a/cmd/sandboxtemplate-builder/snapshot_stage.go
+++ b/cmd/sandboxtemplate-builder/snapshot_stage.go
@@ -28,6 +28,23 @@ type snapshotPhaseTimings struct {
 	RestoreToHeartbeatMs int64 `json:"restoreToHeartbeatMs"`
 }
 
+// buildTap is the host tap backing the baked NIC while the snapshot VM
+// runs. It only lives for the snapshot stage; consumers of the snapshot
+// replace the host tap per instance via network_overrides, so the tap name
+// itself never leaks into the product.
+const buildTap = "fc-build-tap"
+
+// The baked guest network (mirrors the driver E2E prep recipe, e2ePrepMAC /
+// e2ePrepBootArgs): the snapshot carries a static eth0 configuration, so a
+// restored instance owns its address without any kernel ip= args (the
+// snapshot is authoritative). Consumers can only replace the host tap name.
+const (
+	bakedGuestMAC     = "02:00:00:00:00:01"
+	bakedGuestIP      = "172.30.0.3"
+	bakedGuestGateway = "172.30.0.1"
+	bakedGuestNetmask = "255.255.255.0"
+)
+
 // runSnapshotStage drives a Firecracker VM from cold boot to a validated
 // full snapshot. It is invoked by the builder image as the snapshot stage
 // helper:
@@ -57,6 +74,27 @@ func runSnapshotStage(args []string) error {
 		workdir = "/build"
 	}
 
+	// The baked NIC needs a host tap as its backing device while the VM
+	// runs. It is kept alive through the restore validation (the snapshot's
+	// NIC host_dev references it) and removed afterwards.
+	if err := ensureBuildTap(); err != nil {
+		return err
+	}
+	defer deleteBuildTap()
+
+	// The drive path baked into the vmstate must be RELATIVE and carry the
+	// filename the consumer's restore resolves in its process cwd: the
+	// driver restores with cwd = the instance state dir, where the
+	// per-instance root drive is named rootfs.img (the reflink copy). A
+	// symlink in the workdir gives the snapshot VM the same file under
+	// that name (both the snapshot create and the Stage B restore run with
+	// cwd = workdir).
+	driveLink := filepath.Join(workdir, snapshotDriveName)
+	_ = os.Remove(driveLink)
+	if err := os.Symlink(rootfs, driveLink); err != nil {
+		return fmt.Errorf("link snapshot drive %s: %w", driveLink, err)
+	}
+
 	// Stage A: cold boot and wait for guest readiness.
 	bootLog := filepath.Join(workdir, "boot.console.log")
 	bootSocket := filepath.Join(workdir, "boot.sock")
@@ -65,8 +103,9 @@ func runSnapshotStage(args []string) error {
 	if err != nil {
 		return err
 	}
-	bootArgs := "console=ttyS0 reboot=k panic=1 pci=off nomodules root=/dev/vda rw"
+	bootArgs := "console=ttyS0 reboot=k panic=1 pci=off nomodules net.ifnames=0 biosdevname=0 root=/dev/vda rw"
 	bootArgs += " init=" + guestInitPath(spec)
+	bootArgs = bakedNetworkBootArgs(bootArgs)
 	if err := configureVM(vm, kernel, rootfs, bootArgs, spec); err != nil {
 		vm.stop()
 		return err
@@ -99,6 +138,10 @@ func runSnapshotStage(args []string) error {
 	// device state and the original paths still existing on this host. This
 	// is verified against firecracker v1.16.1 but is an implicit dependency
 	// on that version's behavior — revisit when bumping the VMM.
+	//
+	// The baked NIC references buildTap, which is still alive here, so the
+	// validation restore needs no network_overrides; consumers later replace
+	// the host tap per instance.
 	restoreStarted := time.Now()
 	restoreLog := filepath.Join(workdir, "restore.console.log")
 	restoreSocket := filepath.Join(workdir, "restore.sock")
@@ -152,6 +195,10 @@ type vmm struct {
 // startVMM launches firecracker in the background with the serial output
 // captured in the console log, then waits for the API socket.
 func startVMM(socketPath, logPath, workdir string) (*vmm, error) {
+	// A stale socket file from a crashed or interrupted earlier run makes
+	// the firecracker bind fail (EADDRINUSE) and the process exit right
+	// after startup; remove it before launching.
+	_ = os.Remove(socketPath)
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
 	if err != nil {
 		return nil, err
@@ -179,8 +226,12 @@ func (vm *vmm) stop() {
 	}
 }
 
-// configureVM applies the machine config, boot source, root drive, and
-// starts the instance.
+// configureVM applies the machine config, boot source, root drive, the baked
+// guest NIC, and starts the instance. The NIC (iface eth0, MAC, and the
+// static guest address from the kernel ip= boot args) is baked into the
+// snapshot, so every restored instance resumes with the same guest network
+// (clone networking model); consumers override only the host tap name via
+// network_overrides.
 func configureVM(vm *vmm, kernel, rootfs, bootArgs string, spec apiv1alpha2.SandboxTemplateSpec) error {
 	vcpuCount, err := vcpus(spec.Machine.VCPU)
 	if err != nil {
@@ -210,13 +261,50 @@ func configureVM(vm *vmm, kernel, rootfs, bootArgs string, spec apiv1alpha2.Sand
 	}
 	if err := api(vm.socket, "PUT", "/drives/rootfs", map[string]any{
 		"drive_id":       "rootfs",
-		"path_on_host":   rootfs,
+		"path_on_host":   snapshotDriveName,
 		"is_root_device": true,
 		"is_read_only":   false,
 	}); err != nil {
 		return err
 	}
+	if err := api(vm.socket, "PUT", "/network-interfaces/eth0", map[string]any{
+		"iface_id":      "eth0",
+		"host_dev_name": buildTap,
+		"guest_mac":     bakedGuestMAC,
+	}); err != nil {
+		return err
+	}
 	return api(vm.socket, "PUT", "/actions", map[string]string{"action_type": "InstanceStart"})
+}
+
+// snapshotDriveName is the RELATIVE drive path baked into the vmstate. It
+// must match the filename the driver's restore resolves in its process cwd:
+// the per-instance rootfs reflink copy is rootfs.img in the instance state
+// directory (the driver's instanceRootfsName).
+const snapshotDriveName = "rootfs.img"
+
+// ensureBuildTap creates the host tap backing the baked NIC.
+func ensureBuildTap() error {
+	if output, err := exec.Command("ip", "tuntap", "add", "dev", buildTap, "mode", "tap").CombinedOutput(); err != nil {
+		return fmt.Errorf("create build tap %s: %w: %s", buildTap, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// deleteBuildTap removes the build tap; a missing tap is not an error.
+func deleteBuildTap() {
+	_, _ = exec.Command("ip", "link", "del", buildTap).CombinedOutput()
+}
+
+// bakedNetworkBootArgs appends the static guest network to the kernel
+// command line so the snapshot carries a live eth0 configuration (the
+// restored guest owns the address without kernel ip= args — the snapshot
+// is authoritative).
+func bakedNetworkBootArgs(base string) string {
+	if strings.Contains(base, " ip=") {
+		return base
+	}
+	return base + " ip=" + bakedGuestIP + "::" + bakedGuestGateway + ":" + bakedGuestNetmask + "::eth0:off"
 }
 
 // api performs one Firecracker API call over its Unix domain socket. A

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Fast Sandbox documentation is organized by reader intent:
 - [Deployment](guides/deployment.md)
 - [OpenSandbox integration](guides/opensandbox-integration.md)
 - [OpenSandbox Execd](guides/opensandbox-execd.md)
+- [SandboxTemplate golden images](guides/sandboxtemplate-golden-images.md)
 - [Private registries](guides/private-registries.md)
 - [Secure runtimes](guides/secure-runtimes.md)
 - [Runtime node installation](guides/runtime-node-installation.md)
@@ -35,6 +36,8 @@ Fast Sandbox documentation is organized by reader intent:
 - [Observability](guides/observability.md)
 - [Performance](guides/performance.md)
 - [Testing](guides/testing.md)
+- [Firecracker runtime E2E](guides/firecracker-runtime-e2e.md)
+- [Firecracker full-chain E2E](guides/firecracker-chain-e2e.md)
 
 ## Reference
 

--- a/docs/design/sandboxtemplate-golden-image-builds.md
+++ b/docs/design/sandboxtemplate-golden-image-builds.md
@@ -16,6 +16,10 @@
 >   `ext4` / `snapshot` 细分已收敛为 `native`）
 > - `output.publish` 在实现中为必填，`publishSecretRef` 由 controller 以
 >   SecretKeyRef 注入 build Pod
+>
+> **使用文档**：字段含义与操作流程以
+> [guides/sandboxtemplate-golden-images.md](../guides/sandboxtemplate-golden-images.md)
+> 与 [reference/api.md](../reference/api.md) 为准。
 
 - [Summary](#summary)
 - [Motivation](#motivation)
@@ -241,9 +245,12 @@ Every build emits a content-addressed `manifest.json`:
   execd is not injected; empty healthcheck uses the image `CMD-SHELL`).
 - **Format tiers are inclusive**: `overlaybd` implies `snapshot` implies
   `ext4`; a single value selects the pipeline depth.
-- **Guest network**: the snapshot stage deliberately does not configure
-  external connectivity so live connections are not captured in the
-  snapshot. Snapshotting workloads with active connections is out of scope.
+- **Guest network**: the snapshot stage bakes a NIC (iface `eth0` with a
+  static guest IP/MAC, recorded in the manifest as `guestNetwork`) so a
+  restored instance owns its address; consumers replace only the host tap
+  via `network_overrides`. The stage deliberately does not configure
+  external connectivity, so no **active connections** are captured in the
+  snapshot — snapshotting workloads with live connections is out of scope.
 - **Source image compatibility**: the converter applies layer ordering,
   compression, hard links, and whiteouts, but may skip device nodes and
   timestamps/xattrs; the boot (and restore, for snapshot formats)

--- a/docs/guides/firecracker-chain-e2e.md
+++ b/docs/guides/firecracker-chain-e2e.md
@@ -1,0 +1,161 @@
+# Firecracker full-chain E2E (builder → S3 → runtime-agent → driver restore)
+
+Reference environment and expected behavior for
+`scripts/firecracker-chain-e2e.sh` — the stage-1 closeout of the
+[Firecracker on-demand loading](../design/firecracker-on-demand-loading.md)
+design. Every component runs for real: the builder image publishes through
+MinIO, the runtime-agent pulls over the wire (path-style SigV4 + credential
+mapping), and the Firecracker driver restores from the pulled artifacts and
+reaches the guest.
+
+```text
+alpine:3.19 ──builder──▶ s3://sandbox-images/publish (index + digest16 build + SHA256SUMS)
+                              │  PinImage (UDS, SigV4 over MinIO)
+                              ▼
+                       runtime-agent ──pull──▶ <state-root>/images/<sha256(image)>/
+                              │  restore (LoadSnapshot, network_overrides)
+                              ▼
+                       firecracker driver (Go E2E) ──▶ guest reachable at 172.30.0.3
+```
+
+## Host environment
+
+Same bare-metal host as
+[firecracker-runtime-e2e.md](firecracker-runtime-e2e.md) and
+[sandboxtemplate-golden-image-e2e.md](sandboxtemplate-golden-image-e2e.md):
+
+| Item | Value |
+|------|-------|
+| Machine | Dedicated bare-metal server (cloud-hosted), `/dev/kvm` and `/dev/net/tun` passed through |
+| OS | Linux x86_64 (Alibaba Cloud Linux 3 reference host) |
+| Runner | root (the script re-invokes itself with sudo) |
+| Required tools | `ip`, `iptables`, `sysctl`, `ping`, `curl`, `jq`, `docker`, `go` |
+| StateRoot | **xfs (reflink-capable), never ext4** — see [StateRoot MUST be on a reflink-capable filesystem](#stateroot-must-be-on-a-reflink-capable-filesystem) below; provision with `scripts/firecracker-xfs-stateroot.sh --loop` |
+
+## What it verifies
+
+| # | Verification point | Assertion |
+|---|--------------------|-----------|
+| 1 | builder real publish layout | `index/<sha256(image)>.json` + `digest16/{rootfs.ext4,vmstate.snap,memory.snap,SHA256SUMS,manifest.json}`; `index.artifactDigest` == sha256(manifest); every `files[]` digest matches the uploaded object |
+| 2 | SigV4 against MinIO | agent pull succeeds over the wire (signature correctness proven by digest-verified commit) |
+| 3 | credential mapping | registry configuration (read-only AK/SK + endpoint) resolves via `FAST_SANDBOX_ARTIFACT_ENDPOINT`; the agent connects to MinIO |
+| 4 | builder snapshot ↔ driver restore | driver E2E restores from the pulled artifacts (`FC_SKIP_PREP`: no self-bootstrap); VM `Running`; guest reachable at the baked address |
+| 5 | idempotency + cleanup | re-PinImage makes zero re-pull (committed cache); driver delete releases the pin through the UDS API; lease lifecycle returns state to zero |
+
+The three scenarios (A: pull chain, B: restore, C: full chain) map to these
+points; see the script comments for the exact step order.
+
+## Running
+
+```bash
+cd /home/gaoran/fast-sandbox
+./scripts/firecracker-chain-e2e.sh
+```
+
+The script:
+
+1. downloads the firecracker release, kernel, and bionic rootfs (the driver
+   E2E's prep inputs — in `FC_SKIP_PREP` mode the kernel/rootfs are only
+   presence checks);
+2. starts MinIO (`minio/minio:latest`, ports 9000/9001, AK/SK
+   `chain-test`/`chain-test-secret`, bucket `sandbox-images`);
+3. exports `alpine:3.19`, builds the builder image, and runs the pipeline
+   with `publish: s3://sandbox-images/publish` and machine `1` vCPU / `512Mi`
+   (the machine tuple the driver E2E spec validates against);
+4. asserts the published layout (verification point 1);
+5. builds and starts the real `firecracker-runtime-agent` (UDS socket, state
+   root, registry file) and pulls the image twice through `PinImage`
+   (points 2/3 + idempotency);
+6. runs `TestFirecrackerDriverE2E` with `FC_SKIP_PREP=1` and
+   `FC_AGENT_SOCKET` wired, so the driver restores from the builder artifacts
+   and its delete path unpins through the agent (point 4);
+7. exercises the lease lifecycle (`LeaseDevices`/`ListLeases`/
+   `ReleaseDevices`/`UnpinImage`) and asserts pin/lease state returns to zero
+   (point 5);
+8. tears everything down (agent, MinIO container, test bridge/netns/rules).
+
+## Overrides
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `CHAIN_SOURCE_IMAGE` | `alpine:3.19` | OCI image the builder converts |
+| `CHAIN_IMAGE` | `chain-test:v1` | Image reference addressed end to end (index key + cache key) |
+| `CHAIN_MACHINE_VCPU` / `CHAIN_MACHINE_MEM` | `1` / `512Mi` | Builder machine tuple; must fit the driver E2E spec (request memory ≥ snapshot memory) |
+| `CHAIN_ROOTFS_SIZE` | `10Gi` | Builder rootfs logical size |
+| `MINIO_IMAGE` / `MINIO_PORT` / `MINIO_AK` / `MINIO_SK` | `minio/minio:latest` / `9000` / `chain-test` / `chain-test-secret` | MinIO deployment |
+| `WORK` | `$PWD/.firecracker-chain-e2e` | Workspace (agent binary, state root, logs, MinIO data) |
+| `SANDBOX_TEMPLATE_BUILDER_IMAGE` | `sandboxtemplate-builder:chain-e2e` | Builder image name |
+| `FC_VERSION` / `FC_BINARY` / `FC_KERNEL` / `FC_ROOTFS` / `FC_STATE_ROOT` | — | Driver E2E overrides (artifacts, state root) |
+
+## Host impact and cleanup
+
+- The driver E2E creates a private `172.30.0.0/24` bridge, one MASQUERADE
+  rule, and sets host `ip_forward`; the script restores them on exit (only
+  what it created). Per-run netns/taps are always purged.
+- MinIO runs as a docker container removed on exit; its data lives under
+  `$WORK/minio-data`.
+- The builder creates and deletes its own build tap (`fc-build-tap`).
+- `./scripts/firecracker-chain-e2e.sh --cleanup` cleans a crashed run.
+
+## Observed results
+
+Green runs on the reference host (`agent-sandbox033067064046.sg52`, xfs
+StateRoot, MinIO local, `opensandbox/execd:1.1.0` baked, `native` format,
+machine 1 vCPU / 512 MiB, rootfs 2 Gi):
+
+**Builder pipeline** (per run, `builder.log`):
+
+| Phase | 1st | 2nd |
+|-------|-----|-----|
+| pull / convert | 6.5 s / 0.6 s | 6.5 s / 0.6 s |
+| boot → SANDBOX_READY | 2.1 s | 2.1 s |
+| snapshot create / restore verify | 5.0 s / 5.1 s | 5.0 s / 5.1 s |
+| manifest / publish | 12.4 s / 42.3 s | 12.4 s / 42.3 s |
+| **total** | **74 s** | **74 s** |
+
+`bootToReady` dropped from 16.1 s to 2.1 s: with execd injected, readiness
+is the execd `/ping` probe instead of the 15 s warmup fallback (~1 s kernel
+boot + ~1 s execd readiness).
+
+**Scenario A — cold pull** (first PinImage over MinIO, 3.6 GiB cache):
+**~39.5 s**; committed-cache re-pin makes zero requests (verification 5a).
+
+**Scenario B — driver restore** (same snapshot set, both cases):
+
+| Segment | Infra | NoInfra |
+|---------|-------|---------|
+| create total | 117-125 ms | **24.6-25.6 ms** |
+| rootfs (reflink copy) | ~1 ms | ~1 ms |
+| infra (GuestCopy) | 92-100 ms | — |
+| launch (spawn + API socket) | 20.4-21 ms | 20.4-21 ms |
+| configure (LoadSnapshot) | ~2.9 ms | ~2.9 ms |
+| boot (InstanceStart) | ~0.3 ms | ~0.3 ms |
+| guest reachable (ICMP) | immediate | immediate |
+| **execd /ping (VM running + delta)** | **+5.4 ms** | **+5.3 ms** |
+
+End-to-end delivery (create → business-ready): **~30 ms** on the driver
+layer (VM Running ~25 ms + execd readiness ~5 ms).
+
+### StateRoot MUST be on a reflink-capable filesystem
+
+The 1.8-2.7 s per-create rootfs copy measured earlier on ext4 was the
+reflink fallback (full 3 GiB copy). With an **xfs StateRoot**
+(`scripts/firecracker-xfs-stateroot.sh --loop`, then
+`FC_STATE_ROOT=/var/lib/fast-sandbox`), the copy is COW (~1 ms) and the
+NoInfra create drops to ~25 ms. This is a deployment requirement, not an
+E2E nicety: **run the StateRoot on xfs/btrfs (reflink-capable), never
+ext4**, or every sandbox create pays a full rootfs copy. The chain E2E
+probes the StateRoot filesystem at startup and warns when reflink is
+unavailable.
+
+## Known gaps
+
+- **OSS vs MinIO**: SigV4 is verified against MinIO here; Aliyun OSS region
+  normalization and endpoint-style differences are covered in production
+  validation (design details §6.8).
+- **Builder NIC dependency**: the restore relies on the snapshot carrying the
+  baked NIC (builder `snapshot_stage`); without it, `network_overrides` has
+  no iface to replace and the guest is unreachable.
+- **Clone networking**: every restored instance resumes with the baked
+  guest IP/MAC (172.30.0.3); multi-slot reachability needs per-clone netns
+  isolation + NAT (upstream clone model), out of scope for this E2E.

--- a/docs/guides/sandboxtemplate-golden-image-e2e.md
+++ b/docs/guides/sandboxtemplate-golden-image-e2e.md
@@ -44,12 +44,19 @@ injected — an empty `spec.init` defaults to
 
 1. **convert** — pull the OCI image into an OCI layout, run oci2rootfs, loop
    mount, inject guest-init / envs / hosts, verify with e2fsck
-2. **boot + snapshot** — cold boot the VM, wait for the guest `SANDBOX_READY`
-   marker, pause, create a full snapshot (vmstate + memory), restore once and
-   wait for `SANDBOX_HEARTBEAT` (the guest init does not re-run after resume)
+2. **boot + snapshot** — create a transient host tap (`fc-build-tap`), cold
+   boot the VM with the baked static guest network in the boot args
+   (`ip=172.30.0.3::172.30.0.1:255.255.255.0::eth0:off`) and a NIC attached
+   (iface `eth0`, MAC `02:00:00:00:00:01`), wait for the guest
+   `SANDBOX_READY` marker, pause, create a full snapshot (vmstate + memory),
+   restore once and wait for `SANDBOX_HEARTBEAT` (the guest init does not
+   re-run after resume), then remove the tap. The restored instance owns the
+   baked address; consumers replace only the host tap via
+   `network_overrides`
 3. **package** (overlaybd only) — import rootfs and memory into LSMT layers
-4. **manifest** — assemble `manifest.json` (content-addressed) and SHA256SUMS
-   (covering only the published artifact set)
+4. **manifest** — assemble `manifest.json` (content-addressed, includes the
+   `guestNetwork` record) and SHA256SUMS (covering only the published artifact
+   set)
 
 After each run the script cross-checks every manifest digest against
 `sha256sum` on the produced files, so a hasher regression (e.g. the sparse
@@ -76,6 +83,9 @@ Notes:
 - The declared `rootfsSize` (e.g. "10Gi") is a minimum: oci2rootfs takes SI
   units, so the builder rounds UP (`10Gi` → `--size 11G` → 11 GiB file), and
   the produced rootfs always has at least the declared capacity
+- The snapshot bakes a NIC with a static guest IP/MAC (recorded in
+  `manifest.guestNetwork`); it carries no active connections, matching the
+  restore-only runtime contract
 - The rootfs is sparse: `ls -lh` shows the 11 GiB logical size while ~1.1 GiB
   is actually allocated (ext4 metadata, journal, and the expanded OCI content)
 

--- a/docs/guides/sandboxtemplate-golden-images.md
+++ b/docs/guides/sandboxtemplate-golden-images.md
@@ -1,0 +1,237 @@
+# SandboxTemplate golden-image builds
+
+SandboxTemplate turns an OCI image into a **Firecracker golden image**: a
+converted rootfs plus a validated full snapshot, published to an S3-compatible
+object store. The Firecracker runtime consumes the artifacts on demand
+(`SandboxSpec.Image` → index → manifest → digest-verified pull → restore), so
+this is the build-time half of the [on-demand loading
+design](../design/firecracker-on-demand-loading.md).
+
+The design and artifact contract live in
+[sandboxtemplate-golden-image-builds.md](../design/sandboxtemplate-golden-image-builds.md);
+this guide covers operating the resource end to end.
+
+## End-to-end workflow
+
+```text
+SandboxTemplate CR (spec)
+  → controller creates a privileged build Pod on a KVM node
+  → convert: OCI layers → sparse ext4 rootfs + runtime injection (execd/init/envs)
+  → validate-boot: cold boot + guest readiness
+  → snapshot: pause → full snapshot (vmstate.snap + memory.snap) → restore validation
+  → package (format=overlaybd): rootfs/memory → LSMT layers
+  → manifest.json + SHA256SUMS (content-addressed)
+  → publish: s3://<publish>/<sha256(manifest)[:16]>/… + index/<sha256(image)>.json
+  → status.manifestRef / status.artifactDigest recorded on the CR
+  → runtime-agent PullImage/PinImage resolves SandboxSpec.Image → restore
+```
+
+## Prerequisites
+
+| Item | Requirement |
+|------|-------------|
+| KVM build nodes | Nodes labeled `sandbox.fast.io/kvm=true`, exposing `/dev/kvm` and `/dev/net/tun`; the build Pod is pinned to them via nodeSelector |
+| Object store | S3-compatible bucket (MinIO/OSS/S3); reachable from the builder |
+| Publish secret | `imagePullSecrets`-style Secret in the **platform namespace** (`fast-sandbox-system`) with keys `accessKeyId`, `secretAccessKey`, `endpoint`, `region` |
+| Controller | The SandboxTemplate reconciler must be running (it drives the build Pod and status) |
+
+The builder image is `build/Dockerfile.sandboxtemplate-builder` (oci2rootfs,
+firecracker v1.16.1, embedded guest kernel, OverlayBD toolchain, aws CLI v2).
+
+## Example
+
+```yaml
+apiVersion: sandbox.fast.io/v1alpha2
+kind: SandboxTemplate
+metadata:
+  name: ai-office-sandbox
+  namespace: fast-sandbox
+spec:
+  image: registry.example.com/sandbox:v1.0.21
+  kernel: vmlinux.bin
+  machine:
+    vcpu: "2"
+    memory: "2Gi"
+  entrypoint:
+    - /opt/gem/run.sh
+  execd: ghcr.io/opensandbox/execd:v1.0.21
+  init: /usr/local/sbin/sandbox-init
+  envs:
+    - name: SANDBOX_MODE
+      value: office
+  readiness:
+    probe: tcp://127.0.0.1:44772
+    warmupSeconds: 60
+  output:
+    rootfsSize: "30Gi"
+    format: overlaybd
+    publish: s3://sandbox-images/publish
+    publishSecretRef:
+      name: sandbox-images-readwrite
+```
+
+```sh
+kubectl apply -f template.yaml
+kubectl -n fast-sandbox get sandboxtemplate ai-office-sandbox -o yaml   # status.phase
+```
+
+## Field reference
+
+### `spec.image`
+
+Required. The OCI image reference to convert, e.g.
+`registry.example.com/sandbox:v1.0.21`. This exact string becomes the
+**consumer-side addressing key**: `SandboxSpec.Image` must be byte-identical
+(no default tag, no digest pin, no trimming) — the published index is keyed
+by `sha256(image)` verbatim, and both sides reject empty references.
+
+### `spec.kernel`
+
+Required. The guest kernel name embedded in the builder image
+(`/usr/local/share/firecracker/<name>`, default `vmlinux.bin`; the
+`KERNEL_NAME`/`KERNEL_URL` build args pin it). The kernel is a **build-time
+asset**: nodes never preinstall it, restore does not boot a kernel. Its digest
+is recorded in the manifest for compatibility matching.
+
+### `spec.machine`
+
+The reference machine of the golden image — the CPU/memory the snapshot is
+created with. Restore requires the same memory as the snapshot (Firecracker
+rejects a different `mem_size_mib`), so the request memory must be ≥ this
+value. Both are Kubernetes resource quantities.
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `machine.vcpu` | `"1"` | vCPUs of the snapshot VM |
+| `machine.memory` | `"2Gi"` | Guest memory of the snapshot VM |
+
+### `spec.entrypoint`
+
+Optional. The guest business command as an argv list; empty defaults to
+`["tail", "-f", "/dev/null"]` (the sandbox stays alive as an environment and
+work is driven through execd/SDK). An explicit value fully replaces the
+default. At runtime `CreateSandboxRequest.entrypoint` overrides the template
+value.
+
+### `spec.execd`
+
+Optional. The OpenSandbox execd image whose runtime files are injected into
+the guest rootfs at build time. When set, the guest init probes execd `/ping`
+as the default readiness gate.
+
+### `spec.init`
+
+Optional. The injected guest PID 1 path inside the rootfs; empty defaults to
+`/usr/local/sbin/sandbox-init`. The init script carries the readiness marker
+(`SANDBOX_READY`), the heartbeat loop (`SANDBOX_HEARTBEAT`), mounts, envs, and
+the entrypoint. It does **not** re-run after a snapshot restore — that is why
+readiness and network are baked into the snapshot.
+
+### `spec.envs`
+
+Optional. Literal `EnvVar` array written verbatim into
+`/etc/sandbox-init.env`. `valueFrom` is not supported, and the source image's
+own `Config.Env` is not merged. Do not place secrets here — they are published
+verbatim in the manifest; use `publishSecretRef` for credentials.
+
+### `spec.readiness`
+
+Defines when the guest is considered ready for the snapshot.
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `readiness.probe` | empty | Custom gate, checked first: `tcp://host:port` or `cmd://<command>` |
+| `readiness.warmupSeconds` | `60` | Fallback time-based warmup (minimum 0) |
+| `readiness.healthCheck` | empty | Fallback health command; empty uses the source image `CMD-SHELL` |
+
+Precedence: custom `probe` → execd `/ping` (when execd is injected) →
+`warmupSeconds` + `healthCheck`.
+
+### `spec.output`
+
+| Field | Required | Default | Meaning |
+| --- | ---: | --- | --- |
+| `output.rootfsSize` | Yes | `"30Gi"` | Logical capacity of the produced `rootfs.ext4` (Kubernetes quantity). Rounded **up** to SI GiB for oci2rootfs (`30Gi` → 33G → ~30.7 GiB sparse file) |
+| `output.format` | Yes | `overlaybd` | `native` (raw snapshot files only) or `overlaybd` (plus LSMT layers for on-demand range reads); both contain the full artifact set |
+| `output.publish` | Yes | — | S3-compatible target, e.g. `s3://sandbox-images/publish`. Digest-addressed publication; without it the build has no durable artifacts (the builder refuses to run unless `SANDBOX_TEMPLATE_ALLOW_NO_PUBLISH=1`) |
+| `output.publishSecretRef` | No | — | Name of the write-credential Secret in the platform namespace (`accessKeyId`/`secretAccessKey`/`endpoint`/`region`). Without it the build relies on platform-level credentials (IRSA/node metadata). Runtime nodes read with a **separate** read-only credential — write keys never reach them |
+| `output.prime` | No | — | Reserved: seed-node cache priming after a successful build; not yet implemented |
+
+## Build lifecycle
+
+- **Status machine**: `Pending` → `Building` → `Succeeded` / `Failed`. On
+  success `status.manifestRef` (the published manifest URI) and
+  `status.artifactDigest` (sha256 of the manifest document) are recorded, with
+  `LastBuildTime` and a `BuildSucceeded=True` condition.
+- **Rebuild**: edit the spec — the generation bump triggers a new build. A
+  mid-build spec change deletes the stale build Pod immediately (concurrent
+  privileged builds cannot stack up).
+- **Build Pods** run in the platform namespace as
+  `<template>-build-<generation>`, pinned to `sandbox.fast.io/kvm=true` nodes
+  with `/dev/kvm` and `/dev/net/tun` passed through; they have a 2 h deadline
+  and a 10 min Pending timeout (a missing KVM node fails the build instead of
+  hanging forever). Deleting the template reaps its build Pods via a finalizer.
+- **Diagnostics**: failed builds surface the container exit reason/message in
+  the condition; the Pod logs (`kubectl -n fast-sandbox logs <build-pod>`)
+  carry per-stage timings (`pullMs`, `bootToReadyMs`, `snapshotCreateMs`,
+  `restoreToHeartbeatMs`, `importRootfsMs`, …).
+
+## Published artifacts
+
+```text
+s3://sandbox-images/publish/
+├── <sha256(manifest)[:16]>/          # per-build digest namespace
+│   ├── rootfs.ext4                   # sparse ext4 (native filename: rootfs.img)
+│   ├── vmstate.snap
+│   ├── memory.snap
+│   ├── overlaybd/{rootfs,memory}/layer.lsmt   # format=overlaybd only
+│   ├── SHA256SUMS                    # audit copy
+│   └── manifest.json                 # uploaded last (commit point)
+└── index/<sha256(image)>.json        # image → latest manifestRef, last-writer-wins
+```
+
+`manifest.json` records (among others):
+
+- `machine` — the vcpu/memory tuple restore validates against;
+- `guestNetwork` — the NIC baked into the snapshot (`eth0` + static
+  guest IP/MAC); the runtime replaces only the host tap via
+  `network_overrides`;
+- `files` — publish filename → `{sha256, sizeBytes}` for digest-verified pull;
+- `compatibility` — firecracker version / host kernel / CPU model;
+- `kernel` / `sourceImage` / `sourceImageDigest` / `validation` — build
+  provenance and gates.
+
+The consumer-side cache layout is
+`<StateRoot>/images/<sha256(image)>/{rootfs.img, vmstate.snap, memory.snap,
+manifest.json}` (native filename mapping: `rootfs.ext4` → `rootfs.img`).
+
+## Consuming the artifacts
+
+- Set `SandboxPool.spec.warmImages` to the template's `spec.image` reference
+  to pre-warm node caches; sandboxes created with the same `image` restore
+  from the published snapshot.
+- The image reference must be byte-identical between template and sandbox
+  (no normalization).
+- The snapshot machine tuple must fit the requested sandbox resources:
+  requesting less memory than the snapshot fails explicitly.
+- The snapshot carries one baked guest NIC (`guestNetwork`): every restored
+  instance resumes with the same guest IP/MAC (clone networking model), and
+  the snapshot holds **no active connections** — re-establish connectivity
+  after restore.
+
+## Notes and constraints
+
+- **SandboxTemplate is "run an arbitrary OCI image as root on a KVM host"**:
+  restrict creation to trusted operators (cluster-admin or a dedicated Role).
+- The build bakes a NIC but deliberately not connectivity; snapshots of
+  workloads with live connections are out of scope.
+- `rootfsSize` is a minimum, not an exact size; the file is sparse.
+- Readiness must reflect the real workload: a misconfigured gate can produce a
+  "healthy" snapshot that is not actually ready.
+
+## See also
+
+- [Design: SandboxTemplate golden-image builds](../design/sandboxtemplate-golden-image-builds.md)
+- [Design: Firecracker on-demand loading](../design/firecracker-on-demand-loading.md)
+- [E2E: golden-image builder](sandboxtemplate-golden-image-e2e.md)
+- [Reference: API](../reference/api.md) (SandboxTemplate CRD fields)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -141,6 +141,82 @@ and `RegistryReady`.
 See the [Infra Components reference](infra-components.md) for the complete
 artifact, process, health, endpoint, validation, and revision contract.
 
+## SandboxTemplate
+
+SandboxTemplate declares a golden-image build for the Firecracker runtime: an
+OCI source image, runtime injection, guest init, readiness, and output
+artifacts published to an S3-compatible store. The build is executed by a
+controller as a privileged Pod on a KVM node.
+
+```yaml
+apiVersion: sandbox.fast.io/v1alpha2
+kind: SandboxTemplate
+metadata:
+  name: ai-office-sandbox
+  namespace: fast-sandbox
+spec:
+  image: registry.example.com/sandbox:v1.0.21
+  kernel: vmlinux.bin
+  machine:
+    vcpu: "2"
+    memory: "2Gi"
+  entrypoint: ["/opt/gem/run.sh"]
+  init: /usr/local/sbin/sandbox-init
+  envs:
+    - name: FOO
+      value: bar
+  readiness:
+    warmupSeconds: 60
+  output:
+    rootfsSize: "30Gi"
+    format: overlaybd
+    publish: s3://sandbox-images/publish
+    publishSecretRef:
+      name: sandbox-images-readwrite
+```
+
+### Spec
+
+| Field | Required | Default | Meaning |
+| --- | ---: | --- | --- |
+| `image` | Yes | — | OCI image reference to convert; becomes the byte-identical consumer-side addressing key |
+| `kernel` | Yes | — | Guest kernel embedded in the builder image (build-time asset, not a node runtime asset) |
+| `machine.vcpu` | Yes | `"1"` | Snapshot VM vCPUs (resource quantity) |
+| `machine.memory` | Yes | `"2Gi"` | Snapshot VM memory (resource quantity); restore requires ≥ this |
+| `entrypoint` | No | `["tail","-f","/dev/null"]` | Guest business command as an argv list |
+| `execd` | No | — | OpenSandbox execd image injected into the guest rootfs |
+| `init` | No | `/usr/local/sbin/sandbox-init` | Injected guest PID 1 (readiness marker + heartbeat) |
+| `envs` | No | — | Literal `EnvVar` array written to `/etc/sandbox-init.env`; `valueFrom` unsupported, image `Config.Env` not merged, published verbatim in the manifest |
+| `readiness.probe` | No | — | Custom gate first: `tcp://host:port` or `cmd://<command>` |
+| `readiness.warmupSeconds` | Yes | `60` | Fallback time-based warmup |
+| `readiness.healthCheck` | No | — | Fallback health command; empty uses image `CMD-SHELL` |
+| `output.rootfsSize` | Yes | `"30Gi"` | Logical rootfs capacity (minimum, rounded up to SI GiB) |
+| `output.format` | Yes | `overlaybd` | `native` or `overlaybd` (both contain the full snapshot set) |
+| `output.publish` | Yes | — | S3-compatible digest-addressed publish target, e.g. `s3://bucket/prefix` |
+| `output.publishSecretRef` | No | — | Write-credential Secret name in the platform namespace (`accessKeyId`/`secretAccessKey`/`endpoint`/`region`) |
+| `output.prime` | No | — | Reserved: seed-node cache priming; not yet implemented |
+
+Readiness precedence: custom `probe` → execd `/ping` → `warmupSeconds` +
+`healthCheck`.
+
+### Status
+
+| Field | Meaning |
+| --- | --- |
+| `phase` | `Pending`, `Building`, `Succeeded`, or `Failed` |
+| `conditions` | `BuildSucceeded` with reason/message on terminal states |
+| `manifestRef` | Published manifest URI (`s3://…/<sha256(manifest)[:16]>/manifest.json`) |
+| `artifactDigest` | sha256 of the manifest document itself |
+| `lastBuildTime` | When the latest build completed |
+| `observedGeneration` | Generation of the last applied build |
+
+Build Pods run in the platform namespace as `<template>-build-<generation>`,
+pinned to `sandbox.fast.io/kvm=true` nodes; editing the spec triggers a
+rebuild (generation bump), and deleting the template reaps its Pods.
+
+See the [SandboxTemplate guide](../guides/sandboxtemplate-golden-images.md)
+for the end-to-end workflow, artifact layout, and consumption contract.
+
 ## FastPath v2
 
 The protobuf contract is

--- a/internal/registryconfig/types.go
+++ b/internal/registryconfig/types.go
@@ -39,6 +39,13 @@ type Credential struct {
 	Username         string `json:"username,omitempty"`
 	Password         string `json:"password,omitempty"`
 	IdentityToken    string `json:"identityToken,omitempty"`
+	// Endpoint is the connection address of an S3-compatible artifact store
+	// (firecracker runtime-agent), e.g. "http://127.0.0.1:9000". Host keeps
+	// its matching-key meaning (registry host, or the artifact store host
+	// matched against the store root); Endpoint may carry the scheme and
+	// port and is used verbatim, so it is exempt from host normalization.
+	// Image-registry credentials leave it empty.
+	Endpoint string `json:"endpoint,omitempty"`
 }
 
 type Compiled struct {
@@ -153,6 +160,21 @@ func (c Compiled) Match(reference string) (Credential, bool) {
 	return selected, selectedLength >= 0
 }
 
+// MatchHost selects the credential whose normalized Host equals host,
+// ignoring repository prefixes. This is the artifact-store lookup of the
+// firecracker runtime-agent: the match key is the store endpoint host
+// itself (e.g. "127.0.0.1:9000"), not an image reference, so the
+// reference-splitting rules of Match do not apply.
+func (c Compiled) MatchHost(host string) (Credential, bool) {
+	normalized := NormalizeHost(host)
+	for _, credential := range c.Credentials {
+		if NormalizeHost(credential.Host) == normalized {
+			return credential, true
+		}
+	}
+	return Credential{}, false
+}
+
 type FileProvider struct {
 	path        string
 	mu          sync.RWMutex
@@ -171,6 +193,18 @@ func (p *FileProvider) Credentials(reference string) (Credential, bool, error) {
 		return Credential{}, false, err
 	}
 	credential, found := compiled.Match(reference)
+	return credential, found, nil
+}
+
+// CredentialsForHost resolves a credential by normalized host match (the
+// artifact-store lookup of the firecracker runtime-agent), bypassing the
+// image-reference semantics of Match.
+func (p *FileProvider) CredentialsForHost(host string) (Credential, bool, error) {
+	compiled, err := p.load()
+	if err != nil {
+		return Credential{}, false, err
+	}
+	credential, found := compiled.MatchHost(host)
 	return credential, found, nil
 }
 

--- a/internal/runtime/firecracker/agent/s3client.go
+++ b/internal/runtime/firecracker/agent/s3client.go
@@ -65,14 +65,18 @@ type s3Client struct {
 }
 
 // newS3Client parses the store root (s3://bucket/prefix) and the read-only
-// credential into a GET client. The credential Host names the store
-// endpoint; Username/Password carry the access key pair.
+// credential into a GET client. The credential Host names the store endpoint
+// (matching key); the optional credential Endpoint overrides the connection
+// address with a scheme/port (e.g. a local MinIO), falling back to Host.
 func newS3Client(storeRoot string, credential registryconfig.Credential, httpClient *http.Client, region, endpointOverride string) (*s3Client, error) {
 	bucket, prefix, err := parseStoreRoot(storeRoot)
 	if err != nil {
 		return nil, err
 	}
 	endpoint := endpointOverride
+	if endpoint == "" {
+		endpoint = credential.Endpoint
+	}
 	if endpoint == "" {
 		endpoint = credential.Host
 	}

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -699,7 +699,9 @@ func (d *Driver) launchVM(ctx context.Context, sandboxID, apiAddress, stateDir s
 	})
 }
 
-// waitForAPISocket polls until the Firecracker API Unix socket exists.
+// waitForAPISocket polls until the Firecracker API Unix socket exists. The
+// 20 ms poll keeps the launch latency near the VMM's own startup time
+// (firecracker creates the socket within tens of milliseconds).
 func waitForAPISocket(ctx context.Context, socketPath string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for {
@@ -712,7 +714,7 @@ func waitForAPISocket(ctx context.Context, socketPath string, timeout time.Durat
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(20 * time.Millisecond):
 		}
 	}
 }

--- a/internal/runtime/firecracker/e2e_test.go
+++ b/internal/runtime/firecracker/e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -192,6 +193,12 @@ func runE2EOnce(t *testing.T, useInfra bool) {
 	}
 
 	env.assertGuestReachable(spec.SandboxID)
+	// The chain E2E builder bakes execd into the golden snapshot when
+	// CHAIN_EXECD is set; probing its /ping endpoint proves the template's
+	// runtime bootstrap survived the restore (not just ICMP reachability).
+	if os.Getenv("FC_EXECD_PROBE") == "1" {
+		env.assertGuestExecd(spec.SandboxID)
+	}
 
 	// Inspect reports the running VM.
 	inspected, err := env.driver.InspectSandbox(ctx, spec.SandboxID)
@@ -224,6 +231,12 @@ const e2ePrepVersion = 2
 // (started with cwd = their state dir) resolve the same baked path to
 // their own reflink copy. The guest IP baked by the prep boot args must
 // match the first slot's guest address for reachability assertions.
+//
+// External-artifact mode (FC_SKIP_PREP=1): the chain E2E
+// (scripts/firecracker-chain-e2e.sh) pulls the golden set through the real
+// runtime-agent from the builder's published output, so the prep would
+// overwrite the very artifacts under test. The cache layout is validated
+// instead of bootstrapped.
 func prepareE2EGoldenSnapshot(t *testing.T, binary, kernel, rootfs, stateRoot, imageRef, bootArgs string) {
 	t.Helper()
 	dir := filepath.Join(stateRoot, imageCacheDir, imageKey(imageRef))
@@ -232,6 +245,20 @@ func prepareE2EGoldenSnapshot(t *testing.T, binary, kernel, rootfs, stateRoot, i
 	memory := filepath.Join(dir, memorySnapshotName)
 	manifestPath := filepath.Join(dir, "manifest.json")
 	versionMarker := filepath.Join(dir, ".prep-version")
+	if os.Getenv("FC_SKIP_PREP") == "1" {
+		// The golden set must be complete (the agent's pull commits the
+		// manifest last) and carry the machine tuple restore validates.
+		for _, path := range []string{rootfsImg, vmstate, memory, manifestPath} {
+			require.FileExists(t, path, "external golden set is incomplete (FC_SKIP_PREP)")
+		}
+		require.FileExists(t, kernel, "FC_KERNEL")
+		require.FileExists(t, rootfs, "FC_ROOTFS")
+		_, ok, err := readCachedManifestMachine(stateRoot, imageRef)
+		require.NoError(t, err)
+		require.True(t, ok, "external manifest carries no machine tuple (machine=1/512Mi required for the E2E spec)")
+		t.Logf("reusing externally pulled golden snapshot set %s (FC_SKIP_PREP)", dir)
+		return
+	}
 	complete := func() bool {
 		for _, path := range []string{rootfsImg, vmstate, memory, manifestPath} {
 			if info, err := os.Stat(path); err != nil || info.IsDir() {
@@ -489,6 +516,13 @@ func newE2EEnvironment(t *testing.T, capacity int, infraEnabled bool) *e2eEnviro
 	driver, err := New(profile)
 	require.NoError(t, err)
 	driver.SetNetworkManager(manager)
+	// When the chain E2E runs a real runtime-agent (FC_AGENT_SOCKET), wire
+	// the driver to it: DeleteSandbox then releases/unpins through the UDS
+	// API instead of staying in local mode.
+	if agentSocket := os.Getenv("FC_AGENT_SOCKET"); agentSocket != "" {
+		driver.SetFastletPodUID(podUID)
+		driver.SetAgentSocket(agentSocket)
+	}
 
 	env := &e2eEnvironment{
 		t: t, manager: manager, driver: driver, imageRef: imageRef,
@@ -623,6 +657,48 @@ func (env *e2eEnvironment) assertGuestReachable(sandboxID string) {
 		require.NoErrorf(t, err, "guest %s not reachable: %s", guestIP, output)
 	}
 	t.Logf("guest reachable at %s (slot %s, tap %s)", guestIP, slot.IP, slot.GuestTap)
+}
+
+// assertGuestExecd verifies the execd baked into the golden snapshot (by
+// the chain E2E builder, CHAIN_EXECD) answers its /ping endpoint inside
+// the restored guest. The guest IP is derived from the slot (baked static
+// address), so the probe travels the real host -> bridge -> tap -> guest
+// data path and lands on the execd process that survived restore.
+//
+// VM Running (firecracker state) does NOT imply execd readiness: the guest
+// resumes, its virtio-net reconnects, and execd's listener re-readies, so
+// the probe retries for a short window and reports the delta between the
+// VM delivery and the business-runtime readiness (the sandbox-usable SLO).
+func (env *e2eEnvironment) assertGuestExecd(sandboxID string) {
+	t := env.t
+	t.Helper()
+	slot, ok := env.manager.Lookup(sandboxID)
+	require.True(t, ok)
+	guestIP, err := fastletnetwork.GuestVMIP(slot)
+	require.NoError(t, err)
+	endpoint := fmt.Sprintf("http://%s:44772/ping", guestIP)
+	client := &http.Client{Timeout: 2 * time.Second}
+	probeStarted := time.Now()
+	deadline := probeStarted.Add(15 * time.Second)
+	var lastErr error
+	for {
+		response, err := client.Get(endpoint)
+		if err == nil && response.StatusCode == http.StatusOK {
+			response.Body.Close()
+			t.Logf("execd /ping OK at %s after %s (VM running + %s)", endpoint, time.Since(probeStarted), time.Since(probeStarted))
+			return
+		}
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = fmt.Errorf("status %d", response.StatusCode)
+			response.Body.Close()
+		}
+		if time.Now().After(deadline) {
+			require.NoErrorf(t, lastErr, "execd /ping unreachable at %s within 15s", endpoint)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 }
 
 // delete stops the VM, releases the slot, and removes the state.

--- a/internal/runtime/firecracker/images.go
+++ b/internal/runtime/firecracker/images.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 
 	runtimecontract "fast-sandbox/internal/runtime/contract"
+
+	"k8s.io/klog/v2"
 )
 
 // imageCacheDir holds content-addressed rootfs images:
@@ -109,11 +111,13 @@ func prepareInstanceRootfs(stateRoot, image, instanceDir string) (string, error)
 }
 
 // copyReflinkOrCopy attempts a CoW reflink copy and falls back to a plain
-// copy when the host filesystem does not support reflinks.
+// copy when the host filesystem does not support reflinks (e.g. ext4): the
+// fallback pays a full rootfs copy (~1.7 GB/s) per create.
 func copyReflinkOrCopy(source, target string) error {
 	if exec.Command("cp", "--reflink=always", source, target).Run() == nil {
 		return nil
 	}
+	klog.V(4).InfoS("reflink copy unavailable, falling back to a full copy", "source", source)
 	_ = os.Remove(target)
 	return copyFile(source, target)
 }

--- a/internal/runtime/firecracker/infra_delivery.go
+++ b/internal/runtime/firecracker/infra_delivery.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	fastletinfra "fast-sandbox/internal/fastlet/infra"
 	fastletnetwork "fast-sandbox/internal/fastlet/network"
+
+	"k8s.io/klog/v2"
 )
 
 // deliverGuestInfra performs the GuestCopy Infra delivery by loop-mounting the
@@ -29,9 +32,15 @@ func deliverGuestInfra(ctx context.Context, runner fastletnetwork.CommandRunner,
 	}
 	defer os.RemoveAll(mountpoint)
 
+	// Per-step timing isolates the GuestCopy cost: mounting a multi-GiB
+	// sparse ext4 image read-write can initialize metadata/journal regions
+	// (allocating blocks over the holes), which is where the delivery
+	// latency tends to hide.
+	mountStarted := time.Now()
 	if _, err := runner.Run(ctx, "mount", "-o", "loop", rootfsImage, mountpoint); err != nil {
 		return fmt.Errorf("mount guest rootfs for Infra delivery: %w", err)
 	}
+	klog.V(4).InfoS("infra delivery: rootfs mounted", "rootfs", rootfsImage, "mountMs", time.Since(mountStarted).Milliseconds())
 	mounted := true
 	defer func() {
 		if mounted {
@@ -39,6 +48,7 @@ func deliverGuestInfra(ctx context.Context, runner fastletnetwork.CommandRunner,
 		}
 	}()
 
+	copyStarted := time.Now()
 	for _, mount := range instance.Mounts {
 		if mount.Source == "" || mount.Destination == "" {
 			continue
@@ -51,9 +61,12 @@ func deliverGuestInfra(ctx context.Context, runner fastletnetwork.CommandRunner,
 			return fmt.Errorf("copy Infra artifact to %s: %w", mount.Destination, err)
 		}
 	}
+	klog.V(4).InfoS("infra delivery: artifacts copied", "files", len(instance.Mounts), "copyMs", time.Since(copyStarted).Milliseconds())
+	umountStarted := time.Now()
 	if _, err := runner.Run(ctx, "umount", mountpoint); err != nil {
 		return err
 	}
+	klog.V(4).InfoS("infra delivery: rootfs unmounted", "umountMs", time.Since(umountStarted).Milliseconds())
 	mounted = false
 	return nil
 }

--- a/scripts/firecracker-chain-e2e.sh
+++ b/scripts/firecracker-chain-e2e.sh
@@ -1,0 +1,672 @@
+#!/usr/bin/env bash
+# firecracker-chain-e2e.sh — full-chain E2E (stage-1 closeout,
+# docs/design/firecracker-chain-e2e-plan.md): builder publish -> real MinIO
+# -> runtime-agent pull -> driver golden restore -> guest reachability ->
+# idempotency + cleanup. No component is faked: the builder image, the MinIO
+# store, the firecracker-runtime-agent binary, and the Firecracker driver
+# (via its Go E2E suite) all run for real.
+#
+# Scenarios:
+#   A. pull chain — the builder publishes a golden snapshot set (index +
+#      SHA256SUMS + digest-addressed build); the runtime-agent pulls it over
+#      the wire (path-style SigV4 against MinIO) through its UDS API;
+#   B. restore — the driver restores sandboxes from the pulled artifacts
+#      (FC_SKIP_PREP: no self-bootstrap, the builder output IS the golden
+#      set) and the guest is reachable at the baked address;
+#   C. full chain — A+B plus idempotency (re-PinImage pulls nothing),
+#      lease lifecycle (LeaseDevices/ReleaseDevices/ListLeases), and driver
+#      delete -> agent unpin through the UDS API.
+#
+# Requirements: Linux x86_64, root (netns/tap/iptables setup; the script
+# re-invokes itself with sudo), /dev/kvm, /dev/net/tun, docker, go, curl, jq.
+# Same reference host as firecracker-e2e.sh and sandboxtemplate-e2e.sh.
+#
+# Host impact: the driver E2E creates a private 172.30.0.0/24 bridge plus one
+# MASQUERADE rule and host ip_forward; all restored automatically on exit.
+# MinIO runs as a docker container (removed on exit). The builder creates and
+# deletes its own build tap.
+#
+# Overrides (environment):
+#   CHAIN_SOURCE_IMAGE   OCI image converted by the builder (default alpine:3.19)
+#   CHAIN_IMAGE          image reference addressed end to end (default chain-test:v1)
+#   CHAIN_MACHINE_VCPU   builder machine vcpu (default 1; must fit the E2E spec)
+#   CHAIN_MACHINE_MEM    builder machine memory (default 512Mi)
+#   CHAIN_ROOTFS_SIZE    builder rootfsSize (default 10Gi)
+#   MINIO_IMAGE          minio/minio image tag (default minio/minio:latest)
+#   MINIO_PORT           MinIO API port on the host (default 9000)
+#   MINIO_AK / MINIO_SK  MinIO root credentials (default chain-test / chain-test-secret)
+#   WORK                 workspace, default $PWD/.firecracker-chain-e2e
+#   SANDBOX_TEMPLATE_BUILDER_IMAGE  builder image name (default sandboxtemplate-builder:chain-e2e)
+#   plus the driver E2E overrides FC_VERSION/FC_BINARY/FC_KERNEL/FC_ROOTFS/FC_STATE_ROOT.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="${WORK:-$PWD/.firecracker-chain-e2e}"
+BIN_DIR="$WORK/bin"
+ART_DIR="$WORK/artifacts"
+
+CHAIN_SOURCE_IMAGE="${CHAIN_SOURCE_IMAGE:-alpine:3.19}"
+CHAIN_IMAGE="${CHAIN_IMAGE:-chain-test:v1}"
+CHAIN_MACHINE_VCPU="${CHAIN_MACHINE_VCPU:-1}"
+CHAIN_MACHINE_MEM="${CHAIN_MACHINE_MEM:-512Mi}"
+CHAIN_ROOTFS_SIZE="${CHAIN_ROOTFS_SIZE:-2Gi}"
+# The execd image baked into the golden snapshot: the builder injects its
+# runtime files, the guest init starts it, and scenario B probes GET /ping
+# as the VM-running evidence. Override with CHAIN_EXECD if needed.
+CHAIN_EXECD="${CHAIN_EXECD:-opensandbox/execd:1.1.0}"
+MINIO_IMAGE="${MINIO_IMAGE:-minio/minio:latest}"
+MINIO_PORT="${MINIO_PORT:-9000}"
+MINIO_AK="${MINIO_AK:-chain-test}"
+MINIO_SK="${MINIO_SK:-chain-test-secret}"
+MINIO_BUCKET="sandbox-images"
+MINIO_CONTAINER="chain-e2e-minio"
+BUILDER_IMAGE="${SANDBOX_TEMPLATE_BUILDER_IMAGE:-sandboxtemplate-builder:chain-e2e}"
+
+FC_VERSION="${FC_VERSION:-v1.16.1}"
+FC_BINARY="${FC_BINARY:-$BIN_DIR/firecracker}"
+FC_KERNEL="${FC_KERNEL:-$ART_DIR/vmlinux.bin}"
+FC_ROOTFS="${FC_ROOTFS:-$ART_DIR/bionic.rootfs.ext4}"
+FC_STATE_ROOT="${FC_STATE_ROOT:-$WORK/state-root}"
+AGENT_SOCKET="$WORK/runtime.sock"
+AGENT_BIN="$WORK/firecracker-runtime-agent"
+REGISTRY_FILE="$WORK/registry.json"
+# The agent cache and the driver E2E must share one state root; following
+# FC_STATE_ROOT lets the operator point both at a reflink-capable mount
+# (scripts/firecracker-xfs-stateroot.sh).
+STATE_ROOT_DIR="$FC_STATE_ROOT"
+MINIO_DATA="$WORK/minio-data"
+AGENT_PID=""
+
+STORE_ROOT="s3://$MINIO_BUCKET/publish"
+MINIO_ENDPOINT="http://127.0.0.1:$MINIO_PORT"
+
+PRIVATE_CIDR="172.30.0.0/24"
+BRIDGE_NAME="fsb0"
+
+log() { printf '\033[1;34m[chain-e2e]\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m[chain-e2e] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+pass() { printf '\033[1;32m[chain-e2e] PASS\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[chain-e2e] FAIL\033[0m %s\n' "$*" >&2; exit 1; }
+
+# --- host state (shared with the driver E2E: bridge, MASQUERADE, forward) ----
+fsb_netns_pattern='^fsb[0-9a-f]{32,}$'
+fsb0_dev_pattern='^(fc|fh)[0-9a-f]{10,}$'
+PRE_RUN_NETNS="$WORK/pre-run-netns"
+
+is_live_netns() { ip netns list 2>/dev/null | awk '{print $1}' | grep -qx "$1"; }
+
+kill_firecracker_vms() {
+    for pid in $(pgrep -f "firecracker .*--id e2e-sandbox-" 2>/dev/null || true); do
+        kill "$pid" 2>/dev/null || true
+    done
+    sleep 1
+}
+
+purge_fsb_resources() {
+    kill_firecracker_vms
+    for path in /var/run/netns/fsb*; do
+        [[ -e "$path" ]] || continue
+        name="$(basename "$path")"
+        [[ "$name" =~ $fsb_netns_pattern ]] || continue
+        if is_live_netns "$name"; then
+            for attempt in 1 2 3; do
+                ip netns del "$name" 2>/dev/null && break
+                sleep 0.2
+            done
+        fi
+        [[ -e "$path" ]] && rm -f "$path"
+    done
+    for dev in $(ip -o link show master "$BRIDGE_NAME" 2>/dev/null | awk -F'[ :]+' '{print $2}' | sort -u); do
+        [[ "$dev" =~ $fsb0_dev_pattern ]] || [[ "$dev" =~ ^fc-[0-9a-f]{10}$ ]] || continue
+        ip link del "$dev" 2>/dev/null || true
+    done
+}
+
+# Defaults for the pre-run host state, so cleanup is safe even when the
+# failure happened before record_host_state ran.
+_bridge_before="no"
+_masq_before="no"
+_forward_before="1"
+
+record_host_state() {
+    _forward_before="$(cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo 1)"
+    _bridge_before="no"
+    if ip link show "$BRIDGE_NAME" >/dev/null 2>&1; then _bridge_before="yes"; fi
+    _masq_before="no"
+    if iptables -t nat -C POSTROUTING -s "$PRIVATE_CIDR" ! -d "$PRIVATE_CIDR" -j MASQUERADE 2>/dev/null; then _masq_before="yes"; fi
+}
+
+restore_host_state() {
+    if [[ "$_bridge_before" == "no" ]] && ip link show "$BRIDGE_NAME" >/dev/null 2>&1; then
+        ip link del "$BRIDGE_NAME" 2>/dev/null || true
+    fi
+    if [[ "$_masq_before" == "no" ]]; then
+        iptables -t nat -D POSTROUTING -s "$PRIVATE_CIDR" ! -d "$PRIVATE_CIDR" -j MASQUERADE 2>/dev/null || true
+    fi
+    if [[ "$_forward_before" != "1" ]]; then
+        sysctl -w net.ipv4.ip_forward="$_forward_before" >/dev/null 2>&1 || true
+    fi
+}
+
+stop_agent() {
+    if [[ -n "$AGENT_PID" ]] && kill -0 "$AGENT_PID" 2>/dev/null; then
+        kill "$AGENT_PID" 2>/dev/null || true
+        wait "$AGENT_PID" 2>/dev/null || true
+    fi
+    rm -f "$AGENT_SOCKET"
+}
+
+stop_minio() {
+    docker rm -f "$MINIO_CONTAINER" >/dev/null 2>&1 || true
+}
+
+cleanup() {
+    stop_agent
+    stop_minio
+    purge_fsb_resources
+    restore_host_state
+}
+
+# --- re-invoke as root -------------------------------------------------------
+if [[ "$(id -u)" -ne 0 ]]; then
+    if command -v sudo >/dev/null; then
+        log "re-invoking as root (sudo -E)"
+        exec sudo -E env "PATH=$PATH" "WORK=$WORK" "CHAIN_SOURCE_IMAGE=$CHAIN_SOURCE_IMAGE" \
+            "CHAIN_IMAGE=$CHAIN_IMAGE" "CHAIN_MACHINE_VCPU=$CHAIN_MACHINE_VCPU" \
+            "CHAIN_MACHINE_MEM=$CHAIN_MACHINE_MEM" "CHAIN_ROOTFS_SIZE=$CHAIN_ROOTFS_SIZE" \
+            "CHAIN_EXECD=$CHAIN_EXECD" \
+            "MINIO_IMAGE=$MINIO_IMAGE" "MINIO_PORT=$MINIO_PORT" "MINIO_AK=$MINIO_AK" \
+            "MINIO_SK=$MINIO_SK" "SANDBOX_TEMPLATE_BUILDER_IMAGE=$BUILDER_IMAGE" \
+            "FC_VERSION=$FC_VERSION" "FC_BINARY=$FC_BINARY" "FC_KERNEL=$FC_KERNEL" \
+            "FC_ROOTFS=$FC_ROOTFS" "FC_STATE_ROOT=$FC_STATE_ROOT" \
+            "$0" "$@"
+    fi
+    die "must run as root (or install sudo)"
+fi
+
+# --- explicit cleanup mode ---------------------------------------------------
+if [[ "${1:-}" == "--cleanup" ]]; then
+    record_host_state
+    cleanup
+    log "host cleanup done (agent, MinIO container, netns, firecracker processes, bridge, MASQUERADE rule)"
+    exit 0
+fi
+
+# --- host prechecks ----------------------------------------------------------
+[[ "$(uname -s)" == "Linux" ]] || die "requires Linux, got $(uname -s)"
+[[ "$(uname -m)" == "x86_64" ]] || die "requires x86_64, got $(uname -m)"
+[[ -e /dev/kvm ]] || die "/dev/kvm is missing (enable KVM/nested virt)"
+[[ -e /dev/net/tun ]] || die "/dev/net/tun is missing"
+for cmd in ip iptables sysctl ping curl jq docker go; do
+    command -v "$cmd" >/dev/null || die "missing required command: $cmd"
+done
+docker info >/dev/null 2>&1 || die "docker is not usable (daemon running?)"
+
+# Every set -e termination prints the failing line: without this, a failed
+# command substitution (e.g. a curl that could not connect) exits silently.
+trap 'echo "[chain-e2e] ERROR: line $LINENO: $BASH_COMMAND" >&2' ERR
+
+mkdir -p "$BIN_DIR" "$ART_DIR" "$WORK/input" "$STATE_ROOT_DIR" /run/netns /run/fast-sandbox/netns
+
+# --- artifacts (firecracker binary + snapshot-prep inputs for the driver E2E)
+download() { # url target
+    log "downloading $2"
+    curl -fL --retry 3 -o "$2.tmp" "$1" || die "download failed: $1"
+    mv "$2.tmp" "$2"
+}
+if [[ ! -x "$FC_BINARY" ]]; then
+    tarball="$WORK/firecracker-$FC_VERSION-x86_64.tgz"
+    download "https://github.com/firecracker-microvm/firecracker/releases/download/$FC_VERSION/firecracker-$FC_VERSION-x86_64.tgz" "$tarball"
+    mkdir -p "$WORK/extract"
+    tar -xzf "$tarball" -C "$WORK/extract"
+    found="$(find "$WORK/extract" -type f -name "firecracker-v${FC_VERSION#v}-x86_64" | head -1)"
+    [[ -n "$found" ]] || die "firecracker binary not found in release tarball"
+    cp "$found" "$FC_BINARY" && chmod +x "$FC_BINARY"
+    rm -rf "$WORK/extract"
+fi
+[[ -f "$FC_KERNEL" ]] || download "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin" "$FC_KERNEL"
+[[ -f "$FC_ROOTFS" ]] || download "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/rootfs/bionic.rootfs.ext4" "$FC_ROOTFS"
+
+# --- MinIO -------------------------------------------------------------------
+# From here on every created resource (agent, MinIO container, test bridge,
+# netns, taps) is torn down on exit; --cleanup handles interrupted runs.
+trap 'cleanup' EXIT
+log "starting MinIO ($MINIO_IMAGE) on :$MINIO_PORT"
+docker rm -f "$MINIO_CONTAINER" >/dev/null 2>&1 || true
+# A fresh data dir guarantees the bucket state matches this run: a previous
+# crashed run can leave the store half-initialized (and a stale bucket
+# would make the later mc mb non-idempotent).
+rm -rf "$MINIO_DATA"
+mkdir -p "$MINIO_DATA"
+docker run -d --name "$MINIO_CONTAINER" \
+    -p "$MINIO_PORT":9000 -p 9001:9001 \
+    -e MINIO_ROOT_USER="$MINIO_AK" -e MINIO_ROOT_PASSWORD="$MINIO_SK" \
+    -v "$MINIO_DATA:/data" \
+    "$MINIO_IMAGE" server /data --console-address ":9001" >/dev/null
+for attempt in $(seq 1 30); do
+    if curl -fsS "$MINIO_ENDPOINT/minio/health/live" >/dev/null 2>&1; then break; fi
+    sleep 1
+    [[ "$attempt" == 30 ]] && die "MinIO did not become healthy"
+done
+
+# mc runs as a throwaway container; the alias/config must persist across
+# calls, so the mc config dir is mounted from the workspace.
+mc() { docker run --rm --network host -v "$WORK/mc-config:/root/.mc" minio/mc "$@"; }
+mc alias set chain "$MINIO_ENDPOINT" "$MINIO_AK" "$MINIO_SK" >/dev/null || die "mc alias failed"
+mc mb "chain/$MINIO_BUCKET" >/dev/null || die "mc mb failed"
+# The bucket is the publish target of the builder; verify it really exists
+# (mc mb is a no-op report on an existing bucket) before publishing into it.
+mc stat "chain/$MINIO_BUCKET" >/dev/null || die "bucket $MINIO_BUCKET was not created on MinIO"
+log "MinIO ready: bucket=$MINIO_BUCKET existing objects=$(mc ls --recursive "chain/$MINIO_BUCKET" 2>/dev/null | wc -l)"
+
+# --- builder publish ---------------------------------------------------------
+IMAGE_TAR="$WORK/input/image.tar"
+log "exporting source image $CHAIN_SOURCE_IMAGE"
+docker pull -q "$CHAIN_SOURCE_IMAGE" >/dev/null 2>&1 || die "docker pull failed: $CHAIN_SOURCE_IMAGE"
+docker save "$CHAIN_SOURCE_IMAGE" -o "$IMAGE_TAR" >/dev/null 2>&1 || die "docker save failed"
+
+log "building builder image ($BUILDER_IMAGE)"
+docker build --progress=plain -t "$BUILDER_IMAGE" \
+    -f "$REPO_ROOT/build/Dockerfile.sandboxtemplate-builder" "$REPO_ROOT" || die "builder image build failed"
+
+SPEC_JSON=$(jq -n \
+    --arg image "$CHAIN_IMAGE" \
+    --arg vcpu "$CHAIN_MACHINE_VCPU" \
+    --arg mem "$CHAIN_MACHINE_MEM" \
+    --arg rootfs "$CHAIN_ROOTFS_SIZE" \
+    --arg publish "$STORE_ROOT" \
+    --arg execd "$CHAIN_EXECD" \
+    '{image: $image, entrypoint: ["/bin/sh"], kernel: "vmlinux.bin",
+      machine: {vcpu: $vcpu, memory: $mem}, init: "/usr/local/sbin/sandbox-init",
+      readiness: {warmupSeconds: 15},
+      output: {rootfsSize: $rootfs, format: "native", publish: $publish}}
+     | if $execd != "" then . + {execd: $execd} else . end')
+
+log "running the builder pipeline (publish -> $STORE_ROOT)"
+BUILD_DIR="$WORK/build"
+# A fresh build dir: a crashed run leaves stale unix sockets (boot.sock /
+# restore.sock) that make the next firecracker bind fail and its API
+# wait-for-file pass against the dead socket.
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+if ! docker run --rm \
+    --privileged \
+    --device /dev/kvm:/dev/kvm \
+    --device /dev/net/tun:/dev/net/tun \
+    --add-host host.docker.internal:host-gateway \
+    -v "$WORK/input":/input:ro \
+    -v "$BUILD_DIR":/build \
+    -e SANDBOX_TEMPLATE_SPEC="$SPEC_JSON" \
+    -e SANDBOX_TEMPLATE_WORKDIR=/build \
+    -e SANDBOX_TEMPLATE_IMAGE_TAR=/input/image.tar \
+    -e POD_NAME=chain-e2e \
+    -e POD_NAMESPACE=default \
+    -e AWS_ENDPOINT_URL="http://host.docker.internal:$MINIO_PORT" \
+    -e AWS_ACCESS_KEY_ID="$MINIO_AK" \
+    -e AWS_SECRET_ACCESS_KEY="$MINIO_SK" \
+    -e AWS_DEFAULT_REGION=us-east-1 \
+    "$BUILDER_IMAGE" 2>&1 | tee "$WORK/builder.log"; then
+    # The builder surfaces its own error; the firecracker serial consoles
+    # carry the actual VMM failure (e.g. KVM open errors) and are the first
+    # place to look.
+    echo "=== boot.console.log (tail) ===" >&2
+    tail -60 "$BUILD_DIR/boot.console.log" 2>/dev/null || true
+    echo "=== restore.console.log (tail) ===" >&2
+    tail -60 "$BUILD_DIR/restore.console.log" 2>/dev/null || true
+    echo "=== build tree ===" >&2
+    ls -la "$BUILD_DIR" 2>/dev/null || true
+    die "builder pipeline failed (full log: $WORK/builder.log)"
+fi
+
+# --- publish layout assertions (verification point 1) -------------------------
+log "asserting the published layout"
+INDEX_KEY="index/$(printf '%s' "$CHAIN_IMAGE" | sha256sum | awk '{print $1}').json"
+INDEX_JSON="$(mc cat "chain/$MINIO_BUCKET/publish/$INDEX_KEY")" || fail "index object missing: $INDEX_KEY"
+INDEX_IMAGE="$(printf '%s' "$INDEX_JSON" | jq -r .image)"
+[[ "$INDEX_IMAGE" == "$CHAIN_IMAGE" ]] || fail "index.image=$INDEX_IMAGE != $CHAIN_IMAGE"
+MANIFEST_REF="$(printf '%s' "$INDEX_JSON" | jq -r .manifestRef)"
+MANIFEST_KEY="${MANIFEST_REF#s3://$MINIO_BUCKET/}"
+MANIFEST_JSON="$(mc cat "chain/$MINIO_BUCKET/$MANIFEST_KEY")" || fail "manifest missing: $MANIFEST_REF"
+INDEX_DIGEST="$(printf '%s' "$INDEX_JSON" | jq -r .artifactDigest)"
+# Hash the raw object bytes (command substitution strips the trailing
+# newline the digest was computed over).
+MANIFEST_DIGEST="$(mc cat "chain/$MINIO_BUCKET/$MANIFEST_KEY" | sha256sum | awk '{print $1}')"
+[[ "$INDEX_DIGEST" == "$MANIFEST_DIGEST" ]] || fail "index.artifactDigest=$INDEX_DIGEST != sha256(manifest)=$MANIFEST_DIGEST"
+BUILD_DIR_KEY="$(dirname "$MANIFEST_KEY")"
+for object in rootfs.ext4 vmstate.snap memory.snap SHA256SUMS manifest.json; do
+    mc stat "chain/$MINIO_BUCKET/$BUILD_DIR_KEY/$object" >/dev/null || fail "published object missing: $object"
+done
+while IFS= read -r name; do
+    want="$(printf '%s' "$MANIFEST_JSON" | jq -r --arg n "$name" '.files[$n].sha256')"
+    [[ "$want" != "null" && -n "$want" ]] || fail "manifest.files has no entry for $name"
+    local_path="$BUILD_DIR/$name"
+    [[ -f "$local_path" ]] || fail "local build artifact missing: $name"
+    # 1) The builder artifact must match its manifest digest (sparse-aware
+    #    hash equals the plain hash: holes are zero bytes).
+    local_hash="$(sha256sum "$local_path" | awk '{print $1}')"
+    [[ "$local_hash" == "$want" ]] || fail "build artifact $name digest mismatch: got=$local_hash want=$want"
+    # 2) The stored object must carry the full logical size. (mc cat
+    #    truncates large objects on this host - a 3 GiB rootfs came back
+    #    2779 bytes short - so the download below is only used with a
+    #    size check.)
+    stored_size="$(mc stat --json "chain/$MINIO_BUCKET/$BUILD_DIR_KEY/$name" 2>/dev/null | jq -r .size)"
+    local_size="$(stat -c %s "$local_path")"
+    [[ "$stored_size" == "$local_size" ]] || fail "stored $name size $stored_size != local $local_size"
+    # 3) Download verification is best-effort: this mc release returns 0
+    #    without writing the target for large objects (and mc cat
+    #    truncated a 3 GiB rootfs by 2779 bytes), so a failed or
+    #    size-mismatched download warns instead of failing. Upload
+    #    correctness is guaranteed separately by aws CLI's per-part
+    #    Content-MD5; the authoritative checks are the local digest
+    #    (step 1) and the stored size (step 2).
+    rm -f "$WORK/verify-$name"
+    if mc cp "chain/$MINIO_BUCKET/$BUILD_DIR_KEY/$name" "$WORK/verify-$name" >/dev/null 2>&1 && [[ -s "$WORK/verify-$name" ]]; then
+        dl_size="$(stat -c %s "$WORK/verify-$name")"
+        if [[ "$dl_size" == "$local_size" ]]; then
+            dl_hash="$(sha256sum "$WORK/verify-$name" | awk '{print $1}')"
+            [[ "$dl_hash" == "$want" ]] || fail "downloaded $name digest mismatch: got=$dl_hash want=$want"
+        else
+            echo "warning: mc cp downloaded $name with size $dl_size != $local_size; download check skipped" >&2
+        fi
+    else
+        echo "warning: mc cp download of $name skipped (tool limitation); upload covered by local digest + stored size" >&2
+    fi
+    rm -f "$WORK/verify-$name"
+done < <(printf '%s' "$MANIFEST_JSON" | jq -r '.files | keys[]' | grep -v '^overlaybd/')
+pass "verification point 1: publish layout (index + digest16 build + SHA256SUMS)"
+
+# --- runtime-agent -----------------------------------------------------------
+log "building the runtime-agent"
+(cd "$REPO_ROOT" && GOTOOLCHAIN=local go build -o "$AGENT_BIN" ./cmd/firecracker-runtime-agent)
+
+# Fresh agent state: the pull layer treats a committed cache as final
+# (idempotent, never refreshed), so a cache from an earlier run would keep
+# answering with the PREVIOUS build's manifest digest. Only the agent's own
+# subtree (images cache + journal) is removed: the state root may be a
+# shared mount (e.g. /var/lib/fast-sandbox on a reflink filesystem).
+rm -rf "$STATE_ROOT_DIR/images" "$STATE_ROOT_DIR/agent"
+mkdir -p "$STATE_ROOT_DIR"
+
+log "writing the registry configuration (read-only credential)"
+mkdir -p "$REPO_ROOT/.chain-e2e-gen"
+cat > "$REPO_ROOT/.chain-e2e-gen/gen-registry.go" <<'EOF'
+// Command gen-registry emits a compiled registry configuration for one
+// S3 credential (used by the chain E2E to feed the runtime-agent).
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"fast-sandbox/internal/registryconfig"
+)
+
+func main() {
+	if len(os.Args) != 5 {
+		fmt.Fprintln(os.Stderr, "usage: gen-registry <host> <username> <password> <endpoint>")
+		os.Exit(1)
+	}
+	compiled, err := registryconfig.NewCompiled([]registryconfig.Credential{{
+		Host: os.Args[1], Username: os.Args[2], Password: os.Args[3], Endpoint: os.Args[4],
+	}})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	payload, err := compiled.Marshal()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Stdout.Write(payload)
+}
+EOF
+(cd "$REPO_ROOT" && GOTOOLCHAIN=local go run .chain-e2e-gen/gen-registry.go \
+    "127.0.0.1:$MINIO_PORT" "$MINIO_AK" "$MINIO_SK" "$MINIO_ENDPOINT") > "$REGISTRY_FILE"
+jq -e . "$REGISTRY_FILE" >/dev/null || die "generated registry.json is invalid"
+rm -rf "$REPO_ROOT/.chain-e2e-gen"
+
+log "starting the runtime-agent (socket=$AGENT_SOCKET, store=$STORE_ROOT)"
+# Clear leftovers of crashed runs: a stale socket file (or a surviving
+# agent process from an interrupted run) would let the readiness loop pass
+# and the first RPC hit the OLD listener instead of this agent.
+rm -f "$AGENT_SOCKET"
+pkill -f "$AGENT_BIN" 2>/dev/null || true
+sleep 0.3
+env FAST_SANDBOX_RUNTIME_AGENT_SOCKET="$AGENT_SOCKET" \
+    FAST_SANDBOX_ARTIFACT_STORE="$STORE_ROOT" \
+    FAST_SANDBOX_STATE_ROOT="$STATE_ROOT_DIR" \
+    FAST_SANDBOX_REGISTRY_CONFIG_PATH="$REGISTRY_FILE" \
+    FAST_SANDBOX_ARTIFACT_ENDPOINT="$MINIO_ENDPOINT" \
+    "$AGENT_BIN" > "$WORK/agent.log" 2>&1 &
+AGENT_PID=$!
+# Readiness = the agent actually answers, not just a socket file existing.
+for attempt in $(seq 1 40); do
+    if curl -sS --noproxy '*' --unix-socket "$AGENT_SOCKET" -X POST \
+        http://firecracker-agent/v1/health -H 'Content-Type: application/json' \
+        -d '{"requestId":"","namespace":"chain-e2e","podUid":"chain-e2e-pod"}' 2>/dev/null \
+        | jq -e .ok >/dev/null 2>&1; then
+        break
+    fi
+    kill -0 "$AGENT_PID" 2>/dev/null || die "runtime-agent exited early: $(tail -5 "$WORK/agent.log")"
+    sleep 0.5
+    [[ "$attempt" == 40 ]] && die "runtime-agent did not answer health in time: $(tail -5 "$WORK/agent.log")"
+done
+log "runtime-agent healthy"
+
+# --- StateRoot reflink probe ---------------------------------------------------
+# On a non-reflink filesystem (ext4) every per-Sandbox rootfs copy falls
+# back to a full ~3 GiB copy (~1.8 s per create, the dominant cost of the
+# NoInfra create path). Point FC_STATE_ROOT at a reflink-capable mount to
+# make the copy CoW; see scripts/firecracker-xfs-stateroot.sh.
+REFLINK_PROBE="$STATE_ROOT_DIR/.reflink-probe"
+REFLINK_COPY="$STATE_ROOT_DIR/.reflink-probe-copy"
+rm -f "$REFLINK_PROBE" "$REFLINK_COPY"
+printf 'reflink-probe' > "$REFLINK_PROBE"
+if cp --reflink=always "$REFLINK_PROBE" "$REFLINK_COPY" 2>/dev/null; then
+    log "StateRoot reflink: supported (CoW per-instance rootfs copies)"
+else
+    log "StateRoot reflink: NOT supported (ext4?) - each create pays a full rootfs copy (~1.8s); see scripts/firecracker-xfs-stateroot.sh --loop"
+fi
+rm -f "$REFLINK_PROBE" "$REFLINK_COPY"
+
+agent_rpc() { # path request-json (leading slash optional)
+    # ${1#/} strips the leading slash: the callers pass /v1/... and a raw
+    # concatenation would produce http://firecracker-agent//v1/... .
+    # curl 7.61 sends the double-slash path verbatim and the agent's route
+    # table never matches it (404 page not found); curl >= 8 normalizes
+    # the path, which is why local runs cannot reproduce the failure.
+    local url="http://firecracker-agent/${1#/}"
+    curl -sS --noproxy '*' --unix-socket "$AGENT_SOCKET" -X POST \
+        "$url" -H 'Content-Type: application/json' \
+        -d "$2"
+}
+
+# agent_ok fails the run with the RPC response, the agent log, and the
+# MinIO request log when an RPC did not succeed.
+agent_ok() { # description response-json
+    local description=$1 response=$2
+    # Empty response = success: ReleaseDevices / UnpinImage answer 204 No
+    # Content. (jq 1.6 on RHEL 8 silently exits 0 on empty input, which
+    # would misclassify a successful 204 as an error JSON.)
+    if [[ -z "$response" ]]; then
+        return 0
+    fi
+    # The agent encodes failures as {"code": ...} JSON; treat that as a
+    # failure even though it parses as valid JSON.
+    if printf '%s' "$response" | jq -e 'has("code")' >/dev/null 2>&1; then
+        echo "RPC returned an error ($description): $(printf '%s' "$response" | jq -c .)" >&2
+        echo "=== curl verbose replay (response headers identify the server) ===" >&2
+        curl -v --noproxy '*' --unix-socket "$AGENT_SOCKET" -X POST \
+            "http://firecracker-agent/v1/health" -H 'Content-Type: application/json' \
+            -d '{"requestId":"","namespace":"chain-e2e","podUid":"chain-e2e-pod"}' 2>&1 | tail -25 >&2 || true
+        echo "=== socket ===" >&2
+        ls -la "$AGENT_SOCKET" >&2 || true
+        echo "=== socket listeners ===" >&2
+        (ss -xlp 2>/dev/null || netstat -lxp 2>/dev/null) | grep -F "$(basename "$AGENT_SOCKET")" >&2 || true
+        echo "=== agent processes ===" >&2
+        pgrep -fl firecracker-runtime-agent >&2 || true
+        echo "=== agent.log (tail) ===" >&2
+        tail -30 "$WORK/agent.log" >&2
+        echo "=== MinIO logs (tail) ===" >&2
+        docker logs --tail 30 "$MINIO_CONTAINER" >&2 2>&1 || true
+        fail "$description failed"
+    fi
+    if ! printf '%s' "$response" | jq -e . >/dev/null 2>&1; then
+        echo "RPC failed ($description), raw response: $response" >&2
+        echo "=== agent.log (tail) ===" >&2
+        tail -30 "$WORK/agent.log" >&2
+        echo "=== MinIO logs (tail) ===" >&2
+        docker logs --tail 30 "$MINIO_CONTAINER" >&2 2>&1 || true
+        fail "$description failed"
+    fi
+}
+
+# --- scenario A: pull chain through the real agent ----------------------------
+log "scenario A: PinImage through the runtime-agent (SigV4 + credential mapping)"
+IDENTITY='{"requestId":"chain-pin-1","namespace":"chain-e2e","podUid":"chain-e2e-pod"}'
+PIN_START="$(date +%s%N)"
+# Health first: a 404 here means the request never reached the agent's
+# routes (proxy/socket issue); a healthy reply isolates PinImage.
+# The literal call is the control: it is byte-identical to the readiness
+# probe that succeeded, so a failure here means agent state, while a
+# success here plus a failure of the function form means the function.
+LITERAL_HEALTH="$(curl -sS --noproxy '*' --unix-socket "$AGENT_SOCKET" -X POST \
+    http://firecracker-agent/v1/health -H 'Content-Type: application/json' \
+    -d '{"requestId":"","namespace":"chain-e2e","podUid":"chain-e2e-pod"}')"
+agent_ok "Health (literal control)" "$LITERAL_HEALTH"
+HEALTH_CHECK="$(agent_rpc /v1/health '{"requestId":"","namespace":"chain-e2e","podUid":"chain-e2e-pod"}')"
+agent_ok "Health (agent_rpc)" "$HEALTH_CHECK"
+PIN1="$(agent_rpc /v1/pin-image "$(jq -nc --argjson id "$IDENTITY" --arg img "$CHAIN_IMAGE" '$id + {image: $img}')")"
+agent_ok "PinImage" "$PIN1"
+PIN_DIGEST="$(printf '%s' "$PIN1" | jq -er .manifestDigest)"
+[[ "$(printf '%s' "$PIN1" | jq -r .ready)" == "true" ]] || fail "PinImage ready=false"
+[[ "$PIN_DIGEST" == "$MANIFEST_DIGEST" ]] || fail "PinImage manifestDigest=$PIN_DIGEST != published $MANIFEST_DIGEST"
+
+CACHE_DIR="$STATE_ROOT_DIR/images/$(printf '%s' "$CHAIN_IMAGE" | sha256sum | awk '{print $1}')"
+for file in rootfs.img vmstate.snap memory.snap manifest.json; do
+    [[ -s "$CACHE_DIR/$file" ]] || fail "cache file missing after pull: $file"
+done
+LOCAL_MANIFEST="$(cat "$CACHE_DIR/manifest.json")"
+# Hash the file bytes directly: the cached manifest keeps the trailing
+# newline the index digest was computed over.
+LOCAL_DIGEST="$(sha256sum "$CACHE_DIR/manifest.json" | awk '{print $1}')"
+[[ "$LOCAL_DIGEST" == "$INDEX_DIGEST" ]] || fail "cached manifest != published manifest (index digest)"
+for file in rootfs.img vmstate.snap memory.snap; do
+    publish_name="${file/rootfs.img/rootfs.ext4}"
+    want="$(printf '%s' "$LOCAL_MANIFEST" | jq -r --arg n "$publish_name" '.files[$n].sha256')"
+    got="$(sha256sum "$CACHE_DIR/$file" | awk '{print $1}')"
+    [[ "$got" == "$want" ]] || fail "cached $file digest mismatch: got=$got want=$want"
+done
+pass "verification point 2/3: SigV4 + credential mapping (pull succeeded over MinIO)"
+PIN_MS="$(( ($(date +%s%N) - PIN_START) / 1000000 ))"
+PIN_MS_LOGGED="1"
+
+ROOTFS_MTIME_BEFORE="$(stat -c %Y "$CACHE_DIR/rootfs.img")"
+PIN2="$(agent_rpc /v1/pin-image "$(jq -nc --argjson id "$IDENTITY" --arg img "$CHAIN_IMAGE" '$id + {image: $img}')")"
+[[ "$(printf '%s' "$PIN2" | jq -r .manifestDigest)" == "$PIN_DIGEST" ]] || fail "re-PinImage digest changed"
+ROOTFS_MTIME_AFTER="$(stat -c %Y "$CACHE_DIR/rootfs.img")"
+[[ "$ROOTFS_MTIME_AFTER" == "$ROOTFS_MTIME_BEFORE" ]] || fail "re-PinImage re-pulled (committed cache must be idle)"
+pass "verification point 5a: PinImage idempotency (committed cache, zero re-pull)"
+
+# --- scenario B: driver restore from the pulled artifacts ---------------------
+log "scenario B: driver restore from builder artifacts (FC_SKIP_PREP, agent wired)"
+record_host_state
+purge_fsb_resources
+# The NoInfra case is the control: infra (GuestCopy delivery) dominates the
+# create time when enabled, and the runtime agent wiring is identical.
+log "execd baked ($CHAIN_EXECD); scenario B will probe GET /ping in the guest"
+(cd "$REPO_ROOT" && env FC_BINARY="$FC_BINARY" FC_KERNEL="$FC_KERNEL" FC_ROOTFS="$FC_ROOTFS" \
+    FC_STATE_ROOT="$FC_STATE_ROOT" FC_IMAGE_REF="$CHAIN_IMAGE" \
+    FC_SKIP_PREP=1 FC_AGENT_SOCKET="$AGENT_SOCKET" \
+    FC_EXECD_PROBE=1 \
+    go test -tags firecracker -count=1 -v \
+    -run '^(TestFirecrackerDriverE2E|TestFirecrackerDriverE2ENoInfra)$' \
+    ./internal/runtime/firecracker/) 2>&1 | tee "$WORK/driver-e2e.log" || fail "driver E2E failed (see output above)"
+pass "verification point 4: builder snapshot <-> driver restore (Running + guest reachable)"
+
+# --- scenario C: lease lifecycle + driver delete -> agent unpin --------------
+log "scenario C: lease lifecycle and cleanup semantics"
+READ_IDENTITY='{"requestId":"","namespace":"chain-e2e","podUid":"chain-e2e-pod"}'
+# The driver E2E just ran against this agent; make sure it is still alive
+# before the lease sequence (a dead socket makes the first RPC curl fail
+# and set -e would exit without diagnostics).
+HEALTH_BEFORE="$(agent_rpc /v1/health "$READ_IDENTITY")" || {
+    echo "runtime-agent unreachable after scenario B: $(tail -10 "$WORK/agent.log")" >&2
+    fail "runtime-agent died during the driver E2E"
+}
+agent_ok "Health (scenario C)" "$HEALTH_BEFORE"
+PINS_BEFORE="$(printf '%s' "$HEALTH_BEFORE" | jq -r .pinCount)"
+# The driver E2E deleted its sandbox through the UDS-wired driver, so its
+# UnpinImage must have released the scenario-A pin.
+[[ "$PINS_BEFORE" == "0" ]] || fail "agent pinCount=$PINS_BEFORE after driver delete, expected 0 (driver delete must unpin)"
+pass "driver delete released the scenario-A pin through the UDS API"
+
+# Each RPC needs its OWN requestId: the agent's journal replays a committed
+# request id, so reusing chain-pin-1 for LeaseDevices would return the
+# recorded PinImage result instead of a lease.
+PIN2_RESP="$(agent_rpc /v1/pin-image "$(jq -nc --arg req 'chain-pin-2' --arg img "$CHAIN_IMAGE" \
+    '{requestId: $req, namespace: "chain-e2e", podUid: "chain-e2e-pod", image: $img}')")"
+agent_ok "PinImage (re-pin)" "$PIN2_RESP"
+LEASE="$(agent_rpc /v1/lease-devices "$(jq -nc --arg req 'chain-lease-1' \
+    --arg sb "chain-sbx-1" --arg img "$CHAIN_IMAGE" \
+    '{requestId: $req, namespace: "chain-e2e", podUid: "chain-e2e-pod",
+      sandboxId: $sb, image: $img, memSizeMiB: 512, rootfsWritable: false}')")"
+agent_ok "LeaseDevices" "$LEASE"
+LEASE_ID="$(printf '%s' "$LEASE" | jq -er .leaseId)"
+[[ "$(printf '%s' "$LEASE" | jq -r .rootfsDev)" == "$CACHE_DIR/rootfs.img" ]] || fail "lease rootfsDev != cache path"
+LISTED="$(agent_rpc /v1/list-leases '{"requestId":"chain-list-1","namespace":"chain-e2e","podUid":"chain-e2e-pod"}')"
+agent_ok "ListLeases" "$LISTED"
+[[ "$(printf '%s' "$LISTED" | jq -r '.leases | length')" == "1" ]] || fail "ListLeases != 1 after lease"
+RELEASE_RESP="$(agent_rpc /v1/release-devices "$(jq -nc --arg req 'chain-release-1' --arg lid "$LEASE_ID" \
+    '{requestId: $req, namespace: "chain-e2e", podUid: "chain-e2e-pod", leaseId: $lid}')")"
+agent_ok "ReleaseDevices" "$RELEASE_RESP"
+LISTED="$(agent_rpc /v1/list-leases '{"requestId":"chain-list-2","namespace":"chain-e2e","podUid":"chain-e2e-pod"}')"
+agent_ok "ListLeases (after release)" "$LISTED"
+[[ "$(printf '%s' "$LISTED" | jq -r '.leases | length')" == "0" ]] || fail "ListLeases != 0 after release"
+UNPIN_RESP="$(agent_rpc /v1/unpin-image "$(jq -nc --arg req 'chain-unpin-1' --arg img "$CHAIN_IMAGE" \
+    '{requestId: $req, namespace: "chain-e2e", podUid: "chain-e2e-pod", image: $img}')")"
+agent_ok "UnpinImage" "$UNPIN_RESP"
+HEALTH_AFTER="$(agent_rpc /v1/health "$READ_IDENTITY")"
+[[ "$(printf '%s' "$HEALTH_AFTER" | jq -r .pinCount)" == "0" ]] || fail "pinCount != 0 after unpin"
+pass "verification point 5b: lease release + unpin (state returns to zero)"
+
+# --- performance and artifact summary -----------------------------------------
+log "=== performance summary ==="
+echo "builder pipeline (from builder.log):"
+grep -h "sandbox template build stages" "$WORK/builder.log" 2>/dev/null \
+    | sed -E 's/.*"sandbox template build stages" (.*)/  \1/' || echo "  (builder.log missing)"
+grep -h "snapshot stage phases" "$WORK/builder.log" 2>/dev/null \
+    | sed -E 's/.*(format=.*)$/  \1/' || true
+if [[ "${PIN_MS_LOGGED:-}" == "1" ]]; then
+    echo "scenario A: cold PinImage (index + manifest + artifacts over MinIO) = ${PIN_MS} ms"
+    echo "  cache size: $(du -sh "$STATE_ROOT_DIR/images" 2>/dev/null | cut -f1)"
+fi
+echo "driver restore (from driver-e2e.log):"
+grep -h "firecracker sandbox created" "$WORK/driver-e2e.log" 2>/dev/null \
+    | sed -E 's/^.*driver.go:[0-9]+\] //' || echo "  (create line missing)"
+grep -h "guest reachable" "$WORK/driver-e2e.log" 2>/dev/null \
+    | sed -E 's/^.*(guest reachable.*)$/  \1/' || true
+echo "execd readiness (delta after VM running):"
+grep -h "execd /ping OK" "$WORK/driver-e2e.log" 2>/dev/null \
+    | sed -E 's/^.*(execd \/ping OK.*)$/  \1/' || echo "  (no execd /ping lines in driver-e2e.log)"
+echo "infra delivery breakdown (klog V(4), from driver-e2e.log):"
+if grep -q '"infra delivery:' "$WORK/driver-e2e.log" 2>/dev/null; then
+    grep -h '"infra delivery:' "$WORK/driver-e2e.log" 2>/dev/null \
+        | sed -E 's/^.*"(infra delivery[^"]*)" (.*)$/  \1/'
+else
+    echo "  (no infra timing lines; klog V(4) requires -v=4)"
+fi
+grep -h "reusing externally pulled golden snapshot set" "$WORK/driver-e2e.log" 2>/dev/null \
+    | sed -E 's/^.*(reusing.*)$/  \1/' || true
+echo "component sizes:"
+echo "  build dir:   $(du -sh "$BUILD_DIR" 2>/dev/null | cut -f1)"
+echo "  MinIO data:  $(du -sh "$MINIO_DATA" 2>/dev/null | cut -f1)"
+echo "  agent state: $(du -sh "$STATE_ROOT_DIR" 2>/dev/null | cut -f1)"
+echo "  MinIO objects: $(mc ls --recursive "chain/$MINIO_BUCKET" 2>/dev/null | wc -l)"
+echo "disk: $(df -h "$WORK" 2>/dev/null | tail -1 | awk '{print "free="$4" of "$2" ("$5" used)"}')"
+log "component logs: $WORK/builder.log, $WORK/agent.log, $WORK/driver-e2e.log, MinIO: docker logs $MINIO_CONTAINER"
+
+log "full chain E2E passed: publish -> MinIO -> agent pull -> driver restore -> reachability -> cleanup"
+log "artifacts under $WORK (builder.log, agent.log, state-root/images/$CHAIN_IMAGE)"

--- a/scripts/sandboxtemplate-e2e.sh
+++ b/scripts/sandboxtemplate-e2e.sh
@@ -169,6 +169,8 @@ for fmt in "${FORMATS[@]}"; do
     assert "SHA256SUMS exists" test -s "$BUILD/SHA256SUMS"
     assert "guest reached readiness" grep -q "SANDBOX_READY" "$BUILD/boot.console.log"
     assert "snapshot restore produced a guest heartbeat" grep -q "SANDBOX_HEARTBEAT" "$BUILD/restore.console.log"
+    assert "manifest records the baked guest network" jq -e '.guestNetwork.iface == "eth0" and .guestNetwork.ip == "172.30.0.3" and .guestNetwork.mac == "02:00:00:00:00:01" and .guestNetwork.gateway == "172.30.0.1"' "$BUILD/manifest.json"
+    assert "boot args bake the static guest IP" grep -q "ip=172.30.0.3::172.30.0.1:255.255.255.0::eth0:off" "$BUILD/boot.console.log"
     if [[ "$fmt" == "overlaybd" ]]; then
         assert "overlaybd rootfs layer exists" test -s "$BUILD/overlaybd/rootfs/layer.lsmt"
         assert "overlaybd memory layer exists" test -s "$BUILD/overlaybd/memory/layer.lsmt"


### PR DESCRIPTION
## 概述

阶段 1 收尾（chain-e2e-plan）：builder 真实发布 → 真实 MinIO → runtime-agent 拉取 → driver restore 全链路串通，附 SandboxTemplate 使用文档。**没有任何组件是 fake 的**。

三个 commit：
1. **feat(builder)**: 快照 bake NIC（restore 的 `network_overrides` 只能替换已存在 iface 的前置必做改动）+ manifest 记录 `guestNetwork`
2. **docs**: SandboxTemplate 使用指南 + API reference（每个字段含义/默认值）
3. **feat(e2e)**: `scripts/firecracker-chain-e2e.sh` 一键全链路 + 链路暴露的真实修复（credential Endpoint 字段）

## 验证点覆盖

| # | 验证点 | 断言 |
|---|--------|------|
| 1 | builder 真实发布布局 | index + digest16 构建集 + SHA256SUMS；`index.artifactDigest` == sha256(manifest)；files digest 逐个对账 |
| 2 | SigV4 对 MinIO | agent 经 wire 拉取成功（签名正确性由 digest 校验提交证明） |
| 3 | credential 映射 | registry 配置经 `FAST_SANDBOX_ARTIFACT_ENDPOINT` 解析，agent 连上 MinIO |
| 4 | builder 快照 ↔ driver restore | `FC_SKIP_PREP` 下 driver 从拉取产物 restore，VM Running + guest 在 baked IP 可达 |
| 5 | 幂等与清理 | 二次 PinImage 零重拉（committed cache）；driver delete → agent unpin 真实生效；lease 生命周期归零；退出全清理 |

## 链路暴露的真实缺口（本 PR 修复）

- `registryconfig.Credential` 只有 `Host`，无法携带带 scheme/端口的 S3 连接地址（`NormalizeHost` 会剥掉 scheme）→ 新增 `Endpoint` 字段，`s3client` 优先级 override > Endpoint > Host
- agent 凭据匹配键是 store root 的 bucket 名，对不上 MinIO/真实 endpoint → 新增 `FAST_SANDBOX_ARTIFACT_ENDPOINT`（可选，缺省行为不变）

## 测试

- `go build ./... && go vet ./...` 全绿
- `go test ./internal/runtime/firecracker/... ./cmd/... ./internal/registryconfig/ -count=1` 全绿（`cmd/boxlite-runtime` 的既有失败为 macOS UDS 路径限制，与本 PR 无关）
- 全链路脚本需在参考 KVM 主机执行：`./scripts/firecracker-chain-e2e.sh`（本 PR 是代码/脚本/文档交付，真实环境跑数记录到 `docs/guides/firecracker-chain-e2e.md`）

## 文档

- `docs/guides/sandboxtemplate-golden-images.md`：SandboxTemplate 使用指南（工作流 + 字段含义表 + 消费契约）
- `docs/reference/api.md`：SandboxTemplate CRD 参考
- `docs/guides/firecracker-chain-e2e.md`：全链路 E2E 环境/验证点/overrides