### PR TITLE
docs: correct README license labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,4 +314,4 @@ ConfigMap and referenced Secrets; Pools do not embed credentials. See
 
 ## License
 
-[MIT](LICENSE)
+[Apache-2.0](LICENSE)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -265,4 +265,4 @@ Create 延迟终止于 `RuntimeReady`。Component 健康检查和路由发布独
 
 ## License
 
-[MIT](LICENSE)
+[Apache-2.0](LICENSE)


### PR DESCRIPTION
The root `LICENSE` contains Apache License 2.0, while the English and Chinese README license sections label the same file as MIT.

This updates both labels to `Apache-2.0` so the documentation matches the repository license. It does not change the license terms or link targets.

Validation:

- `make test SCOPE=unit`
- focused assertions confirm both README files use `[Apache-2.0](LICENSE)` and no `[MIT](LICENSE)` references remain
- `git diff --check`