### PR TITLE
refactor(sandboxtemplate): run build Pods in the template namespace with owner references

### DIFF
--- a/config/rbac/base.yaml
+++ b/config/rbac/base.yaml
@@ -34,13 +34,19 @@ rules:
   resources: ["configmaps", "secrets"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "create"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "create"]
+- apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "patch", "update"]
 - apiGroups: ["node.k8s.io"]
   resources: ["runtimeclasses"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["sandbox.fast.io"]
-  resources: ["sandboxes", "sandboxpools", "sandboxtemplates", "sandboxes/status", "sandboxpools/status", "sandboxtemplates/status", "sandboxtemplates/finalizers"]
+  resources: ["sandboxes", "sandboxpools", "sandboxtemplates", "sandboxes/status", "sandboxpools/status", "sandboxtemplates/status"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
@@ -109,33 +115,11 @@ roleRef: {apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: fast-san
 subjects:
 - {kind: ServiceAccount, name: fast-sandbox-proxy, namespace: fast-sandbox-system}
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: sandbox-template-builder
-  namespace: fast-sandbox-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: sandbox-template-builder
-  namespace: fast-sandbox-system
-rules:
-# The builder Pod reports the build outcome by merge-patching its own
-# annotations; build Pods run only in this (platform) namespace.
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["patch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: sandbox-template-builder
-  namespace: fast-sandbox-system
-roleRef: {apiGroup: rbac.authorization.k8s.io, kind: Role, name: sandbox-template-builder}
-subjects:
-- {kind: ServiceAccount, name: sandbox-template-builder, namespace: fast-sandbox-system}
----
+# The SandboxTemplate build Pod runs in the template's (tenant) namespace,
+# owned by the template for cascading deletion. The controller provisions
+# the builder ServiceAccount + Role + RoleBinding (pods/patch only, for the
+# builder to self-report its outcome) per tenant namespace on demand; the
+# controller ClusterRole above grants the create/get permissions it needs.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/config/rbac/base.yaml
+++ b/config/rbac/base.yaml
@@ -38,7 +38,9 @@ rules:
   verbs: ["get", "create"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]
-  verbs: ["get", "create"]
+  # update: ensureBuilderRBAC converges pre-existing same-named Role /
+  # RoleBinding back onto the enforced shape instead of trusting them.
+  verbs: ["get", "create", "update"]
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "patch", "update"]

--- a/config/samples/sandboxtemplate-firecracker.yaml
+++ b/config/samples/sandboxtemplate-firecracker.yaml
@@ -1,16 +1,18 @@
 # sandboxtemplate-firecracker.yaml — golden-image build for the Firecracker
 # on-demand loading chain.
 #
-# The controller runs a privileged builder Job on a node labeled
-# sandbox.fast.io/kvm=true; the builder bakes the golden snapshot set
-# (rootfs.ext4 / vmstate.snap / memory.snap + manifest) and publishes it to
-# the artifact store (MinIO). The runtime-agent then pulls it per node.
+# The controller runs a privileged builder Pod (owned by this template, in
+# the template's namespace) on a node labeled sandbox.fast.io/kvm=true; the
+# builder bakes the golden snapshot set (rootfs.ext4 / vmstate.snap /
+# memory.snap + manifest) and publishes it to the artifact store (MinIO).
+# The runtime-agent then pulls it per node.
 #
 # Prerequisites:
-#   - Secret <publishSecretRef.name> in namespace fast-sandbox-system with
+#   - Secret <publishSecretRef.name> in this template's namespace with
 #     keys accessKeyId / secretAccessKey / endpoint / region
 #     (see scripts/integration-env.sh for the generated values).
 #   - Node label: kubectl label node <node> sandbox.fast.io/kvm=true
+#   - The namespace must allow privileged Pods (the builder mounts /dev/kvm).
 #
 # Apply with:
 #   kubectl apply -f config/samples/sandboxtemplate-firecracker.yaml

--- a/docs/assets/firecracker-integration-environment.svg
+++ b/docs/assets/firecracker-integration-environment.svg
@@ -48,13 +48,13 @@
   <text x="175" y="218" font-size="10.5" font-weight="bold" fill="#1e40af" text-anchor="middle">Deployment</text>
   <text x="230" y="218" font-size="12.5" font-weight="bold" fill="#1e40af">controller</text>
   <text x="136" y="244" font-size="11.5" fill="#0f172a">reconciles Template/Pool/Sandbox CRs</text>
-  <text x="136" y="262" font-size="11.5" fill="#0f172a">creates builder Jobs · drives fastlet scheduling</text>
+  <text x="136" y="262" font-size="11.5" fill="#0f172a">creates builder Pods · drives fastlet scheduling</text>
 
-  <!-- builder Job -->
+  <!-- builder Pod -->
   <rect x="120" y="320" width="420" height="75" rx="8" fill="#ffffff" stroke="#94a3b8" stroke-width="1.5"/>
   <rect x="132" y="334" width="44" height="20" rx="4" fill="#e2e8f0"/>
   <text x="154" y="348" font-size="10.5" font-weight="bold" fill="#475569" text-anchor="middle">Job</text>
-  <text x="188" y="348" font-size="12.5" font-weight="bold" fill="#334155">builder Job</text>
+  <text x="188" y="348" font-size="12.5" font-weight="bold" fill="#334155">builder Pod</text>
   <text x="136" y="374" font-size="11.5" fill="#0f172a">bakes the golden snapshot (on-demand)</text>
 
   <!-- pool -->

--- a/docs/design/sandboxtemplate-golden-image-builds.md
+++ b/docs/design/sandboxtemplate-golden-image-builds.md
@@ -262,7 +262,10 @@ Every build emits a content-addressed `manifest.json`:
   Role). The build Pods run in the **template's namespace** under the
   `sandbox-template-builder` ServiceAccount, which the controller provisions
   per namespace with only `pods/patch` (the builder self-reports its
-  outcome); the controller RBAC (`sandboxtemplates` create/update) and the
+  outcome) and **converges on every reconcile**: a same-named Role or
+  RoleBinding with broader content (e.g. pre-created by a tenant) is
+  rewritten back onto the enforced shape rather than trusted, so the
+  boundary holds by construction, not by assumption; the controller RBAC (`sandboxtemplates` create/update) and the
   builder SA are deliberately scoped, and the controller never reads
   secrets — publish credentials reach the build Pod as SecretKeyRef
   references resolved by the kubelet (secret lives in the template's

--- a/docs/design/sandboxtemplate-golden-image-builds.md
+++ b/docs/design/sandboxtemplate-golden-image-builds.md
@@ -259,29 +259,37 @@ Every build emits a content-addressed `manifest.json`:
 - **Privileged-build entry point**: a SandboxTemplate is effectively
   "run an arbitrary OCI image as root on a KVM host" — creating templates
   must be restricted to trusted operators (cluster-admin or a dedicated
-  Role), while the *build Pods* themselves run under the platform's
-  `sandbox-template-builder` ServiceAccount confined to the platform
-  namespace. The controller RBAC (`sandboxtemplates` create/update +
-  `sandboxtemplates/finalizers`) and the builder SA (`pods/patch` only) are
-  deliberately scoped; the controller never reads secrets — publish
-  credentials reach the build Pod as SecretKeyRef references resolved by
-  the kubelet (secret lives in the platform namespace).
+  Role). The build Pods run in the **template's namespace** under the
+  `sandbox-template-builder` ServiceAccount, which the controller provisions
+  per namespace with only `pods/patch` (the builder self-reports its
+  outcome); the controller RBAC (`sandboxtemplates` create/update) and the
+  builder SA are deliberately scoped, and the controller never reads
+  secrets — publish credentials reach the build Pod as SecretKeyRef
+  references resolved by the kubelet (secret lives in the template's
+  namespace, next to the Pod). Because the builder is privileged (host
+  `/dev/kvm` passthrough), the tenant namespace must allow privileged Pods
+  (PodSecurityAdmission); this moves the privilege boundary from "control
+  plane only" to "template namespace", in exchange for native cascading
+  deletion: the build Pod carries a controller owner reference to the
+  template, so deleting a template garbage-collects its build Pods without
+  a finalizer.
 - **Publish credentials**: `output.publish` is required; when
   `output.publishSecretRef` names an imagePullSecrets-style secret
   (`accessKeyId`/`secretAccessKey`/`endpoint`/`region`), the controller
   injects them as `AWS_*` env vars (SecretKeyRef) into the build Pod. The
-  secret MUST live in the platform namespace (`fast-sandbox-system`) — a
-  SecretKeyRef resolves against the Pod's own namespace and cannot cross
-  namespaces; the platform operator manages it out of band. Without the
-  secret, the build relies on platform-level credentials (e.g. IRSA / node
-  metadata), which must be present on KVM nodes.
+  secret MUST live in the template's namespace — a SecretKeyRef resolves
+  against the Pod's own namespace; the platform operator manages it out of
+  band. Without the secret, the build relies on platform-level credentials
+  (e.g. IRSA / node metadata), which must be present on KVM nodes.
 - **Build lifecycle safety**: build Pods have `activeDeadlineSeconds`
   (2 h), deterministic names (`<template>-build-<generation>`, so
-  concurrent reconciles dedupe), a finalizer on the template that reaps
-  Pods on deletion, and a Pending timeout (10 min) that fails builds which
+  concurrent reconciles dedupe), an owner reference to the template (GC
+  cascades deletion), and a Pending timeout (10 min) that fails builds which
   never get scheduled (e.g. no node labeled `sandbox.fast.io/kvm=true`).
-  KVM/tun devices are passed through as hostPath CharDevice mounts, and the
-  Pod is pinned to KVM nodes via nodeSelector.
+  Finished Pods are retained for `BuildTTL` (24 h) so their annotations stay
+  inspectable, then reaped by the controller. KVM/tun devices are passed
+  through as hostPath CharDevice mounts, and the Pod is pinned to KVM nodes
+  via nodeSelector.
 
 ### Risks and Mitigations
 

--- a/docs/guides/firecracker-integration-env.md
+++ b/docs/guides/firecracker-integration-env.md
@@ -13,7 +13,7 @@ A bare-metal KVM host running the full fast-sandbox Firecracker chain with
 one command:
 
 ```
-SandboxTemplate (builder Job, in-cluster)
+SandboxTemplate (builder Pod, in-cluster)
   → golden snapshot published to MinIO
   → node runtime-agent (DaemonSet) pulls + caches
   → SandboxPool schedules fastlet Pods (×2, 5 slots each)
@@ -36,7 +36,7 @@ One-liners:
 |---|---|---|---|
 | MinIO | host Docker container | host | on the kind network (container IP = endpoint); publish + pull credentials |
 | controller | Deployment (1 replica) | control plane | CRDs + RBAC + route-keys; Fast-Path gRPC :9090 |
-| builder Job | Job (on-demand) | KVM-labeled node | /dev/kvm, /dev/net/tun, self-mknod loop devices, publish creds |
+| builder Pod | Job (on-demand) | KVM-labeled node | /dev/kvm, /dev/net/tun, self-mknod loop devices, publish creds |
 | runtime installer | DaemonSet (per-node) | firecracker-node | installs firecracker v1.16.1 + jailer + kernel → hostPath |
 | runtime-agent | DaemonSet (per-node) | firecracker-node | UDS socket + StateRoot shared with fastlets; MinIO pull creds |
 | fastlet Pod | pool-managed Pod ×2 | firecracker-node | profile hostPaths auto-injected; agent socket; registry plan |
@@ -64,7 +64,7 @@ SandboxTemplate controller) and `fast-sandbox.io/firecracker-node=true`
    mounts fail otherwise).
 10. **agent** — readiness = POST /v1/health with a real podUID (read routes
     are POST-only and validate caller identity).
-11. **template build** — builder Job → publish → manifest assertions
+11. **template build** — builder Pod → publish → manifest assertions
     (index/manifest/artifactDigest/sizeBytes/guestNetwork).
 12. **pool** — 2 fastlet pods (poolMin=2), warmImages Cached on both.
 
@@ -231,7 +231,7 @@ Baseline on the reference node (XFS StateRoot):
 - The artifact store must be S3-compatible with immutable,
   digest-addressed objects (`index/<sha256(image)>.json`). Publish and
   pull credentials should be separate (write vs read-only).
-- The store endpoint must be reachable from: builder Job, agent DaemonSet
+- The store endpoint must be reachable from: builder Pod, agent DaemonSet
   (both in-cluster) — a host-side MinIO needs the same routing story as the
   kind-network container-IP trick.
 

--- a/docs/guides/sandboxtemplate-golden-image-e2e.md
+++ b/docs/guides/sandboxtemplate-golden-image-e2e.md
@@ -129,8 +129,9 @@ Notes and known limits:
 - private-registry images: the builder Pod has no imagePullSecrets and the
   CRD has no credential field — pulls are anonymous. For private source or
   execd images, the platform operator must bind registry pull secrets to
-  the `sandbox-template-builder` ServiceAccount (cluster-level secret +
-  SA imagePullSecrets), which is a documented platform responsibility
+  the `sandbox-template-builder` ServiceAccount in the template's
+  namespace (per-tenant secret + SA imagePullSecrets), which is a
+  documented platform responsibility
 - supply chain: the kernel (S3), oci2rootfs and overlaybd (GitHub) are
   downloaded at builder-image build time at pinned revisions but without
   checksum verification; upgrades should pin and verify checksums

--- a/docs/guides/sandboxtemplate-golden-images.md
+++ b/docs/guides/sandboxtemplate-golden-images.md
@@ -32,7 +32,9 @@ SandboxTemplate CR (spec)
 |------|-------------|
 | KVM build nodes | Nodes labeled `sandbox.fast.io/kvm=true`, exposing `/dev/kvm` and `/dev/net/tun`; the build Pod is pinned to them via nodeSelector |
 | Object store | S3-compatible bucket (MinIO/OSS/S3); reachable from the builder |
-| Publish secret | `imagePullSecrets`-style Secret in the **platform namespace** (`fast-sandbox-system`) with keys `accessKeyId`, `secretAccessKey`, `endpoint`, `region` |
+| Publish secret | `imagePullSecrets`-style Secret in the **template's namespace** with keys `accessKeyId`, `secretAccessKey`, `endpoint`, `region` |
+| Builder RBAC | Provisioned automatically: the controller creates the `sandbox-template-builder` ServiceAccount + Role (`pods/patch`) + RoleBinding in the template's namespace on first build |
+| Pod security | The template's namespace must permit **privileged** Pods (e.g. PodSecurityAdmission `allow` privileged), so the builder can mount `/dev/kvm` and `/dev/net/tun` |
 | Controller | The SandboxTemplate reconciler must be running (it drives the build Pod and status) |
 
 The builder image is `build/Dockerfile.sandboxtemplate-builder` (oci2rootfs,
@@ -154,7 +156,7 @@ Precedence: custom `probe` → execd `/ping` (when execd is injected) →
 | `output.rootfsSize` | Yes | `"30Gi"` | Logical capacity of the produced `rootfs.ext4` (Kubernetes quantity). Rounded **up** to SI GiB for oci2rootfs (`30Gi` → 33G → ~30.7 GiB sparse file) |
 | `output.format` | Yes | `overlaybd` | `native` (raw snapshot files only) or `overlaybd` (plus LSMT layers for on-demand range reads); both contain the full artifact set |
 | `output.publish` | Yes | — | S3-compatible target, e.g. `s3://sandbox-images/publish`. Digest-addressed publication; without it the build has no durable artifacts (the builder refuses to run unless `SANDBOX_TEMPLATE_ALLOW_NO_PUBLISH=1`) |
-| `output.publishSecretRef` | No | — | Name of the write-credential Secret in the platform namespace (`accessKeyId`/`secretAccessKey`/`endpoint`/`region`). Without it the build relies on platform-level credentials (IRSA/node metadata). Runtime nodes read with a **separate** read-only credential — write keys never reach them |
+| `output.publishSecretRef` | No | — | Name of the write-credential Secret in the template's namespace (`accessKeyId`/`secretAccessKey`/`endpoint`/`region`). Without it the build relies on platform-level credentials (IRSA/node metadata). Runtime nodes read with a **separate** read-only credential — write keys never reach them |
 | `output.prime` | No | — | Reserved: seed-node cache priming after a successful build; not yet implemented |
 
 ## Build lifecycle
@@ -166,13 +168,15 @@ Precedence: custom `probe` → execd `/ping` (when execd is injected) →
 - **Rebuild**: edit the spec — the generation bump triggers a new build. A
   mid-build spec change deletes the stale build Pod immediately (concurrent
   privileged builds cannot stack up).
-- **Build Pods** run in the platform namespace as
-  `<template>-build-<generation>`, pinned to `sandbox.fast.io/kvm=true` nodes
-  with `/dev/kvm` and `/dev/net/tun` passed through; they have a 2 h deadline
-  and a 10 min Pending timeout (a missing KVM node fails the build instead of
-  hanging forever). Deleting the template reaps its build Pods via a finalizer.
+- **Build Pods** run in the template's own namespace as
+  `<template>-build-<generation>`, owned by the template (deleting the
+  template cascades to its Pods via the garbage collector), pinned to
+  `sandbox.fast.io/kvm=true` nodes with `/dev/kvm` and `/dev/net/tun` passed
+  through; they have a 2 h deadline and a 10 min Pending timeout (a missing
+  KVM node fails the build instead of hanging forever). Finished Pods are
+  kept 24 h for annotation inspection, then reaped by the controller.
 - **Diagnostics**: failed builds surface the container exit reason/message in
-  the condition; the Pod logs (`kubectl -n fast-sandbox logs <build-pod>`)
+  the condition; the Pod logs (`kubectl -n <namespace> logs <build-pod>`)
   carry per-stage timings (`pullMs`, `bootToReadyMs`, `snapshotCreateMs`,
   `restoreToHeartbeatMs`, `importRootfsMs`, …).
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -204,7 +204,7 @@ spec:
 | `output.rootfsSize` | Yes | `"30Gi"` | Logical rootfs capacity (minimum, rounded up to SI GiB) |
 | `output.format` | Yes | `overlaybd` | `native` or `overlaybd` (both contain the full snapshot set) |
 | `output.publish` | Yes | — | S3-compatible digest-addressed publish target, e.g. `s3://bucket/prefix` |
-| `output.publishSecretRef` | No | — | Write-credential Secret name in the platform namespace (`accessKeyId`/`secretAccessKey`/`endpoint`/`region`) |
+| `output.publishSecretRef` | No | — | Write-credential Secret name in the template's namespace (`accessKeyId`/`secretAccessKey`/`endpoint`/`region`) |
 | `output.prime` | No | — | Reserved: seed-node cache priming; not yet implemented |
 
 Readiness precedence: custom `probe` → execd `/ping` → `warmupSeconds` +
@@ -221,9 +221,11 @@ Readiness precedence: custom `probe` → execd `/ping` → `warmupSeconds` +
 | `lastBuildTime` | When the latest build completed |
 | `observedGeneration` | Generation of the last applied build |
 
-Build Pods run in the platform namespace as `<template>-build-<generation>`,
-pinned to `sandbox.fast.io/kvm=true` nodes; editing the spec triggers a
-rebuild (generation bump), and deleting the template reaps its Pods.
+Build Pods run in the template's own namespace as
+`<template>-build-<generation>`, owned by the template (deleting the
+template cascades to its Pods via the garbage collector), pinned to
+`sandbox.fast.io/kvm=true` nodes; editing the spec triggers a rebuild
+(generation bump). Finished Pods are reaped after the build TTL (24 h).
 
 See the [SandboxTemplate guide](../guides/sandboxtemplate-golden-images.md)
 for the end-to-end workflow, artifact layout, and consumption contract.

--- a/internal/controlplane/reconciler/sandboxtemplate_controller.go
+++ b/internal/controlplane/reconciler/sandboxtemplate_controller.go
@@ -10,6 +10,7 @@ import (
 	apiv1alpha2 "fast-sandbox/api/v1alpha2"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,13 +31,12 @@ const (
 	workdirEnvName                       = "SANDBOX_TEMPLATE_WORKDIR"
 	sandboxTemplateBuildDir              = "/build"
 	sandboxTemplateBuilderServiceAccount = "sandbox-template-builder"
-	// builderNamespace is where build Pods run: the platform namespace, not
-	// the tenant namespace, so the privileged builder and its RBAC stay
-	// confined to the control plane.
-	builderNamespace = "fast-sandbox-system"
-	// sandboxTemplateFinalizer lets the controller clean up build Pods when
-	// a template is deleted (build Pods cannot carry an owner reference
-	// across namespaces).
+	// sandboxTemplateFinalizer is a legacy cleanup finalizer from the era
+	// when build Pods ran in the platform namespace and could not carry an
+	// owner reference. Build Pods now live in the template's namespace and
+	// are owned by the template (cascading GC), so the finalizer is only
+	// stripped from templates created before the owner-reference change;
+	// nothing new ever sets it.
 	sandboxTemplateFinalizer = "sandbox.fast.io/sandboxtemplate-cleanup"
 	// buildDeadlineSeconds bounds a single build run; podPendingTimeout
 	// fails a build whose Pod never leaves Pending (e.g. no KVM node).
@@ -46,10 +46,10 @@ const (
 const builderImageEnv = "SANDBOX_TEMPLATE_SPEC"
 
 // sandboxTemplateBuildLabel links a build Pod to its SandboxTemplate (name
-// and namespace; build Pods run in the platform namespace, so ownership is
-// by labels, not owner references); sandboxTemplateGenerationLabel carries
-// the template generation the Pod was created for so a mid-build spec change
-// is never adopted.
+// and namespace; the Pod also carries an owner reference — the labels let
+// the controller adopt, watch and prune builds cheaply);
+// sandboxTemplateGenerationLabel carries the template generation the Pod
+// was created for so a mid-build spec change is never adopted.
 const (
 	sandboxTemplateBuildLabel        = "sandbox.fast.io/sandboxtemplate"
 	sandboxTemplateNamespaceLabel    = "sandbox.fast.io/template-namespace"
@@ -75,7 +75,10 @@ const (
 // validate-boot → snapshot → package) and publishes the content-addressed
 // artifacts; this controller tracks the Pod and records the outcome (phase,
 // conditions, manifestRef, artifactDigest) in status. `output.prime` is
-// reserved but not implemented (see the PrimeSpec doc comment).
+// reserved but not implemented (see the PrimeSpec doc comment). Build Pods
+// run in the template's own namespace and carry a controller owner
+// reference, so deleting a template cascades to its build Pods via the
+// garbage collector; finished Pods are additionally reaped after BuildTTL.
 type SandboxTemplateReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -97,20 +100,16 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, request ctrl.
 		return ctrl.Result{}, err
 	}
 
-	// Deletion: the template owns privileged build Pods it cannot reference
-	// (owner refs cannot cross namespaces), so clean them up before the
-	// finalizer is removed.
+	// Deletion: build Pods are owned by the template (same namespace, owner
+	// reference), so the garbage collector cascades the delete. The only
+	// remaining job here is stripping the legacy cleanup finalizer from
+	// templates created before the owner-reference change.
 	if !template.DeletionTimestamp.IsZero() {
-		if err := r.cleanupTemplate(ctx, &template); err != nil {
-			return ctrl.Result{}, err
+		if controllerutil.ContainsFinalizer(&template, sandboxTemplateFinalizer) {
+			controllerutil.RemoveFinalizer(&template, sandboxTemplateFinalizer)
+			return ctrl.Result{}, r.Update(ctx, &template)
 		}
 		return ctrl.Result{}, nil
-	}
-	if !controllerutil.ContainsFinalizer(&template, sandboxTemplateFinalizer) {
-		controllerutil.AddFinalizer(&template, sandboxTemplateFinalizer)
-		if err := r.Update(ctx, &template); err != nil {
-			return ctrl.Result{}, err
-		}
 	}
 
 	// A build already applied to the current generation is terminal. The
@@ -235,17 +234,18 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, request ctrl.
 }
 
 // SetupWithManager registers the controller for SandboxTemplate objects.
-// Build Pods are watched by label: they live in the platform namespace and
-// carry no owner reference (it cannot cross namespaces), so the controller
-// maps their events back to the owning template.
+// Build Pods run in the template's namespace and carry an owner reference;
+// they are also watched by label so the controller can drive the build
+// lifecycle (phase tracking, stale-generation replacement, TTL reaping)
+// that owner references alone do not cover.
 func (r *SandboxTemplateReconciler) SetupWithManager(manager ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(manager).
 		For(&apiv1alpha2.SandboxTemplate{}).
 		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.mapBuildPod),
 			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				// Only platform-namespace Pods can be builders; drop the
-				// cluster-wide watch noise.
-				return obj.GetNamespace() == builderNamespace
+				// Only builder Pods (tagged with the template build label)
+				// trigger reconciles; drop the cluster-wide watch noise.
+				return obj.GetLabels()[sandboxTemplateBuildLabel] != ""
 			}))).
 		Complete(r)
 }
@@ -255,7 +255,7 @@ func (r *SandboxTemplateReconciler) SetupWithManager(manager ctrl.Manager) error
 // a builder.
 func (r *SandboxTemplateReconciler) mapBuildPod(_ context.Context, obj client.Object) []reconcile.Request {
 	pod, ok := obj.(*corev1.Pod)
-	if !ok || pod.Namespace != builderNamespace {
+	if !ok {
 		return nil
 	}
 	name := pod.Labels[sandboxTemplateBuildLabel]
@@ -266,32 +266,14 @@ func (r *SandboxTemplateReconciler) mapBuildPod(_ context.Context, obj client.Ob
 	return []reconcile.Request{{NamespacedName: client.ObjectKey{Namespace: namespace, Name: name}}}
 }
 
-// cleanupTemplate deletes every build Pod of a deleted template, then
-// removes the finalizer so the object can disappear.
-func (r *SandboxTemplateReconciler) cleanupTemplate(ctx context.Context, template *apiv1alpha2.SandboxTemplate) error {
-	var pods corev1.PodList
-	if err := r.List(ctx, &pods, client.InNamespace(builderNamespace), client.MatchingLabels{
-		sandboxTemplateBuildLabel:     templateLabelValue(template.Name),
-		sandboxTemplateNamespaceLabel: template.Namespace,
-	}); err != nil {
-		return err
-	}
-	for index := range pods.Items {
-		if err := r.Delete(ctx, &pods.Items[index], client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-	controllerutil.RemoveFinalizer(template, sandboxTemplateFinalizer)
-	return r.Update(ctx, template)
-}
-
 // findBuildPod returns the build Pod for the template's current generation,
-// or nil. Build Pods run in the platform namespace and are linked to the
-// template by labels. A Pod built for an older generation (spec changed
-// mid-build) is never adopted: its outcome does not apply to the new spec.
+// or nil. Build Pods run in the template's own namespace and are linked to
+// the template by labels (and an owner reference). A Pod built for an older
+// generation (spec changed mid-build) is never adopted: its outcome does not
+// apply to the new spec.
 func (r *SandboxTemplateReconciler) findBuildPod(ctx context.Context, template *apiv1alpha2.SandboxTemplate) (*corev1.Pod, error) {
 	var pods corev1.PodList
-	if err := r.List(ctx, &pods, client.InNamespace(builderNamespace), client.MatchingLabels{
+	if err := r.List(ctx, &pods, client.InNamespace(template.Namespace), client.MatchingLabels{
 		sandboxTemplateBuildLabel:     templateLabelValue(template.Name),
 		sandboxTemplateNamespaceLabel: template.Namespace,
 	}); err != nil {
@@ -395,7 +377,7 @@ func (r *SandboxTemplateReconciler) cleanupFinishedPods(ctx context.Context, tem
 
 func (r *SandboxTemplateReconciler) listBuildPods(ctx context.Context, template *apiv1alpha2.SandboxTemplate) (*corev1.PodList, error) {
 	var pods corev1.PodList
-	if err := r.List(ctx, &pods, client.InNamespace(builderNamespace), client.MatchingLabels{
+	if err := r.List(ctx, &pods, client.InNamespace(template.Namespace), client.MatchingLabels{
 		sandboxTemplateBuildLabel:     templateLabelValue(template.Name),
 		sandboxTemplateNamespaceLabel: template.Namespace,
 	}); err != nil {
@@ -407,9 +389,17 @@ func (r *SandboxTemplateReconciler) listBuildPods(ctx context.Context, template 
 // createBuildPod launches the builder Pod that executes the pipeline. The
 // template spec is serialized into the environment; the builder image runs
 // the stages (convert → validate-boot → snapshot → package) and publishes
-// the artifacts. The Pod has a deterministic name (<template>-build-<gen>)
-// so concurrent reconciles dedupe via AlreadyExists.
+// the artifacts. The Pod runs in the template's namespace (so it can carry
+// an owner reference and the publish secret can be SecretKeyRef'd from the
+// same namespace) and has a deterministic name (<template>-build-<gen>) so
+// concurrent reconciles dedupe via AlreadyExists.
 func (r *SandboxTemplateReconciler) createBuildPod(ctx context.Context, template *apiv1alpha2.SandboxTemplate) error {
+	// The build Pod self-reports its outcome by merge-patching its own
+	// annotations; provision the minimal builder RBAC (SA + Role + RoleBinding,
+	// pods/patch only) in the template's namespace, idempotently.
+	if err := r.ensureBuilderRBAC(ctx, template.Namespace); err != nil {
+		return err
+	}
 	payload, err := json.Marshal(template.Spec)
 	if err != nil {
 		return err
@@ -464,7 +454,7 @@ func (r *SandboxTemplateReconciler) createBuildPod(ctx context.Context, template
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildPodName(template),
-			Namespace: builderNamespace,
+			Namespace: template.Namespace,
 			Labels: map[string]string{
 				sandboxTemplateBuildLabel:      templateLabelValue(template.Name),
 				sandboxTemplateNamespaceLabel:  template.Namespace,
@@ -524,10 +514,55 @@ func (r *SandboxTemplateReconciler) createBuildPod(ctx context.Context, template
 			},
 		},
 	}
-	// No owner reference: build Pods live in the platform namespace while the
-	// template lives in the tenant namespace, and owner references cannot
-	// cross namespaces. Association is by the labels above.
+	// The Pod is owned by the template, so deleting the template cascades
+	// to it via the garbage collector.
+	if err := ctrl.SetControllerReference(template, pod, r.Scheme); err != nil {
+		return err
+	}
 	if err := r.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// ensureBuilderRBAC makes sure the builder ServiceAccount, Role and
+// RoleBinding exist in the given namespace. The build Pod runs in the
+// template's (tenant) namespace and self-reports its outcome by
+// merge-patching its own annotations, so it needs pods/patch there. The
+// RBAC is provisioned per namespace on demand because a privileged platform
+// SA must not be statically bound into arbitrary tenant namespaces.
+func (r *SandboxTemplateReconciler) ensureBuilderRBAC(ctx context.Context, namespace string) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxTemplateBuilderServiceAccount, Namespace: namespace},
+	}
+	if err := r.Create(ctx, sa); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxTemplateBuilderServiceAccount, Namespace: namespace},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"patch"},
+		}},
+	}
+	if err := r.Create(ctx, role); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxTemplateBuilderServiceAccount, Namespace: namespace},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     sandboxTemplateBuilderServiceAccount,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      sandboxTemplateBuilderServiceAccount,
+			Namespace: namespace,
+		}},
+	}
+	if err := r.Create(ctx, binding); err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 	return nil
@@ -537,11 +572,11 @@ func (r *SandboxTemplateReconciler) createBuildPod(ctx context.Context, template
 // (keys accessKeyId/secretAccessKey/endpoint/region) onto AWS_* env vars via
 // SecretKeyRef: the credentials are never copied into the Pod spec, and the
 // controller does not read tenant secrets during reconcile. The secret must
-// exist in the PLATFORM namespace (builderNamespace) — SecretKeyRef resolves
-// against the Pod's own namespace, so a tenant-namespace secret cannot be
-// referenced. All keys are required (Optional=false): a missing key fails
-// the Pod at container start with CreateContainerConfigError instead of
-// degrading silently.
+// exist in the template's namespace — SecretKeyRef resolves against the
+// Pod's own namespace, and the build Pod now runs next to its template. All
+// keys are required (Optional=false): a missing key fails the Pod at
+// container start with CreateContainerConfigError instead of degrading
+// silently.
 func publishCredentialEnvRefs(ref *corev1.LocalObjectReference) []corev1.EnvVar {
 	key := func(secretKey, envName string) corev1.EnvVar {
 		return corev1.EnvVar{Name: envName, ValueFrom: &corev1.EnvVarSource{
@@ -626,14 +661,12 @@ func podCompletionTime(pod *corev1.Pod) *time.Time {
 	return nil
 }
 
-// buildPodName derives the deterministic build Pod name from the template's
-// namespace AND name (two tenants can create same-named templates; without
-// the namespace the second build would collide on the same Pod name, its
-// Create would be swallowed by AlreadyExists, and the tenant would stay
-// stuck in Building forever). Long names are truncated with a sha256
-// prefix, keeping the result within a sane 63-char budget.
+// buildPodName derives the deterministic build Pod name from the template
+// name (Pods run in the template's own namespace, so names cannot collide
+// across tenants). Long names are truncated with a sha256 prefix, keeping
+// the result within a sane 63-char budget.
 func buildPodName(template *apiv1alpha2.SandboxTemplate) string {
-	seed := template.Namespace + "-" + template.Name
+	seed := template.Name
 	if len(seed) > 40 {
 		sum := sha256.Sum256([]byte(seed))
 		seed = fmt.Sprintf("%s-%x", seed[:40], sum[:8])

--- a/internal/controlplane/reconciler/sandboxtemplate_controller.go
+++ b/internal/controlplane/reconciler/sandboxtemplate_controller.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	apiv1alpha2 "fast-sandbox/api/v1alpha2"
@@ -270,7 +271,10 @@ func (r *SandboxTemplateReconciler) mapBuildPod(_ context.Context, obj client.Ob
 // or nil. Build Pods run in the template's own namespace and are linked to
 // the template by labels (and an owner reference). A Pod built for an older
 // generation (spec changed mid-build) is never adopted: its outcome does not
-// apply to the new spec.
+// apply to the new spec. Neither is a Pod that is not owned by this template
+// UID — a same-named Pod left over by a previously deleted template (its
+// name is deterministic, so a recreated template collides on the name while
+// the old Pod is still being garbage-collected) must not be adopted.
 func (r *SandboxTemplateReconciler) findBuildPod(ctx context.Context, template *apiv1alpha2.SandboxTemplate) (*corev1.Pod, error) {
 	var pods corev1.PodList
 	if err := r.List(ctx, &pods, client.InNamespace(template.Namespace), client.MatchingLabels{
@@ -284,6 +288,9 @@ func (r *SandboxTemplateReconciler) findBuildPod(ctx context.Context, template *
 	for index := range pods.Items {
 		pod := &pods.Items[index]
 		if pod.Labels[sandboxTemplateGenerationLabel] != generation {
+			continue
+		}
+		if !ownedByTemplate(pod, template) {
 			continue
 		}
 		// Pick deterministically: if duplicates ever exist for the same
@@ -329,7 +336,9 @@ func (r *SandboxTemplateReconciler) earliestRetention(ctx context.Context, templ
 
 // cleanupStalePods deletes build Pods of earlier generations once a new
 // generation arrives; a mid-build spec change replaces the in-flight builder
-// instead of letting it run to completion.
+// instead of letting it run to completion. Pods not owned by this template's
+// UID (leftovers of a deleted same-named template) are deleted the same way,
+// so the deterministic name cannot trap the controller on a stale Pod.
 func (r *SandboxTemplateReconciler) cleanupStalePods(ctx context.Context, template *apiv1alpha2.SandboxTemplate) error {
 	pods, err := r.listBuildPods(ctx, template)
 	if err != nil {
@@ -338,6 +347,17 @@ func (r *SandboxTemplateReconciler) cleanupStalePods(ctx context.Context, templa
 	generation := fmt.Sprintf("%d", template.Generation)
 	for index := range pods.Items {
 		pod := &pods.Items[index]
+		if !ownedByTemplate(pod, template) {
+			// Leftover of a deleted same-named template (or a stray):
+			// never adopt, delete immediately. If it is already being
+			// garbage-collected, nothing to do.
+			if pod.DeletionTimestamp == nil {
+				if err := r.Delete(ctx, pod, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
+					return err
+				}
+			}
+			continue
+		}
 		if pod.Labels[sandboxTemplateGenerationLabel] == generation {
 			continue
 		}
@@ -352,6 +372,20 @@ func (r *SandboxTemplateReconciler) cleanupStalePods(ctx context.Context, templa
 		}
 	}
 	return nil
+}
+
+// ownedByTemplate reports whether the Pod carries a controller owner
+// reference to the given template. buildPodName is deterministic, so a
+// recreated template collides on the Pod name while the old Pod is still
+// being garbage-collected; the UID check is what keeps that leftover from
+// being adopted.
+func ownedByTemplate(pod *corev1.Pod, template *apiv1alpha2.SandboxTemplate) bool {
+	for _, ref := range pod.OwnerReferences {
+		if ref.UID == template.UID && ref.Controller != nil && *ref.Controller {
+			return true
+		}
+	}
+	return false
 }
 
 // cleanupFinishedPods removes finished build Pods (any generation, including
@@ -525,12 +559,18 @@ func (r *SandboxTemplateReconciler) createBuildPod(ctx context.Context, template
 	return nil
 }
 
-// ensureBuilderRBAC makes sure the builder ServiceAccount, Role and
-// RoleBinding exist in the given namespace. The build Pod runs in the
-// template's (tenant) namespace and self-reports its outcome by
-// merge-patching its own annotations, so it needs pods/patch there. The
-// RBAC is provisioned per namespace on demand because a privileged platform
-// SA must not be statically bound into arbitrary tenant namespaces.
+// ensureBuilderRBAC converges the builder ServiceAccount, Role and
+// RoleBinding in the given namespace onto exactly the minimal builder
+// privileges (pods/patch). The build Pod runs in the template's (tenant)
+// namespace and self-reports its outcome by merge-patching its own
+// annotations, so it needs pods/patch there. The RBAC is provisioned per
+// namespace on demand because a privileged platform SA must not be
+// statically bound into arbitrary tenant namespaces. Existing objects are
+// not trusted: a same-named Role or RoleBinding with broader content (e.g.
+// pre-created by a tenant) is converged back onto the enforced shape, so
+// the boundary holds by construction rather than by assumption. The
+// ServiceAccount itself is only created, never rewritten, so platform
+// additions such as imagePullSecrets for private registry pulls survive.
 func (r *SandboxTemplateReconciler) ensureBuilderRBAC(ctx context.Context, namespace string) error {
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{Name: sandboxTemplateBuilderServiceAccount, Namespace: namespace},
@@ -546,7 +586,7 @@ func (r *SandboxTemplateReconciler) ensureBuilderRBAC(ctx context.Context, names
 			Verbs:     []string{"patch"},
 		}},
 	}
-	if err := r.Create(ctx, role); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := r.ensureRole(ctx, role); err != nil {
 		return err
 	}
 	binding := &rbacv1.RoleBinding{
@@ -562,10 +602,48 @@ func (r *SandboxTemplateReconciler) ensureBuilderRBAC(ctx context.Context, names
 			Namespace: namespace,
 		}},
 	}
-	if err := r.Create(ctx, binding); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := r.ensureRoleBinding(ctx, binding); err != nil {
 		return err
 	}
 	return nil
+}
+
+// ensureRole creates the Role or, when a same-named one already exists,
+// rewrites its rules onto the desired set. The Role name is reserved for
+// the builder, so any existing content (broader or unrelated rules) is
+// treated as drift to be corrected, never as something to trust.
+func (r *SandboxTemplateReconciler) ensureRole(ctx context.Context, desired *rbacv1.Role) error {
+	if err := r.Create(ctx, desired); err == nil || !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	current := &rbacv1.Role{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(desired), current); err != nil {
+		return err
+	}
+	if reflect.DeepEqual(current.Rules, desired.Rules) {
+		return nil
+	}
+	current.Rules = desired.Rules
+	return r.Update(ctx, current)
+}
+
+// ensureRoleBinding creates the RoleBinding or, when a same-named one
+// already exists, rewrites its roleRef and subjects onto the desired ones
+// (same rationale as ensureRole: bindings are drift-corrected, not trusted).
+func (r *SandboxTemplateReconciler) ensureRoleBinding(ctx context.Context, desired *rbacv1.RoleBinding) error {
+	if err := r.Create(ctx, desired); err == nil || !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	current := &rbacv1.RoleBinding{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(desired), current); err != nil {
+		return err
+	}
+	if reflect.DeepEqual(current.RoleRef, desired.RoleRef) && reflect.DeepEqual(current.Subjects, desired.Subjects) {
+		return nil
+	}
+	current.RoleRef = desired.RoleRef
+	current.Subjects = desired.Subjects
+	return r.Update(ctx, current)
 }
 
 // publishCredentialEnvRefs maps the imagePullSecrets-style publish secret

--- a/internal/controlplane/reconciler/sandboxtemplate_controller_test.go
+++ b/internal/controlplane/reconciler/sandboxtemplate_controller_test.go
@@ -10,6 +10,7 @@ import (
 	apiv1alpha2 "fast-sandbox/api/v1alpha2"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,7 +21,7 @@ import (
 
 func newSandboxTemplate(namespace, name string) *apiv1alpha2.SandboxTemplate {
 	return &apiv1alpha2.SandboxTemplate{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Generation: 1},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: "template-uid", Generation: 1},
 		Spec: apiv1alpha2.SandboxTemplateSpec{
 			Image:  "registry.example.com/sandbox:v1.0.0",
 			Kernel: "vmlinux.bin",
@@ -59,6 +60,9 @@ func newSandboxTemplateReconciler(t *testing.T, objects ...client.Object) *Sandb
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add core scheme: %v", err)
 	}
+	if err := rbacv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add rbac scheme: %v", err)
+	}
 	return &SandboxTemplateReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(&apiv1alpha2.SandboxTemplate{}).
@@ -78,10 +82,10 @@ func reconcileOnce(t *testing.T, r *SandboxTemplateReconciler, key client.Object
 	return result
 }
 
-func listBuilderPods(t *testing.T, r *SandboxTemplateReconciler) []corev1.Pod {
+func listBuilderPods(t *testing.T, r *SandboxTemplateReconciler, namespace string) []corev1.Pod {
 	t.Helper()
 	var pods corev1.PodList
-	if err := r.List(context.Background(), &pods, client.InNamespace(builderNamespace)); err != nil {
+	if err := r.List(context.Background(), &pods, client.InNamespace(namespace)); err != nil {
 		t.Fatalf("list pods: %v", err)
 	}
 	return pods.Items
@@ -96,7 +100,7 @@ func TestSandboxTemplateReconcileCreatesPodAndTracksPhase(t *testing.T) {
 	key := client.ObjectKey{Namespace: namespace, Name: name}
 
 	// First reconcile: Pending → Building, and a build Pod is created in
-	// the platform namespace with the publish credentials injected.
+	// the template's namespace with the publish credentials injected.
 	reconcileOnce(t, reconciler, key)
 	var updated apiv1alpha2.SandboxTemplate
 	if err := reconciler.Get(context.Background(), key, &updated); err != nil {
@@ -105,14 +109,14 @@ func TestSandboxTemplateReconcileCreatesPodAndTracksPhase(t *testing.T) {
 	if updated.Status.Phase != apiv1alpha2.SandboxTemplatePhaseBuilding {
 		t.Fatalf("expected Building phase, got %s", updated.Status.Phase)
 	}
-	if !containsString(updated.Finalizers, sandboxTemplateFinalizer) {
-		t.Fatalf("expected cleanup finalizer to be set")
-	}
-	pods := listBuilderPods(t, reconciler)
+	pods := listBuilderPods(t, reconciler, namespace)
 	if len(pods) != 1 {
-		t.Fatalf("expected one build pod in %s, got %d", builderNamespace, len(pods))
+		t.Fatalf("expected one build pod in %s, got %d", namespace, len(pods))
 	}
 	pod := &pods[0]
+	if pod.Namespace != namespace {
+		t.Fatalf("expected the build pod in the template namespace, got %q", pod.Namespace)
+	}
 	if pod.Name != buildPodName(&updated) {
 		t.Fatalf("expected deterministic pod name, got %q", pod.Name)
 	}
@@ -124,6 +128,25 @@ func TestSandboxTemplateReconcileCreatesPodAndTracksPhase(t *testing.T) {
 	}
 	if pod.Labels[sandboxTemplateGenerationLabel] != "1" {
 		t.Fatalf("build pod missing generation label, got %q", pod.Labels[sandboxTemplateGenerationLabel])
+	}
+	// The Pod carries a controller owner reference to the template: deleting
+	// the template cascades to it via the garbage collector.
+	if len(pod.OwnerReferences) != 1 ||
+		pod.OwnerReferences[0].UID != updated.UID ||
+		pod.OwnerReferences[0].Controller == nil || !*pod.OwnerReferences[0].Controller {
+		t.Fatalf("expected the build pod to be owned by the template, got %+v", pod.OwnerReferences)
+	}
+	// The builder RBAC is provisioned in the template's namespace.
+	sa := &corev1.ServiceAccount{}
+	if err := reconciler.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: sandboxTemplateBuilderServiceAccount}, sa); err != nil {
+		t.Fatalf("expected builder serviceaccount in %s: %v", namespace, err)
+	}
+	binding := &rbacv1.RoleBinding{}
+	if err := reconciler.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: sandboxTemplateBuilderServiceAccount}, binding); err != nil {
+		t.Fatalf("expected builder rolebinding in %s: %v", namespace, err)
+	}
+	if binding.RoleRef.Name != sandboxTemplateBuilderServiceAccount || len(binding.Subjects) != 1 {
+		t.Fatalf("unexpected builder rolebinding: %+v", binding)
 	}
 
 	// Protocol contract: the serialized SANDBOX_TEMPLATE_SPEC round-trips to
@@ -174,7 +197,7 @@ func TestSandboxTemplateReconcileCreatesPodAndTracksPhase(t *testing.T) {
 
 	// A duplicate reconcile must be a no-op (deterministic name + AlreadyExists).
 	reconcileOnce(t, reconciler, key)
-	if pods := listBuilderPods(t, reconciler); len(pods) != 1 {
+	if pods := listBuilderPods(t, reconciler, namespace); len(pods) != 1 {
 		t.Fatalf("expected exactly one build pod after duplicate reconcile, got %d", len(pods))
 	}
 
@@ -225,7 +248,7 @@ func TestSandboxTemplateReconcileCreatesPodAndTracksPhase(t *testing.T) {
 	if result.RequeueAfter != 0 {
 		t.Fatalf("expected no requeue for terminal build, got %v", result.RequeueAfter)
 	}
-	if pods := listBuilderPods(t, reconciler); len(pods) != 0 {
+	if pods := listBuilderPods(t, reconciler, namespace); len(pods) != 0 {
 		t.Fatalf("expected the finished pod to be cleaned up, got %d", len(pods))
 	}
 }
@@ -237,7 +260,7 @@ func TestSandboxTemplateReconcileFailedPod(t *testing.T) {
 	key := client.ObjectKey{Namespace: namespace, Name: name}
 
 	reconcileOnce(t, reconciler, key)
-	pods := listBuilderPods(t, reconciler)
+	pods := listBuilderPods(t, reconciler, namespace)
 	pod := &pods[0]
 	pod.Status.Phase = corev1.PodFailed
 	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
@@ -280,7 +303,7 @@ func TestSandboxTemplateReconcileIgnoresStaleGenerationPod(t *testing.T) {
 
 	// First reconcile creates a Pod for generation 1.
 	reconcileOnce(t, reconciler, key)
-	pods := listBuilderPods(t, reconciler)
+	pods := listBuilderPods(t, reconciler, namespace)
 	if len(pods) != 1 {
 		t.Fatalf("expected one build pod, got %d", len(pods))
 	}
@@ -296,7 +319,7 @@ func TestSandboxTemplateReconcileIgnoresStaleGenerationPod(t *testing.T) {
 		t.Fatalf("update template: %v", err)
 	}
 	reconcileOnce(t, reconciler, key)
-	pods = listBuilderPods(t, reconciler)
+	pods = listBuilderPods(t, reconciler, namespace)
 	if len(pods) != 1 {
 		t.Fatalf("expected the stale pod to be deleted and one fresh pod created, got %d", len(pods))
 	}
@@ -320,7 +343,7 @@ func TestSandboxTemplateReconcileBuildTTLRetainsPod(t *testing.T) {
 	key := client.ObjectKey{Namespace: namespace, Name: name}
 
 	reconcileOnce(t, reconciler, key)
-	pods := listBuilderPods(t, reconciler)
+	pods := listBuilderPods(t, reconciler, namespace)
 	pod := &pods[0]
 	pod.Status.Phase = corev1.PodSucceeded
 	pod.Status.Conditions = []corev1.PodCondition{{
@@ -336,7 +359,7 @@ func TestSandboxTemplateReconcileBuildTTLRetainsPod(t *testing.T) {
 	// Within BuildTTL the finished Pod is retained (annotations still
 	// inspectable); beyond TTL it is cleaned up.
 	reconcileOnce(t, reconciler, key)
-	if pods := listBuilderPods(t, reconciler); len(pods) != 1 {
+	if pods := listBuilderPods(t, reconciler, namespace); len(pods) != 1 {
 		t.Fatalf("expected the finished pod to be retained within BuildTTL, got %d", len(pods))
 	}
 	pod.Status.Conditions = []corev1.PodCondition{{
@@ -349,34 +372,41 @@ func TestSandboxTemplateReconcileBuildTTLRetainsPod(t *testing.T) {
 		t.Fatalf("update pod status: %v", err)
 	}
 	reconcileOnce(t, reconciler, key)
-	if pods := listBuilderPods(t, reconciler); len(pods) != 0 {
+	if pods := listBuilderPods(t, reconciler, namespace); len(pods) != 0 {
 		t.Fatalf("expected the finished pod to be cleaned up after BuildTTL, got %d", len(pods))
 	}
 }
 
-func TestSandboxTemplateDeletionCleansUpBuildPods(t *testing.T) {
+func TestSandboxTemplateBuildPodOwnedByTemplate(t *testing.T) {
 	namespace, name := "tenant-a", "gone"
 	template := newSandboxTemplate(namespace, name)
 	reconciler := newSandboxTemplateReconciler(t, template)
 	key := client.ObjectKey{Namespace: namespace, Name: name}
 
 	reconcileOnce(t, reconciler, key)
-	if pods := listBuilderPods(t, reconciler); len(pods) != 1 {
+	pods := listBuilderPods(t, reconciler, namespace)
+	if len(pods) != 1 {
 		t.Fatalf("expected one build pod, got %d", len(pods))
 	}
-
-	// Deleting the template must reap the privileged build Pod (no
-	// cross-namespace ownerRef) before the finalizer is removed.
+	// The build Pod is owned by the template, so deleting the template
+	// cascades to it via the garbage collector — no finalizer needed.
+	foundOwner := false
+	for _, ref := range pods[0].OwnerReferences {
+		if ref.APIVersion == "sandbox.fast.io/v1alpha2" && ref.Kind == "SandboxTemplate" &&
+			ref.UID == template.UID && ref.Controller != nil && *ref.Controller {
+			foundOwner = true
+		}
+	}
+	if !foundOwner {
+		t.Fatalf("expected a controller owner reference to the template, got %+v", pods[0].OwnerReferences)
+	}
+	// Without a finalizer the template disappears immediately on delete.
 	if err := reconciler.Delete(context.Background(), template); err != nil {
 		t.Fatalf("delete template: %v", err)
 	}
 	reconcileOnce(t, reconciler, key)
-	if pods := listBuilderPods(t, reconciler); len(pods) != 0 {
-		t.Fatalf("expected build pods to be deleted with the template, got %d", len(pods))
-	}
-	// The finalizer is removed, so the object disappears.
 	if err := reconciler.Get(context.Background(), key, &apiv1alpha2.SandboxTemplate{}); !apierrors.IsNotFound(err) {
-		t.Fatalf("expected the template to be gone after finalizer removal, got %v", err)
+		t.Fatalf("expected the template to be gone without a finalizer, got %v", err)
 	}
 }
 
@@ -387,7 +417,7 @@ func TestSandboxTemplateReconcileFailsStuckPendingPod(t *testing.T) {
 	stale := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildPodName(template),
-			Namespace: builderNamespace,
+			Namespace: namespace,
 			Labels: map[string]string{
 				sandboxTemplateBuildLabel:      name,
 				sandboxTemplateNamespaceLabel:  namespace,
@@ -421,15 +451,6 @@ func TestSandboxTemplateReconcileFailsStuckPendingPod(t *testing.T) {
 	}
 }
 
-func containsString(list []string, want string) bool {
-	for _, entry := range list {
-		if entry == want {
-			return true
-		}
-	}
-	return false
-}
-
 func TestSandboxTemplateReconcileSelfHealsPendingPhase(t *testing.T) {
 	namespace, name := "tenant-a", "recover"
 	template := newSandboxTemplate(namespace, name)
@@ -438,7 +459,7 @@ func TestSandboxTemplateReconcileSelfHealsPendingPhase(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildPodName(template),
-			Namespace: builderNamespace,
+			Namespace: namespace,
 			Labels: map[string]string{
 				sandboxTemplateBuildLabel:      name,
 				sandboxTemplateNamespaceLabel:  namespace,
@@ -466,7 +487,7 @@ func TestSandboxTemplatePendingTimeoutDeletesPod(t *testing.T) {
 	stale := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildPodName(template),
-			Namespace: builderNamespace,
+			Namespace: namespace,
 			Labels: map[string]string{
 				sandboxTemplateBuildLabel:      name,
 				sandboxTemplateNamespaceLabel:  namespace,
@@ -481,7 +502,7 @@ func TestSandboxTemplatePendingTimeoutDeletesPod(t *testing.T) {
 	key := client.ObjectKey{Namespace: namespace, Name: name}
 
 	reconcileOnce(t, reconciler, key)
-	if pods := listBuilderPods(t, reconciler); len(pods) != 0 {
+	if pods := listBuilderPods(t, reconciler, namespace); len(pods) != 0 {
 		t.Fatalf("expected the stuck Pending pod to be deleted, got %d", len(pods))
 	}
 }

--- a/internal/controlplane/reconciler/sandboxtemplate_controller_test.go
+++ b/internal/controlplane/reconciler/sandboxtemplate_controller_test.go
@@ -91,6 +91,18 @@ func listBuilderPods(t *testing.T, r *SandboxTemplateReconciler, namespace strin
 	return pods.Items
 }
 
+// builderPodOwnerRefs returns the controller owner reference the reconcile
+// loop stamps on build Pods (same shape as ctrl.SetControllerReference).
+func builderPodOwnerRefs(template *apiv1alpha2.SandboxTemplate) []metav1.OwnerReference {
+	return []metav1.OwnerReference{{
+		APIVersion: apiv1alpha2.GroupVersion.String(),
+		Kind:       "SandboxTemplate",
+		Name:       template.Name,
+		UID:        template.UID,
+		Controller: ptr(true),
+	}}
+}
+
 func TestSandboxTemplateReconcileCreatesPodAndTracksPhase(t *testing.T) {
 	namespace, name := "tenant-a", "golden"
 	template := newSandboxTemplate(namespace, name)
@@ -423,6 +435,7 @@ func TestSandboxTemplateReconcileFailsStuckPendingPod(t *testing.T) {
 				sandboxTemplateNamespaceLabel:  namespace,
 				sandboxTemplateGenerationLabel: "1",
 			},
+			OwnerReferences: builderPodOwnerRefs(template),
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-podPendingTimeout - time.Minute)),
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "build"}}},
@@ -465,6 +478,7 @@ func TestSandboxTemplateReconcileSelfHealsPendingPhase(t *testing.T) {
 				sandboxTemplateNamespaceLabel:  namespace,
 				sandboxTemplateGenerationLabel: "1",
 			},
+			OwnerReferences: builderPodOwnerRefs(template),
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "build"}}},
 	}
@@ -493,6 +507,7 @@ func TestSandboxTemplatePendingTimeoutDeletesPod(t *testing.T) {
 				sandboxTemplateNamespaceLabel:  namespace,
 				sandboxTemplateGenerationLabel: "1",
 			},
+			OwnerReferences: builderPodOwnerRefs(template),
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-podPendingTimeout - time.Minute)),
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "build"}}},
@@ -504,5 +519,108 @@ func TestSandboxTemplatePendingTimeoutDeletesPod(t *testing.T) {
 	reconcileOnce(t, reconciler, key)
 	if pods := listBuilderPods(t, reconciler, namespace); len(pods) != 0 {
 		t.Fatalf("expected the stuck Pending pod to be deleted, got %d", len(pods))
+	}
+}
+
+func TestSandboxTemplateEnsureBuilderRBACConvergesDrift(t *testing.T) {
+	namespace, name := "tenant-a", "converge"
+	// A tenant pre-created a same-named Role with broader rules and a
+	// RoleBinding pointing at a different role/subject, plus a builder SA
+	// carrying platform-managed imagePullSecrets.
+	wideRole := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxTemplateBuilderServiceAccount, Namespace: namespace},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"*"},
+		}},
+	}
+	otherBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxTemplateBuilderServiceAccount, Namespace: namespace},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: "some-other-role"},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "someone-else", Namespace: namespace}},
+	}
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxTemplateBuilderServiceAccount, Namespace: namespace},
+		ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}},
+	}
+	template := newSandboxTemplate(namespace, name)
+	reconciler := newSandboxTemplateReconciler(t, template, wideRole, otherBinding, sa)
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+
+	reconcileOnce(t, reconciler, key)
+
+	// The Role is converged back onto pods/patch, the RoleBinding onto the
+	// builder SA — drift is corrected, not trusted.
+	var role rbacv1.Role
+	if err := reconciler.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: sandboxTemplateBuilderServiceAccount}, &role); err != nil {
+		t.Fatalf("get role: %v", err)
+	}
+	want := []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"patch"}}}
+	if !reflect.DeepEqual(role.Rules, want) {
+		t.Fatalf("expected the role to be converged to pods/patch, got %+v", role.Rules)
+	}
+	var binding rbacv1.RoleBinding
+	if err := reconciler.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: sandboxTemplateBuilderServiceAccount}, &binding); err != nil {
+		t.Fatalf("get rolebinding: %v", err)
+	}
+	if binding.RoleRef.Name != sandboxTemplateBuilderServiceAccount ||
+		len(binding.Subjects) != 1 || binding.Subjects[0].Name != sandboxTemplateBuilderServiceAccount {
+		t.Fatalf("expected the rolebinding to be converged onto the builder SA, got %+v / %+v", binding.RoleRef, binding.Subjects)
+	}
+	// Platform-managed additions to the SA (imagePullSecrets) survive.
+	var saAfter corev1.ServiceAccount
+	if err := reconciler.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: sandboxTemplateBuilderServiceAccount}, &saAfter); err != nil {
+		t.Fatalf("get serviceaccount: %v", err)
+	}
+	if len(saAfter.ImagePullSecrets) != 1 || saAfter.ImagePullSecrets[0].Name != "regcred" {
+		t.Fatalf("expected SA imagePullSecrets to be preserved, got %+v", saAfter.ImagePullSecrets)
+	}
+}
+
+func TestSandboxTemplateReconcileReplacesLeftoverPodOfDeletedTemplate(t *testing.T) {
+	namespace, name := "tenant-a", "recreate"
+	template := newSandboxTemplate(namespace, name)
+	// A Pod left over by a previously deleted same-named template: same
+	// deterministic name and labels, but a different owner UID. The
+	// recreated template must not adopt it.
+	leftover := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      buildPodName(template),
+			Namespace: namespace,
+			Labels: map[string]string{
+				sandboxTemplateBuildLabel:      name,
+				sandboxTemplateNamespaceLabel:  namespace,
+				sandboxTemplateGenerationLabel: "1",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "sandbox.fast.io/v1alpha2",
+				Kind:       "SandboxTemplate",
+				Name:       name,
+				UID:        "old-template-uid",
+				Controller: ptr(true),
+			}},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "build"}}},
+	}
+	reconciler := newSandboxTemplateReconciler(t, template, leftover)
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+
+	reconcileOnce(t, reconciler, key)
+	pods := listBuilderPods(t, reconciler, namespace)
+	if len(pods) != 1 {
+		t.Fatalf("expected exactly one pod after replacing the leftover, got %d", len(pods))
+	}
+	// The leftover was deleted and replaced by a Pod owned by the new
+	// template UID (fake client deletes synchronously, so one reconcile is
+	// enough to observe the replacement).
+	owned := false
+	for _, ref := range pods[0].OwnerReferences {
+		if ref.UID == template.UID && ref.Controller != nil && *ref.Controller {
+			owned = true
+		}
+	}
+	if !owned {
+		t.Fatalf("expected the leftover to be replaced by a pod owned by the new template, got %+v", pods[0].OwnerReferences)
 	}
 }

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -2,7 +2,7 @@
 # integration-env.sh — Kind single-host full-chain integration environment.
 #
 # Builds the fast-sandbox Firecracker on-demand loading chain on a bare-metal
-# KVM host: SandboxTemplate golden-image build (builder Job in-cluster) →
+# KVM host: SandboxTemplate golden-image build (builder Pod in-cluster) →
 # publish MinIO → node runtime-agent (DaemonSet) → fastlet sandbox restore →
 # execd /ping delivery verification.
 #
@@ -721,7 +721,8 @@ credentials_up() {
 	local host
 	host="${MINIO_ENDPOINT#http://}"
 	host="${host#https://}"
-	# Publish credentials: SecretKeyRef'd by the builder Job (fast-sandbox-system).
+	# Publish credentials: SecretKeyRef'd by the builder Pod (same namespace
+	# as the template).
 	kubectl -n "$NS" create secret generic sandbox-oss-credentials \
 		--from-literal=accessKeyId="$MINIO_AK" \
 		--from-literal=secretAccessKey="$MINIO_SK" \


### PR DESCRIPTION
## Summary

The SandboxTemplate build Pod currently runs in the platform namespace (`fast-sandbox-system`) because it is privileged and its RBAC was confined to the control plane. Since owner references cannot cross namespaces, the Pod is associated to its template by labels only and relies on a finalizer to be reaped when the template is deleted.

This PR moves the build Pod into the template's own namespace and makes the template its controller owner, so deletion cascades through the garbage collector.

## Changes

- **`sandboxtemplate_controller.go`**
  - Pod created in `template.Namespace` with `ctrl.SetControllerReference` (cascading GC); `cleanupTemplate` + the finalizer logic removed. The legacy finalizer is still stripped on delete for templates created before this change.
  - New `ensureBuilderRBAC`: idempotently provisions the `sandbox-template-builder` ServiceAccount + Role (`pods/patch`, for the builder's self-reported outcome) + RoleBinding in each template namespace.
  - Watch, listing and cleanup paths (`findBuildPod`, `listBuildPods`, stale/finished Pod cleanup, `mapBuildPod`, watch predicate) now follow the template namespace / build label instead of the platform namespace.
  - Deterministic Pod name drops the namespace seed (no cross-namespace collision possible anymore).
  - `publishCredentialEnvRefs` doc updated: the publish secret now resolves from the Pod's own (template) namespace.
- **`config/rbac/base.yaml`**: controller ClusterRole gains `serviceaccounts`/`roles`/`rolebindings` create+get, drops `sandboxtemplates/finalizers`; the platform-namespace builder SA/Role/RoleBinding are removed (per-tenant provisioning replaces them).
- **Tests**: updated to tenant-namespace expectations, owner-reference assertions, and provisioning of the builder RBAC; the deletion test now verifies the owner reference mechanism.
- **Docs**: design doc, golden-images guide, reference/api.md, e2e guide, sample and integration-env comments updated (publish secret in template namespace, privileged-Pod requirement, cascading deletion).

## Trade-offs (documented in the design doc)

- The template's namespace must permit **privileged** Pods (PodSecurityAdmission) for `/dev/kvm` passthrough.
- The publish secret must live in the template's namespace (SecretKeyRef cannot cross namespaces).
- The privileged-builder boundary moves from "control plane only" to "template namespace"; in exchange, template deletion natively reaps build Pods, and finished-Pod BuildTTL reaping is unchanged.

## Verification

- `go build ./...`, `go vet ./...` clean.
- `go test ./internal/controlplane/reconciler/ -count=1` passes (all SandboxTemplate tests).