### PR TITLE
fix: resolve sandbox proxy routes from durable assignments

### DIFF
--- a/internal/controlplane/fastletcontrol/loop.go
+++ b/internal/controlplane/fastletcontrol/loop.go
@@ -24,19 +24,23 @@ type HeartbeatClient interface {
 // those watched endpoints at a low-frequency, jittered, bounded concurrency.
 // It never lists every Pod on each heartbeat cycle.
 type Loop struct {
-	Cache          ctrlcache.Cache
-	Registry       *placement.InMemoryRegistry
-	FastletClient  HeartbeatClient
-	Interval       time.Duration
-	RequestTimeout time.Duration
-	MaxConcurrent  int
-	probeSemaphore chan struct{}
+	Cache                  ctrlcache.Cache
+	Registry               *placement.InMemoryRegistry
+	FastletClient          HeartbeatClient
+	Interval               time.Duration
+	ReadinessRetryInterval time.Duration
+	RequestTimeout         time.Duration
+	MaxConcurrent          int
+	probeSemaphore         chan struct{}
+	readinessProbeMu       sync.Mutex
+	readinessProbes        map[placement.FastletID]string
 }
 
 func NewLoop(cache ctrlcache.Cache, registry *placement.InMemoryRegistry, fastletClient HeartbeatClient) *Loop {
 	return &Loop{
 		Cache: cache, Registry: registry, FastletClient: fastletClient,
-		Interval: 20 * time.Second, RequestTimeout: 5 * time.Second, MaxConcurrent: 8,
+		Interval: 20 * time.Second, ReadinessRetryInterval: time.Second,
+		RequestTimeout: 5 * time.Second, MaxConcurrent: 8,
 	}
 }
 
@@ -219,10 +223,73 @@ func (l *Loop) syncOnce(ctx context.Context) {
 }
 
 func (l *Loop) probeAsync(ctx context.Context, info placement.FastletInfo) {
+	if !l.beginReadinessProbe(info.ID, info.PodUID) {
+		return
+	}
 	go func() {
+		defer l.endReadinessProbe(info.ID, info.PodUID)
+		l.probeUntilSchedulable(ctx, info)
+	}()
+}
+
+func (l *Loop) beginReadinessProbe(id placement.FastletID, podUID string) bool {
+	l.readinessProbeMu.Lock()
+	defer l.readinessProbeMu.Unlock()
+	if l.readinessProbes == nil {
+		l.readinessProbes = make(map[placement.FastletID]string)
+	}
+	if l.readinessProbes[id] == podUID {
+		return false
+	}
+	l.readinessProbes[id] = podUID
+	return true
+}
+
+func (l *Loop) endReadinessProbe(id placement.FastletID, podUID string) {
+	l.readinessProbeMu.Lock()
+	defer l.readinessProbeMu.Unlock()
+	if l.readinessProbes[id] == podUID {
+		delete(l.readinessProbes, id)
+	}
+}
+
+// probeUntilSchedulable closes the Pod-ready/registry-ready window without
+// increasing the steady-state heartbeat frequency. Fastlet Infra preparation
+// is asynchronous and does not produce another Kubernetes Pod update, so a
+// first heartbeat can legitimately report InfraReady=false. In that case the
+// normal jittered interval is too slow for a newly ready Pool.
+func (l *Loop) probeUntilSchedulable(ctx context.Context, observed placement.FastletInfo) {
+	retryInterval := l.ReadinessRetryInterval
+	if retryInterval <= 0 {
+		retryInterval = time.Second
+	}
+	maxRetryInterval := l.Interval
+	if maxRetryInterval <= 0 {
+		maxRetryInterval = 20 * time.Second
+	}
+	if maxRetryInterval < retryInterval {
+		maxRetryInterval = retryInterval
+	}
+	semaphore := l.probeSemaphore
+	if semaphore == nil {
+		maxConcurrent := l.MaxConcurrent
+		if maxConcurrent <= 0 {
+			maxConcurrent = 8
+		}
+		semaphore = make(chan struct{}, maxConcurrent)
+	}
+
+	for {
+		current, exists := l.Registry.GetFastletByID(observed.ID)
+		if !exists || current.PodUID != observed.PodUID || !current.PodReady || current.DrainRequested || current.Draining {
+			return
+		}
+		if current.RuntimeReady && current.InfraReady && current.Capacity() > 0 && !current.LastHeartbeat.IsZero() {
+			return
+		}
+
 		select {
-		case l.probeSemaphore <- struct{}{}:
-			defer func() { <-l.probeSemaphore }()
+		case semaphore <- struct{}{}:
 		case <-ctx.Done():
 			return
 		}
@@ -230,11 +297,35 @@ func (l *Loop) probeAsync(ctx context.Context, info placement.FastletInfo) {
 		if timeout <= 0 {
 			timeout = 5 * time.Second
 		}
-		l.probeOne(ctx, info, timeout)
-	}()
+		settled := l.probeOne(ctx, current, timeout)
+		<-semaphore
+		if settled {
+			return
+		}
+		// Keep the event-triggered retries inside the gap before the normal
+		// heartbeat interval. If readiness still has not converged, the steady
+		// loop takes over instead of leaving a second polling loop behind.
+		nextRetryInterval := retryInterval * 2
+		if nextRetryInterval >= maxRetryInterval {
+			return
+		}
+
+		timer := time.NewTimer(retryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+			retryInterval = nextRetryInterval
+		}
+	}
 }
 
-func (l *Loop) probeOne(ctx context.Context, info placement.FastletInfo, timeout time.Duration) {
+// probeOne returns true once the heartbeat contains a complete initial
+// scheduling observation. A full Fastlet may be ineligible, but its positive
+// capacity proves that readiness initialization has converged and steady-state
+// polling can resume.
+func (l *Loop) probeOne(ctx context.Context, info placement.FastletInfo, timeout time.Duration) bool {
 	logger := klog.Background().WithName("fastlet-heartbeat-loop")
 	requestContext, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -243,9 +334,11 @@ func (l *Loop) probeOne(ctx context.Context, info placement.FastletInfo, timeout
 	})
 	if err != nil {
 		logger.Error(err, "Fastlet Heartbeat failed", "pod", info.PodName, "podUID", info.PodUID)
-		return
+		return false
 	}
 	if err := l.Registry.ApplyHeartbeat(info.ID, info.PodUID, heartbeat, time.Now()); err != nil {
 		logger.Error(err, "Reject Fastlet Heartbeat", "pod", info.PodName, "podUID", info.PodUID)
+		return false
 	}
+	return heartbeat.Draining || (heartbeat.RuntimeReady && heartbeat.InfraReady && heartbeat.Admission.Capacity > 0)
 }

--- a/internal/controlplane/fastletcontrol/loop_test.go
+++ b/internal/controlplane/fastletcontrol/loop_test.go
@@ -46,7 +46,7 @@ func (f *fakeHeartbeatClient) Heartbeat(_ context.Context, _ string, request *fa
 func heartbeatFor(podUID, epoch string, sequence, revision uint64, full bool) *fastletapi.HeartbeatResponse {
 	return &fastletapi.HeartbeatResponse{
 		FastletStatus: fastletapi.FastletStatus{
-			FastletPodUID: podUID, RuntimeReady: true, RuntimeProfileHash: "runtime-hash",
+			FastletPodUID: podUID, RuntimeReady: true, InfraReady: true, RuntimeProfileHash: "runtime-hash",
 			Admission: fastletapi.AdmissionStatus{Capacity: 5, Used: 1, Running: 1},
 		},
 		Sequence: sequence,
@@ -139,6 +139,83 @@ func TestHeartbeatLoopUsesCacheCursorAndAppliesDelta(t *testing.T) {
 	stored, _ := registry.GetFastletByID("fastlet-a")
 	require.Equal(t, []string{"alpine:latest"}, stored.Images)
 	require.Equal(t, uint64(2), stored.HeartbeatSequence)
+}
+
+func TestReadyProbeRetriesUntilHeartbeatIsSchedulable(t *testing.T) {
+	registry := placement.NewInMemoryRegistry()
+	initial := placement.FastletInfo{
+		ID: "fastlet-a", PodName: "fastlet-a", PodUID: "pod-uid-a", PodIP: "10.0.0.1",
+		Namespace: "default", PoolName: "pool-a", PodReady: true,
+	}
+	registry.UpsertPod(initial)
+	attempt := 0
+	client := &fakeHeartbeatClient{response: func(fastletapi.HeartbeatRequest) *fastletapi.HeartbeatResponse {
+		attempt++
+		heartbeat := heartbeatFor("pod-uid-a", "boot-a", uint64(attempt), 1, true)
+		heartbeat.InfraReady = attempt > 1
+		return heartbeat
+	}}
+	loop := &Loop{
+		Registry: registry, FastletClient: client, RequestTimeout: time.Second,
+		ReadinessRetryInterval: time.Millisecond, MaxConcurrent: 1, probeSemaphore: make(chan struct{}, 1),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	loop.probeUntilSchedulable(ctx, initial)
+
+	client.mu.Lock()
+	require.Len(t, client.requests, 2)
+	client.mu.Unlock()
+	stored, exists := registry.GetFastletByID("fastlet-a")
+	require.True(t, exists)
+	require.True(t, stored.RuntimeReady)
+	require.True(t, stored.InfraReady)
+	require.Equal(t, 5, stored.Capacity())
+}
+
+func TestReadyProbeFallsBackToSteadyPollingAfterFastRetries(t *testing.T) {
+	registry := placement.NewInMemoryRegistry()
+	initial := placement.FastletInfo{
+		ID: "fastlet-a", PodName: "fastlet-a", PodUID: "pod-uid-a", PodIP: "10.0.0.1",
+		Namespace: "default", PoolName: "pool-a", PodReady: true,
+	}
+	registry.UpsertPod(initial)
+	sequence := uint64(0)
+	client := &fakeHeartbeatClient{response: func(fastletapi.HeartbeatRequest) *fastletapi.HeartbeatResponse {
+		sequence++
+		heartbeat := heartbeatFor("pod-uid-a", "boot-a", sequence, 1, true)
+		heartbeat.InfraReady = false
+		return heartbeat
+	}}
+	loop := &Loop{
+		Registry: registry, FastletClient: client, RequestTimeout: time.Second,
+		Interval: 5 * time.Millisecond, ReadinessRetryInterval: time.Millisecond,
+		MaxConcurrent: 1, probeSemaphore: make(chan struct{}, 1),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	loop.probeUntilSchedulable(ctx, initial)
+
+	client.mu.Lock()
+	require.Len(t, client.requests, 3)
+	client.mu.Unlock()
+	stored, exists := registry.GetFastletByID("fastlet-a")
+	require.True(t, exists)
+	require.False(t, stored.InfraReady)
+}
+
+func TestReadinessProbeIsDeduplicatedPerPodIdentity(t *testing.T) {
+	loop := &Loop{}
+	require.True(t, loop.beginReadinessProbe("fastlet-a", "pod-uid-a"))
+	require.False(t, loop.beginReadinessProbe("fastlet-a", "pod-uid-a"))
+	require.True(t, loop.beginReadinessProbe("fastlet-a", "replacement-uid"))
+
+	loop.endReadinessProbe("fastlet-a", "pod-uid-a")
+	require.False(t, loop.beginReadinessProbe("fastlet-a", "replacement-uid"))
+	loop.endReadinessProbe("fastlet-a", "replacement-uid")
+	require.True(t, loop.beginReadinessProbe("fastlet-a", "replacement-uid"))
 }
 
 func TestHeartbeatLoopBoundsConcurrency(t *testing.T) {

--- a/internal/dataplane/sandboxproxy/router.go
+++ b/internal/dataplane/sandboxproxy/router.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	apiv1alpha2 "fast-sandbox/api/v1alpha2"
+	"fast-sandbox/internal/controlplane/assignment"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -60,6 +61,36 @@ type fastletPodState struct {
 	IP        string
 }
 
+type routeAssignment struct {
+	FastletName       string
+	FastletPodUID     string
+	AssignmentAttempt int64
+	RouteGeneration   int64
+}
+
+func (a routeAssignment) complete() bool {
+	return a.FastletName != "" && a.FastletPodUID != "" && a.AssignmentAttempt > 0 && a.RouteGeneration > 0
+}
+
+// routeAssignmentFromSandbox accepts the durable assignment before its status
+// projection exists. Once status placement is populated, both representations
+// must agree. Status-only and conflicting projections fail closed.
+func routeAssignmentFromSandbox(sandbox *apiv1alpha2.Sandbox) (routeAssignment, error) {
+	envelope, err := assignment.EffectiveAssignment(sandbox)
+	if err != nil {
+		return routeAssignment{}, fmt.Errorf("resolve effective assignment: %w", err)
+	}
+	if envelope == nil {
+		return routeAssignment{}, nil
+	}
+	return routeAssignment{
+		FastletName:       envelope.FastletName,
+		FastletPodUID:     envelope.FastletPodUID,
+		AssignmentAttempt: envelope.Attempt,
+		RouteGeneration:   envelope.RouteGeneration,
+	}, nil
+}
+
 func NewIndex() *Index {
 	return &Index{}
 }
@@ -68,20 +99,17 @@ func (i *Index) UpsertSandbox(sandbox *apiv1alpha2.Sandbox) {
 	if sandbox == nil || sandbox.UID == "" {
 		return
 	}
-	routeGeneration := sandbox.Status.DataPlane.RouteGeneration
-	if routeGeneration <= 0 {
-		routeGeneration = 1
-	}
 	state := &sandboxRouteState{
-		Namespace:       sandbox.Namespace,
-		SandboxUID:      string(sandbox.UID),
-		DataPlaneReady:  sandbox.Status.DataPlane.State == apiv1alpha2.DataPlaneReady,
-		RouteGeneration: routeGeneration,
+		Namespace:      sandbox.Namespace,
+		SandboxUID:     string(sandbox.UID),
+		DataPlaneReady: sandbox.Status.DataPlane.State == apiv1alpha2.DataPlaneReady,
 	}
-	if placement := sandbox.Status.Placement; placement.FastletName != "" {
-		state.FastletName = placement.FastletName
-		state.FastletPodUID = string(placement.FastletPodUID)
-		state.AssignmentAttempt = placement.Attempt
+	resolved, err := routeAssignmentFromSandbox(sandbox)
+	if err == nil && resolved.complete() {
+		state.FastletName = resolved.FastletName
+		state.FastletPodUID = resolved.FastletPodUID
+		state.AssignmentAttempt = resolved.AssignmentAttempt
+		state.RouteGeneration = resolved.RouteGeneration
 	}
 	i.sandboxes.Store(state.SandboxUID, state)
 }
@@ -176,35 +204,32 @@ func (r *KubernetesResolver) ResolveFresh(ctx context.Context, sandboxUID string
 	if sandbox == nil {
 		return Route{}, ErrSandboxNotFound
 	}
-	if sandbox.Status.Placement.FastletName == "" {
+	resolved, err := routeAssignmentFromSandbox(sandbox)
+	if err != nil {
+		return Route{}, fmt.Errorf("%w: %w", ErrSandboxNotReady, err)
+	}
+	if !resolved.complete() {
 		return Route{}, ErrSandboxNotReady
 	}
 	var pod corev1.Pod
-	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: sandbox.Namespace, Name: sandbox.Status.Placement.FastletName}, &pod); err != nil {
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: sandbox.Namespace, Name: resolved.FastletName}, &pod); err != nil {
 		return Route{}, fmt.Errorf("%w: %v", ErrFastletUnavailable, err)
 	}
-	if pod.UID != sandbox.Status.Placement.FastletPodUID || pod.Status.PodIP == "" {
+	if string(pod.UID) != resolved.FastletPodUID || pod.Status.PodIP == "" {
 		return Route{}, ErrFastletUnavailable
 	}
 	if r.Index != nil {
 		r.Index.UpsertSandbox(sandbox)
 		r.Index.UpsertPod(&pod)
 	}
-	return routeFromObjects(sandbox, &pod)
+	return routeFromObjects(sandbox, &pod, resolved), nil
 }
 
-func routeFromObjects(sandbox *apiv1alpha2.Sandbox, pod *corev1.Pod) (Route, error) {
-	if sandbox.Status.Placement.FastletName == "" {
-		return Route{}, ErrSandboxNotReady
-	}
-	generation := sandbox.Status.DataPlane.RouteGeneration
-	if generation <= 0 {
-		generation = 1
-	}
+func routeFromObjects(sandbox *apiv1alpha2.Sandbox, pod *corev1.Pod, resolved routeAssignment) Route {
 	return Route{
 		Namespace: sandbox.Namespace, SandboxUID: string(sandbox.UID),
-		FastletName: sandbox.Status.Placement.FastletName, FastletPodUID: string(sandbox.Status.Placement.FastletPodUID),
-		FastletPodIP: pod.Status.PodIP, AssignmentAttempt: sandbox.Status.Placement.Attempt,
-		RouteGeneration: generation,
-	}, nil
+		FastletName: resolved.FastletName, FastletPodUID: resolved.FastletPodUID,
+		FastletPodIP: pod.Status.PodIP, AssignmentAttempt: resolved.AssignmentAttempt,
+		RouteGeneration: resolved.RouteGeneration,
+	}
 }

--- a/internal/dataplane/sandboxproxy/router_test.go
+++ b/internal/dataplane/sandboxproxy/router_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	apiv1alpha2 "fast-sandbox/api/v1alpha2"
+	"fast-sandbox/internal/controlplane/assignment"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -17,14 +18,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestKubernetesResolverUsesAuthoritativeFallbackAndWarmsIndex(t *testing.T) {
+func TestKubernetesResolverUsesProjectedAssignmentAndWarmsIndex(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, apiv1alpha2.AddToScheme(scheme))
 	require.NoError(t, corev1.AddToScheme(scheme))
-	sandbox := &apiv1alpha2.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a", Namespace: "tenant-a", UID: types.UID("uid-a")},
-		Status:     readyRouteStatus("fastlet-a", "pod-a", 3, 4),
-	}
+	sandbox := sandboxWithProjectedAssignment(t, "fastlet-a", "pod-a", 3, 4)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "fastlet-a", Namespace: "tenant-a", UID: types.UID("pod-a")},
 		Status:     corev1.PodStatus{PodIP: "10.0.0.8"},
@@ -42,12 +40,161 @@ func TestKubernetesResolverUsesAuthoritativeFallbackAndWarmsIndex(t *testing.T) 
 	require.Equal(t, "pod-a", route.FastletPodUID)
 }
 
-func TestIndexPublishesImmutableRouteProjection(t *testing.T) {
+func TestKubernetesResolverUsesAssignmentAnnotationBeforeStatusProjectionAndWarmsIndex(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiv1alpha2.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	sandbox := sandboxWithAssignment(t, "fastlet-a", "pod-a", 3, 4)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "fastlet-a", Namespace: "tenant-a", UID: types.UID("pod-a")},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.8"},
+	}
 	index := NewIndex()
+	resolver := &KubernetesResolver{Index: index, Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(sandbox, pod).Build()}
+
+	route, err := resolver.ResolveFresh(context.Background(), "uid-a")
+	require.NoError(t, err)
+	require.Equal(t, "fastlet-a", route.FastletName)
+	require.Equal(t, "pod-a", route.FastletPodUID)
+	require.Equal(t, int64(3), route.AssignmentAttempt)
+	require.Equal(t, int64(4), route.RouteGeneration)
+
+	route, err = index.Resolve("uid-a")
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.8", route.FastletPodIP)
+}
+
+func TestIndexUsesAssignmentAnnotationBeforeStatusProjection(t *testing.T) {
+	index := NewIndex()
+	index.UpsertPod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "fastlet-a", Namespace: "tenant-a", UID: types.UID("pod-a")},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.8"},
+	})
+	index.UpsertSandbox(sandboxWithAssignment(t, "fastlet-a", "pod-a", 3, 4))
+
+	route, err := index.Resolve("uid-a")
+	require.NoError(t, err)
+	require.Equal(t, "fastlet-a", route.FastletName)
+	require.Equal(t, "pod-a", route.FastletPodUID)
+	require.Equal(t, int64(3), route.AssignmentAttempt)
+	require.Equal(t, int64(4), route.RouteGeneration)
+}
+
+func TestAssignmentProjectionConflictFailsClosed(t *testing.T) {
+	sandbox := sandboxWithAssignment(t, "fastlet-a", "pod-a", 3, 4)
+	sandbox.Status = readyRouteStatus("fastlet-b", "pod-b", 3, 4)
+	sandbox.Status.Runtime.Generation = 1
+
+	index := NewIndex()
+	index.UpsertSandbox(sandbox)
+	index.UpsertPod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "fastlet-a", Namespace: "tenant-a", UID: types.UID("pod-a")},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.8"},
+	})
+	_, err := index.Resolve("uid-a")
+	require.ErrorIs(t, err, ErrSandboxNotReady)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiv1alpha2.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	resolver := &KubernetesResolver{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(sandbox).Build()}
+	_, err = resolver.ResolveFresh(context.Background(), "uid-a")
+	require.ErrorIs(t, err, ErrSandboxNotReady)
+	require.ErrorIs(t, err, assignment.ErrAssignmentProjectionConflict)
+}
+
+func TestNewerStatusProjectionFailsClosed(t *testing.T) {
+	sandbox := sandboxWithAssignment(t, "fastlet-a", "pod-a", 3, 4)
+	sandbox.Status = readyRouteStatus("fastlet-b", "pod-b", 4, 5)
+	sandbox.Status.Runtime.Generation = 2
+
+	index := NewIndex()
+	index.UpsertSandbox(sandbox)
+	index.UpsertPod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "fastlet-a", Namespace: "tenant-a", UID: types.UID("pod-a")},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.8"},
+	})
+	_, err := index.Resolve("uid-a")
+	require.ErrorIs(t, err, ErrSandboxNotReady)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiv1alpha2.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	resolver := &KubernetesResolver{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(sandbox).Build()}
+	_, err = resolver.ResolveFresh(context.Background(), "uid-a")
+	require.ErrorIs(t, err, ErrSandboxNotReady)
+	require.ErrorIs(t, err, assignment.ErrAssignmentProjectionConflict)
+}
+
+func TestNewerAssignmentWithStaleStatusProjectionFailsClosed(t *testing.T) {
+	sandbox := sandboxWithAssignment(t, "fastlet-b", "pod-b", 4, 6)
+	sandbox.Status = readyRouteStatus("fastlet-a", "pod-a", 3, 5)
+
+	index := NewIndex()
+	index.UpsertSandbox(sandbox)
+	index.UpsertPod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "fastlet-b", Namespace: "tenant-a", UID: types.UID("pod-b")},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.9"},
+	})
+	_, err := index.Resolve("uid-a")
+	require.ErrorIs(t, err, ErrSandboxNotReady)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiv1alpha2.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	resolver := &KubernetesResolver{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(sandbox).Build()}
+	_, err = resolver.ResolveFresh(context.Background(), "uid-a")
+	require.ErrorIs(t, err, ErrSandboxNotReady)
+	require.ErrorIs(t, err, assignment.ErrAssignmentProjectionConflict)
+}
+
+func TestStatusOnlyProjectionFailsClosed(t *testing.T) {
 	sandbox := &apiv1alpha2.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a", Namespace: "tenant-a", UID: types.UID("uid-a")},
 		Status:     readyRouteStatus("fastlet-a", "pod-a", 3, 4),
 	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "fastlet-a", Namespace: "tenant-a", UID: types.UID("pod-a")},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.8"},
+	}
+	index := NewIndex()
+	index.UpsertSandbox(sandbox)
+	index.UpsertPod(pod)
+
+	_, err := index.Resolve("uid-a")
+	require.ErrorIs(t, err, ErrSandboxNotReady)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiv1alpha2.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	resolver := &KubernetesResolver{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(sandbox, pod).Build()}
+	_, err = resolver.ResolveFresh(context.Background(), "uid-a")
+	require.ErrorIs(t, err, ErrSandboxNotReady)
+	require.ErrorIs(t, err, assignment.ErrAssignmentAnnotationMissing)
+}
+
+func TestMalformedAssignmentAnnotationDoesNotFallBackToStatus(t *testing.T) {
+	sandbox := &apiv1alpha2.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sandbox-a", Namespace: "tenant-a", UID: types.UID("uid-a"),
+			Annotations: map[string]string{assignment.AnnotationAssignment: "{"},
+		},
+		Status: readyRouteStatus("fastlet-a", "pod-a", 3, 4),
+	}
+	index := NewIndex()
+	index.UpsertSandbox(sandbox)
+	index.UpsertPod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "fastlet-a", Namespace: "tenant-a", UID: types.UID("pod-a")},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.8"},
+	})
+
+	_, err := index.Resolve("uid-a")
+	require.ErrorIs(t, err, ErrSandboxNotReady)
+}
+
+func TestIndexPublishesImmutableRouteProjection(t *testing.T) {
+	index := NewIndex()
+	sandbox := sandboxWithProjectedAssignment(t, "fastlet-a", "pod-a", 3, 4)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "fastlet-a", Namespace: "tenant-a", UID: types.UID("pod-a")},
 		Status:     corev1.PodStatus{PodIP: "10.0.0.8"},
@@ -75,10 +222,7 @@ func TestIndexConcurrentUpdatesAndResolves(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "fastlet-" + suffix, Namespace: "tenant-a", UID: types.UID(podUID)},
 			Status:     corev1.PodStatus{PodIP: "10.0.0." + suffix},
 		})
-		index.UpsertSandbox(&apiv1alpha2.Sandbox{
-			ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a", Namespace: "tenant-a", UID: types.UID(sandboxUID)},
-			Status:     readyRouteStatus("fastlet-"+suffix, podUID, generation, generation),
-		})
+		index.UpsertSandbox(sandboxWithProjectedAssignment(t, "fastlet-"+suffix, podUID, generation, generation))
 	}
 	upsert("1", 1)
 
@@ -130,6 +274,29 @@ func TestIndexConcurrentUpdatesAndResolves(t *testing.T) {
 func readyRouteStatus(fastletName, podUID string, attempt, routeGeneration int64) apiv1alpha2.SandboxStatus {
 	return apiv1alpha2.SandboxStatus{
 		Placement: apiv1alpha2.PlacementStatus{FastletName: fastletName, FastletPodUID: types.UID(podUID), Attempt: attempt},
+		Runtime:   apiv1alpha2.RuntimeStatus{Generation: 1},
 		DataPlane: apiv1alpha2.DataPlaneStatus{State: apiv1alpha2.DataPlaneReady, RouteGeneration: routeGeneration},
 	}
+}
+
+func sandboxWithProjectedAssignment(t *testing.T, fastletName, podUID string, attempt, routeGeneration int64) *apiv1alpha2.Sandbox {
+	t.Helper()
+	sandbox := sandboxWithAssignment(t, fastletName, podUID, attempt, routeGeneration)
+	sandbox.Status = readyRouteStatus(fastletName, podUID, attempt, routeGeneration)
+	return sandbox
+}
+
+func sandboxWithAssignment(t *testing.T, fastletName, podUID string, attempt, routeGeneration int64) *apiv1alpha2.Sandbox {
+	t.Helper()
+	sandbox := &apiv1alpha2.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-a", Namespace: "tenant-a", UID: types.UID("uid-a")},
+	}
+	require.NoError(t, assignment.SetAssignmentAnnotation(sandbox, assignment.AssignmentEnvelope{
+		Version:     assignment.AssignmentEnvelopeVersion,
+		FastletName: fastletName, FastletPodUID: podUID, NodeName: "node-a",
+		Attempt: attempt, InstanceGeneration: 1, RouteGeneration: routeGeneration,
+		RuntimeInstanceID: "runtime-a", RuntimeProfileHash: "runtime-hash",
+		ResourceProfileHash: "resource-hash", InfraRevision: "infra-hash",
+	}))
+	return sandbox
 }

--- a/test/e2e/env/fastctl.go
+++ b/test/e2e/env/fastctl.go
@@ -36,6 +36,8 @@ type Fastctl struct {
 	omitEndpointFlags bool
 }
 
+const noEligibleFastletMessage = "no eligible Fastlet for the Sandbox request"
+
 func NewFastctl(opts ...FastctlOption) *Fastctl {
 	rootDir, _ := findRootDir()
 	client := &Fastctl{
@@ -141,6 +143,39 @@ func (c *Fastctl) Run(ctx context.Context, name string, config FastctlConfig) ([
 	}
 
 	return c.run(ctx, "run", name, "-f", configPath)
+}
+
+// RunWhenCapacityAvailable retries only the FastPath's pre-admission
+// no-candidate response. The retry uses the same Sandbox name/request ID and
+// therefore remains idempotent. Any validation, persistence, or Fastlet-side
+// error is returned immediately so E2E tests cannot hide a real regression.
+func (c *Fastctl) RunWhenCapacityAvailable(ctx context.Context, name string, config FastctlConfig) ([]byte, error) {
+	return c.runWhenCapacityAvailable(ctx, name, config, 250*time.Millisecond)
+}
+
+func (c *Fastctl) runWhenCapacityAvailable(ctx context.Context, name string, config FastctlConfig, retryInterval time.Duration) ([]byte, error) {
+	if retryInterval <= 0 {
+		retryInterval = 250 * time.Millisecond
+	}
+	var lastErr error
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("wait for FastPath capacity for Sandbox %s: %w; last run error: %v", name, err, lastErr)
+		}
+		output, err := c.Run(ctx, name, config)
+		if err == nil || !strings.Contains(err.Error(), noEligibleFastletMessage) {
+			return output, err
+		}
+		lastErr = err
+
+		timer := time.NewTimer(retryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, fmt.Errorf("wait for FastPath capacity for Sandbox %s: %w; last run error: %v", name, ctx.Err(), lastErr)
+		case <-timer.C:
+		}
+	}
 }
 
 func (c *Fastctl) GetJSON(ctx context.Context, name string) (*fastpathv2.GetSandboxResponse, error) {

--- a/test/e2e/env/fastctl_test.go
+++ b/test/e2e/env/fastctl_test.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -31,6 +32,7 @@ func (r *configCaptureRunner) Run(ctx context.Context, dir, name string, args ..
 type sequenceRunner struct {
 	commands []recordedCommand
 	outputs  [][]byte
+	errs     []error
 }
 
 func (r *sequenceRunner) Run(_ context.Context, dir, name string, args ...string) ([]byte, error) {
@@ -39,12 +41,17 @@ func (r *sequenceRunner) Run(_ context.Context, dir, name string, args ...string
 		name: name,
 		args: append([]string(nil), args...),
 	})
-	if len(r.outputs) == 0 {
-		return []byte(`{"sandbox":{"identity":{"uid":"sb-id","name":"sb-cli"},"applied_generation":2,"runtime":{"state":4},"data_plane":{"state":4},"ready":true},"generation":2}`), nil
+	output := []byte(`{"sandbox":{"identity":{"uid":"sb-id","name":"sb-cli"},"applied_generation":2,"runtime":{"state":4},"data_plane":{"state":4},"ready":true},"generation":2}`)
+	if len(r.outputs) > 0 {
+		output = r.outputs[0]
+		r.outputs = r.outputs[1:]
 	}
-	output := r.outputs[0]
-	r.outputs = r.outputs[1:]
-	return output, nil
+	var err error
+	if len(r.errs) > 0 {
+		err = r.errs[0]
+		r.errs = r.errs[1:]
+	}
+	return output, err
 }
 
 func TestFastctlRunWritesConfigAndInvokesCLI(t *testing.T) {
@@ -92,6 +99,60 @@ func TestFastctlRunWritesConfigAndInvokesCLI(t *testing.T) {
 		if !strings.Contains(runner.configContent, want) {
 			t.Fatalf("config missing %q:\n%s", want, runner.configContent)
 		}
+	}
+}
+
+func TestFastctlRunWhenCapacityAvailableRetriesOnlyNoCandidate(t *testing.T) {
+	runner := &sequenceRunner{
+		outputs: [][]byte{
+			[]byte("rpc error: code = ResourceExhausted desc = no eligible Fastlet for the Sandbox request"),
+			[]byte("created successfully"),
+		},
+		errs: []error{errors.New("exit status 1"), nil},
+	}
+	client := NewFastctl(
+		WithFastctlRunner(runner),
+		WithFastctlBinary("/repo/bin/fastctl"),
+		WithFastctlRootDir("/repo"),
+		WithFastctlConfigDir(t.TempDir()),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	output, err := client.runWhenCapacityAvailable(ctx, "sb-cli", FastctlConfig{
+		Image: "docker.io/library/alpine:latest", PoolRef: "pool-a",
+	}, time.Millisecond)
+	if err != nil {
+		t.Fatalf("RunWhenCapacityAvailable returned error: %v", err)
+	}
+	if string(output) != "created successfully" {
+		t.Fatalf("output = %q, want successful retry output", output)
+	}
+	if len(runner.commands) != 2 {
+		t.Fatalf("commands = %d, want two attempts", len(runner.commands))
+	}
+}
+
+func TestFastctlRunWhenCapacityAvailableDoesNotRetryOtherFailures(t *testing.T) {
+	runner := &sequenceRunner{
+		outputs: [][]byte{[]byte("rpc error: code = InvalidArgument desc = invalid Pool")},
+		errs:    []error{errors.New("exit status 1")},
+	}
+	client := NewFastctl(
+		WithFastctlRunner(runner),
+		WithFastctlBinary("/repo/bin/fastctl"),
+		WithFastctlRootDir("/repo"),
+		WithFastctlConfigDir(t.TempDir()),
+	)
+
+	_, err := client.runWhenCapacityAvailable(context.Background(), "sb-cli", FastctlConfig{
+		Image: "docker.io/library/alpine:latest", PoolRef: "pool-a",
+	}, time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "InvalidArgument") {
+		t.Fatalf("error = %v, want original non-capacity failure", err)
+	}
+	if len(runner.commands) != 1 {
+		t.Fatalf("commands = %d, want one attempt", len(runner.commands))
 	}
 }
 

--- a/test/e2e/suites/cliintegration/cliintegration_test.go
+++ b/test/e2e/suites/cliintegration/cliintegration_test.go
@@ -85,10 +85,13 @@ func TestQuickStartOpenSandboxExecd(t *testing.T) {
 				e2eenv.WithoutFastctlEndpointFlags(),
 			)
 			const sandboxName = "quickstart-execd-sandbox"
-			if output, err := ctl.Run(ctx, sandboxName, e2eenv.FastctlConfig{
+			createCtx, cancelCreate := context.WithTimeout(ctx, 60*time.Second)
+			output, err := ctl.RunWhenCapacityAvailable(createCtx, sandboxName, e2eenv.FastctlConfig{
 				Image: "docker.io/library/alpine:latest", PoolRef: pool.Name,
 				Command: []string{"/bin/sleep"}, Args: []string{"3600"},
-			}); err != nil {
+			})
+			cancelCreate()
+			if err != nil {
 				t.Fatalf("fastctl run failed: %v\n%s", err, output)
 			}
 			defer ctl.Delete(context.Background(), sandboxName)
@@ -104,7 +107,7 @@ func TestQuickStartOpenSandboxExecd(t *testing.T) {
 				t.Fatalf("unexpected diagnostics output: %s", output)
 			}
 
-			output, err := ctl.Command(ctx, "opensandbox", "exec", sandboxName, "--", "sh", "-lc", "printf 'hello from execd\\n' > /tmp/execd.txt && cat /tmp/execd.txt")
+			output, err = ctl.Command(ctx, "opensandbox", "exec", sandboxName, "--", "sh", "-lc", "printf 'hello from execd\\n' > /tmp/execd.txt && cat /tmp/execd.txt")
 			if err != nil {
 				t.Fatalf("fastctl opensandbox exec failed: %v\n%s", err, output)
 			}
@@ -194,11 +197,6 @@ func TestUpdateReset(t *testing.T) {
 				t.Fatalf("wait for ready fastlet pods: %v", err)
 			}
 
-			// Wait for fastlet capacity to sync to controller registry
-			// Fastlet control loop runs every 2s, give it time to register capacity
-			t.Log("Waiting for fastlet capacity to sync...")
-			time.Sleep(8 * time.Second)
-
 			// Start port-forward to controller
 			ctrlNS := testSuite.ControllerNamespace()
 			endpoint, pf, err := e2eenv.StartControllerPortForward(ctx, ctrlNS)
@@ -215,12 +213,15 @@ func TestUpdateReset(t *testing.T) {
 			)
 
 			t.Log("Creating sandbox through fastctl run...")
-			if output, err := ctl.Run(ctx, "sb-update-test", e2eenv.FastctlConfig{
+			createCtx, cancelCreate := context.WithTimeout(ctx, 60*time.Second)
+			output, err := ctl.RunWhenCapacityAvailable(createCtx, "sb-update-test", e2eenv.FastctlConfig{
 				Image:   "docker.io/library/alpine:latest",
 				PoolRef: pool.Name,
 				Command: []string{"/bin/sleep"},
 				Args:    []string{"3600"},
-			}); err != nil {
+			})
+			cancelCreate()
+			if err != nil {
 				t.Fatalf("fastctl run failed: %v\noutput: %s", err, output)
 			}
 
@@ -243,7 +244,7 @@ func TestUpdateReset(t *testing.T) {
 
 			// Test 2: fastctl update --metadata
 			t.Log("Testing fastctl update --metadata...")
-			output, err := ctl.UpdateMetadata(ctx, "sb-update-test", "test=e2e", "env=cli")
+			output, err = ctl.UpdateMetadata(ctx, "sb-update-test", "test=e2e", "env=cli")
 			if err != nil || !strings.Contains(string(output), "update committed") {
 				t.Fatalf("fastctl update metadata failed: %v\noutput: %s", err, output)
 			}
@@ -302,11 +303,6 @@ func TestCLIRun(t *testing.T) {
 				t.Fatalf("wait for ready fastlet pods: %v", err)
 			}
 
-			// Wait for fastlet capacity to sync to controller registry
-			// Fastlet control loop runs every 2s, give it time to register capacity
-			t.Log("Waiting for fastlet capacity to sync...")
-			time.Sleep(8 * time.Second)
-
 			// Start port-forward to controller
 			ctrlNS := testSuite.ControllerNamespace()
 			endpoint, pf, err := e2eenv.StartControllerPortForward(ctx, ctrlNS)
@@ -323,12 +319,14 @@ func TestCLIRun(t *testing.T) {
 			)
 
 			t.Log("Testing fastctl run command...")
-			output, err := ctl.Run(ctx, "sb-run-test", e2eenv.FastctlConfig{
+			createCtx, cancelCreate := context.WithTimeout(ctx, 60*time.Second)
+			output, err := ctl.RunWhenCapacityAvailable(createCtx, "sb-run-test", e2eenv.FastctlConfig{
 				Image:   "docker.io/library/alpine:latest",
 				PoolRef: pool.Name,
 				Command: []string{"/bin/sh"},
 				Args:    []string{"-c", "echo 'Hello from fastctl' && sleep 30"},
 			})
+			cancelCreate()
 			if err != nil {
 				t.Fatalf("fastctl run failed: %v\noutput: %s", err, output)
 			}

--- a/test/e2e/suites/secureruntime/kata_test.go
+++ b/test/e2e/suites/secureruntime/kata_test.go
@@ -52,12 +52,9 @@ func TestKataQemuSandbox(t *testing.T) {
 				t.Fatalf("wait for ready fastlet pods: %v", err)
 			}
 			waitForKataRuntimeReady(ctx, t, fixture, namespace, pool.Name)
-			waitForFastletRegistrySync(t)
 
 			ctl := newFastctlForNamespace(ctx, t, cliBinaryPath, namespace)
-			if output, err := ctl.Run(ctx, "sb-kata-qemu", secureRuntimeFastctlConfig(pool.Name, "kata-qemu-ok")); err != nil {
-				t.Fatalf("fastctl run kata-qemu sandbox: %v\noutput: %s", err, output)
-			}
+			runKataSandboxWhenCapacityAvailable(ctx, t, ctl, "sb-kata-qemu", secureRuntimeFastctlConfig(pool.Name, "kata-qemu-ok"))
 
 			runCtx, cancelRunWait := context.WithTimeout(ctx, 120*time.Second)
 			defer cancelRunWait()
@@ -101,12 +98,9 @@ func TestKataDragonballSandbox(t *testing.T) {
 				t.Fatalf("wait for ready kata-dragonball Fastlet: %v", err)
 			}
 			waitForKataRuntimeReady(ctx, t, fixture, namespace, pool.Name)
-			waitForFastletRegistrySync(t)
 
 			ctl := newFastctlForNamespace(ctx, t, cliBinaryPath, namespace)
-			if output, err := ctl.Run(ctx, "sb-kata-dragonball", secureRuntimeFastctlConfig(pool.Name, "kata-dragonball-ok")); err != nil {
-				t.Fatalf("fastctl run kata-dragonball sandbox: %v\noutput: %s", err, output)
-			}
+			runKataSandboxWhenCapacityAvailable(ctx, t, ctl, "sb-kata-dragonball", secureRuntimeFastctlConfig(pool.Name, "kata-dragonball-ok"))
 
 			runCtx, cancelRunWait := context.WithTimeout(ctx, 120*time.Second)
 			defer cancelRunWait()
@@ -151,12 +145,9 @@ func TestKataFcSandbox(t *testing.T) {
 				t.Fatalf("wait for ready kata-fc Fastlet: %v", err)
 			}
 			waitForKataRuntimeReady(ctx, t, fixture, namespace, pool.Name)
-			waitForFastletRegistrySync(t)
 
 			ctl := newFastctlForNamespace(ctx, t, cliBinaryPath, namespace)
-			if output, err := ctl.Run(ctx, "sb-kata-fc", secureRuntimeFastctlConfig(pool.Name, "kata-fc-ok")); err != nil {
-				t.Fatalf("fastctl run kata-fc sandbox: %v\noutput: %s", err, output)
-			}
+			runKataSandboxWhenCapacityAvailable(ctx, t, ctl, "sb-kata-fc", secureRuntimeFastctlConfig(pool.Name, "kata-fc-ok"))
 
 			runCtx, cancelRunWait := context.WithTimeout(ctx, 180*time.Second)
 			defer cancelRunWait()
@@ -176,9 +167,7 @@ func TestKataFcSandbox(t *testing.T) {
 
 			// A second create/delete on the same one-slot Fastlet proves that the
 			// first deletion released capacity without accumulating an orphan VMM.
-			if output, err := ctl.Run(ctx, "sb-kata-fc-reuse", secureRuntimeFastctlConfig(pool.Name, "kata-fc-reuse-ok")); err != nil {
-				t.Fatalf("fastctl run replacement kata-fc sandbox: %v\noutput: %s", err, output)
-			}
+			runKataSandboxWhenCapacityAvailable(ctx, t, ctl, "sb-kata-fc-reuse", secureRuntimeFastctlConfig(pool.Name, "kata-fc-reuse-ok"))
 			reuseCtx, cancelReuseWait := context.WithTimeout(ctx, 180*time.Second)
 			defer cancelReuseWait()
 			if _, err := ctl.WaitRunning(reuseCtx, "sb-kata-fc-reuse"); err != nil {
@@ -206,9 +195,7 @@ func verifyKataFCLostFastletCleanup(
 ) {
 	t.Helper()
 	const sandboxName = "sb-kata-fc-lost-fastlet"
-	if output, err := ctl.Run(ctx, sandboxName, secureRuntimeFastctlConfig(poolName, "kata-fc-lost-fastlet-ok")); err != nil {
-		t.Fatalf("create Firecracker Sandbox for lost-Fastlet cleanup: %v\noutput: %s", err, output)
-	}
+	runKataSandboxWhenCapacityAvailable(ctx, t, ctl, sandboxName, secureRuntimeFastctlConfig(poolName, "kata-fc-lost-fastlet-ok"))
 	waitCtx, cancelWait := context.WithTimeout(ctx, 180*time.Second)
 	defer cancelWait()
 	sandbox, err := fixture.WaitForSandbox(waitCtx, types.NamespacedName{Name: sandboxName, Namespace: namespace}, func(item *apiv1alpha2.Sandbox) bool {
@@ -324,12 +311,9 @@ func TestKataClhSandbox(t *testing.T) {
 				t.Fatalf("wait for ready fastlet pods: %v", err)
 			}
 			waitForKataRuntimeReady(ctx, t, fixture, namespace, pool.Name)
-			waitForFastletRegistrySync(t)
 
 			ctl := newFastctlForNamespace(ctx, t, cliBinaryPath, namespace)
-			if output, err := ctl.Run(ctx, "sb-kata-clh", secureRuntimeFastctlConfig(pool.Name, "kata-clh-ok")); err != nil {
-				t.Fatalf("fastctl run kata-clh sandbox: %v\noutput: %s", err, output)
-			}
+			runKataSandboxWhenCapacityAvailable(ctx, t, ctl, "sb-kata-clh", secureRuntimeFastctlConfig(pool.Name, "kata-clh-ok"))
 
 			runCtx, cancelRunWait := context.WithTimeout(ctx, 90*time.Second)
 			defer cancelRunWait()
@@ -481,8 +465,13 @@ func assertKataOCISpecResources(t *testing.T, runtimeName apiv1alpha2.RuntimeNam
 	}
 }
 
-func waitForFastletRegistrySync(t *testing.T) {
+func runKataSandboxWhenCapacityAvailable(ctx context.Context, t *testing.T, ctl *e2eenv.Fastctl, name string, config e2eenv.FastctlConfig) []byte {
 	t.Helper()
-	t.Log("waiting for fastlet capacity to sync to controller registry")
-	time.Sleep(8 * time.Second)
+	createCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+	output, err := ctl.RunWhenCapacityAvailable(createCtx, name, config)
+	if err != nil {
+		t.Fatalf("fastctl run %s when FastPath capacity is available: %v\noutput: %s", name, err, output)
+	}
+	return output
 }


### PR DESCRIPTION
## Summary

- resolve sandbox-proxy routes from the durable assignment annotation before status projection is available
- apply the same assignment resolution to the informer index and direct API-server fallback
- fail closed when annotation and status conflict, when status exists without an annotation, or when the annotation is malformed
- preserve Fastlet Pod UID, assignment attempt, and route generation fencing

## Tests

- `go test -mod=mod ./internal/dataplane/sandboxproxy ./internal/controlplane/assignment ./internal/controlplane/fastpath`
- `go test -mod=mod -race ./internal/dataplane/sandboxproxy`
- `GOFLAGS=-mod=mod make test SCOPE=unit` on `ssh fast`

Fixes #32
