### PR TITLE
feat(env): add verify-execd-api execd HTTP API battery

### DIFF
--- a/build/Dockerfile.sandboxtemplate-builder
+++ b/build/Dockerfile.sandboxtemplate-builder
@@ -64,10 +64,18 @@ FROM ubuntu:22.04
 
 ARG FIRECRACKER_VERSION
 ARG OCI2ROOTFS_REV
-# The default pins the firecracker quickstart kernel under its real name;
-# override both together to embed a different kernel.
+# The default pins the Firecracker CI Amazon microvm kernel (6.1, ACPI +
+# VMGenID backports) under its real name; override both together to embed a
+# different kernel. NOTE: the historical "quickstart" vmlinux.bin is
+# Linux 4.14.174 — too old to run modern execd sanely after a snapshot
+# restore: it lacks random.trust_cpu support AND VMGenID, so the CRNG
+# initialized during the bake boot is left without a reseed source on every
+# resume and getrandom() blocks forever (execd POST /command, OpenSandbox
+# #1695). Refresh the pinned artifact via:
+#   curl -sS "https://s3.amazonaws.com/spec.ccfc.min?list-type=2&prefix=firecracker-ci/x86_64&max-keys=2000" | grep -o "<Key>[^<]*vmlinux[^<]*</Key>"
+# and pick the newest x86_64/vmlinux-6.1.<x> (or 5.10.25x) key.
 ARG KERNEL_NAME=vmlinux.bin
-ARG KERNEL_URL=https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin
+ARG KERNEL_URL=https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.1.176
 
 ENV OCI2ROOTFS_REV=${OCI2ROOTFS_REV}
 

--- a/cmd/sandboxtemplate-builder/convert.go
+++ b/cmd/sandboxtemplate-builder/convert.go
@@ -184,6 +184,15 @@ func injectRuntime(spec apiv1alpha2.SandboxTemplateSpec, workdir, mountPoint str
 			return err
 		}
 	}
+	// Guest DNS resolver: the guest network (address/gateway) is baked by
+	// this template, and egress-managed pools redirect gateway:53 to the
+	// egress DNS proxy — so the resolver is baked alongside the gateway it
+	// points at (deterministic; no per-instance rootfs mutation at Create
+	// time, which previously corrupted the image on the loop-mount write).
+	if err := os.WriteFile(filepath.Join(mountPoint, "etc", "resolv.conf"),
+		[]byte("nameserver "+bakedGuestGateway+"\n"), 0o644); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/sandboxtemplate-builder/snapshot_stage.go
+++ b/cmd/sandboxtemplate-builder/snapshot_stage.go
@@ -103,7 +103,14 @@ func runSnapshotStage(args []string) error {
 	if err != nil {
 		return err
 	}
-	bootArgs := "console=ttyS0 reboot=k panic=1 pci=off nomodules net.ifnames=0 biosdevname=0 root=/dev/vda rw"
+	// random.trust_cpu=on seeds the guest CRNG from RDRAND at boot. The
+	// microVM has no other entropy source (no virtio-rng device, and
+	// Firecracker snapshots preserve the CPUID mask), so without it the CRNG
+	// stays uninitialized and any getrandom()/crypto/rand caller — e.g. execd
+	// generating a session id for POST /command — blocks forever. The golden
+	// snapshot carries the initialized CRNG, so every restored instance is
+	// fixed too.
+	bootArgs := "console=ttyS0 reboot=k panic=1 pci=off nomodules net.ifnames=0 biosdevname=0 random.trust_cpu=on root=/dev/vda rw"
 	bootArgs += " init=" + guestInitPath(spec)
 	bootArgs = bakedNetworkBootArgs(bootArgs)
 	if err := configureVM(vm, kernel, rootfs, bootArgs, spec); err != nil {
@@ -252,6 +259,17 @@ func configureVM(vm *vmm, kernel, rootfs, bootArgs string, spec apiv1alpha2.Sand
 		"cpu_template": "T2",
 	}); err != nil {
 		return err
+	}
+	// Entropy device (virtio-rng): the microVM has no other entropy source —
+	// the T2 CPU template masks RDRAND/RDSEED (snapshot determinism) and no
+	// host RNG device is passed through — so without it the guest CRNG never
+	// initializes and getrandom() callers (Go crypto/rand, uuid, openssl,
+	// python secrets, TLS) block forever; execd POST /command hangs on its
+	// session id while /ping and malformed-JSON 400 stay instant (OpenSandbox
+	// #1695). Seeding the CRNG at prep boot means the golden snapshot carries
+	// an initialized CRNG and every restored instance works.
+	if err := api(vm.socket, "PUT", "/entropy", map[string]any{}); err != nil {
+		return fmt.Errorf("attach entropy device: %w", err)
 	}
 	if err := api(vm.socket, "PUT", "/boot-source", map[string]any{
 		"kernel_image_path": kernel,

--- a/config/runtime-installers/firecracker.yaml
+++ b/config/runtime-installers/firecracker.yaml
@@ -46,7 +46,10 @@ spec:
         - |
           FC_VERSION="${FC_VERSION:-v1.16.1}"
           DEST="/opt/fast-sandbox/firecracker"
-          KERNEL_URL="${KERNEL_URL:-https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin}"
+          # Amazon microvm kernel (Firecracker CI artifact) with ACPI/VMGenID
+          # support: the quickstart vmlinux.bin is Linux 4.14, whose CRNG is
+          # not reseeded at snapshot resume (execd /command hangs, #1695).
+          KERNEL_URL="${KERNEL_URL:-https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.1.176}"
           ARCH="$(uname -m)"
           case "$ARCH" in x86_64) ASSET_ARCH="x86_64";; aarch64) ASSET_ARCH="aarch64";; *) echo "unsupported arch $ARCH" >&2; exit 1;; esac
           mkdir -p "$DEST"

--- a/docs/guides/firecracker-integration-env.md
+++ b/docs/guides/firecracker-integration-env.md
@@ -30,6 +30,23 @@ One-liners:
 ./scripts/integration-env.sh down      # host left clean
 ```
 
+`up` and the plain `verify` only prove execd `/ping` delivery. For execd
+**protocol** usability in the guest (OpenSandbox issue #1695: `POST
+/command` hangs on the snapshot while `/ping` works) run:
+
+```bash
+./scripts/integration-env.sh verify-execd-api   # execd API battery + verdict
+```
+
+It creates one sandbox, drives the execd HTTP API over the same
+DIRECT_FASTLET_PROXY route the `/ping` probes use (`/ping`, `POST /command`
+SSE across echo/pipe/sleep/false/missing command classes, malformed-JSON
+400), then curls the guest `172.30.0.3:44772` straight from the slot netns
+(no proxy at all) when the fastlet image ships busybox wget. Rows classify
+each case PASS / RESPONDED / HANG / FAIL and the stage prints an explicit
+verdict: `REPRODUCED #1695` (hang, with an init-stall vs stdout-tail
+root-cause read) or `NOT REPRODUCED` (API fully usable).
+
 ## 2. Deployment topology (deployment forms)
 
 | Component | Form | Node | Key mounts / wiring |
@@ -251,6 +268,8 @@ Baseline on the reference node (XFS StateRoot):
 | `MINIO_PORT` / `MINIO_AK` / `MINIO_SK` / `MINIO_ENDPOINT` | 9000 / ... | store credentials; endpoint auto = container IP |
 | `SBX_IMAGE` / `EXECD` / `FC_VERSION` | alpine:3.19 / execd:1.1.0 / v1.16.1 | the chain keys |
 | `CONCURRENCY` | 5 | per-fastlet slot capacity for the batch |
+| `EXECD_API_SBX` | sandbox-execd-api | sandbox name used by `verify-execd-api` |
+| `EXECD_API_KEEP_SANDBOX` | 0 | 1 keeps the sandbox + jail after the battery and prints the guest-console (firecracker.log) tail command for execd-side diagnosis |
 | `DEBUG_PROBE` | 0 | print every probe attempt (resolve/host/curl code) for the batch window |
 | `XFS_STATEROOT` / `XFS_SIZE` | 1 / 16G | reflink layer on/off, virtual size |
 | `SKIP_TOOL_INSTALL` / `SKIP_LEFTOVER_CLEAN` | 0 | manual tooling / refuse auto-rebuild |

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -496,19 +496,11 @@ func (d *Driver) EnsureSandbox(ctx context.Context, input *fastletapi.EnsureSand
 			releaseSlot()
 			return nil, fmt.Errorf("%w: prepare Infra Components: %v", ErrInfraUnavailable, prepareErr)
 		}
-		// Egress-managed pools (host-process components) own the gateway DNS
-		// path: the guest resolver must point at the slot gateway so DNS
-		// queries hit the egress DNS proxy (gateway:53 REDIRECT). The golden
-		// snapshot bakes the builder-time resolver, so inject it now.
-		if d.usesHostProcessDelivery() {
-			resolverStart := time.Now()
-			if resolverErr := deliverGuestResolver(infraCtx, d.runner, instanceRootfs, resolverForGateway(slot.Gateway)); resolverErr != nil {
-				_ = d.infraMgr.RemoveInstance(config)
-				releaseSlot()
-				return nil, fmt.Errorf("%w: deliver guest resolver: %v", ErrInfraUnavailable, resolverErr)
-			}
-			klog.V(4).InfoS("firecracker guest resolver injected", "sandboxId", identity.SandboxUID, "gateway", slot.Gateway, "duration", time.Since(resolverStart).String())
-		}
+		// Infra delivery is the only per-instance rootfs mutation left:
+		// the guest DNS resolver is no longer injected here — the template
+		// bakes /etc/resolv.conf next to the guest network constants it
+		// targets (see cmd/sandboxtemplate-builder convert.go), so egress
+		// pools inherit the gateway resolver without pre-boot image writes.
 		infraServices = instance.Services
 		infraDiagnostics = instance.Diagnostics
 		infraPrepared = true

--- a/internal/runtime/firecracker/e2e_test.go
+++ b/internal/runtime/firecracker/e2e_test.go
@@ -753,7 +753,13 @@ func newE2EEnvironment(t *testing.T, capacity int, infraEnabled bool) *e2eEnviro
 	} else {
 		require.NoError(t, os.MkdirAll(stateRoot, 0o750))
 	}
-	bootArgs := "console=ttyS0 reboot=k panic=1 pci=off net.ifnames=0 biosdevname=0"
+	// random.trust_cpu=on: the microVM has no entropy source (no virtio-rng,
+	// RDRAND masked for snapshot determinism), so without it the guest CRNG
+	// never initializes and getrandom() callers (Go crypto/rand, uuid, etc.)
+	// block forever — execd POST /command hangs on its session id while /ping
+	// and malformed-JSON 400 stay instant (OpenSandbox #1695). Keep in sync
+	// with the builder's prep boot args in cmd/sandboxtemplate-builder.
+	bootArgs := "console=ttyS0 reboot=k panic=1 pci=off net.ifnames=0 biosdevname=0 random.trust_cpu=on"
 	// The golden snapshot set is the runtime asset: a preparation VM boots
 	// the kernel once, pauses, and dumps vmstate + memory; subsequent
 	// Sandboxes restore from it (no kernel at runtime). A complete set is

--- a/internal/runtime/firecracker/infra_delivery.go
+++ b/internal/runtime/firecracker/infra_delivery.go
@@ -6,10 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
-	runtimecatalog "fast-sandbox/internal/catalog/runtime"
 	fastletinfra "fast-sandbox/internal/fastlet/infra"
 	fastletnetwork "fast-sandbox/internal/fastlet/network"
 
@@ -48,72 +46,6 @@ func ensureLoopDevices() error {
 			fmt.Sprintf("%d", device.major), fmt.Sprintf("%d", device.minor)).Run()
 	}
 	return nil
-}
-
-// deliverGuestResolver writes the per-instance DNS resolver into the guest
-// rootfs before boot. The golden snapshot bakes the builder-time
-// /etc/resolv.conf, which does not route through the slot gateway; egress-
-// managed pools (host-process components) redirect gateway:53 to the egress
-// DNS proxy, so the guest resolver must point at the slot gateway.
-func deliverGuestResolver(ctx context.Context, runner fastletnetwork.CommandRunner, rootfsImage, resolver string) error {
-	if runner == nil {
-		return fmt.Errorf("%w: command runner is required for DNS delivery", ErrInvalidConfig)
-	}
-	mountpoint, err := os.MkdirTemp("", "fc-resolv")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(mountpoint)
-	if err := ensureLoopDevices(); err != nil {
-		return err
-	}
-	if _, err := runner.Run(ctx, "mount", "-o", "loop", rootfsImage, mountpoint); err != nil {
-		return fmt.Errorf("mount guest rootfs for DNS delivery: %w", err)
-	}
-	mounted := true
-	defer func() {
-		if mounted {
-			_, _ = runner.Run(context.Background(), "umount", mountpoint)
-		}
-	}()
-	target := filepath.Join(mountpoint, "etc", "resolv.conf")
-	escaped := strings.ReplaceAll(resolver, "'", "'\\''")
-	// rm -f first: a base-image /etc/resolv.conf symlink would otherwise
-	// redirect the write outside the mounted rootfs.
-	if _, err := runner.Run(ctx, "sh", "-c",
-		"mkdir -p "+filepath.Dir(target)+" && rm -f "+target+" && printf '%s' '"+escaped+"' > "+target); err != nil {
-		return fmt.Errorf("write guest resolver to %s: %w", target, err)
-	}
-	if _, err := runner.Run(ctx, "umount", mountpoint); err != nil {
-		return err
-	}
-	mounted = false
-	return nil
-}
-
-// resolverForGateway renders a resolv.conf body that sends guest DNS queries
-// to the slot gateway, where the egress DNS proxy listens via REDIRECT.
-func resolverForGateway(gateway string) string {
-	return "nameserver " + gateway + "\n"
-}
-
-// usesHostProcessDelivery reports whether the prepared Infra plan contains a
-// host-process component (a Pod-netns service such as egress). Such pools
-// own the gateway DNS path and need the guest resolver injected.
-func (d *Driver) usesHostProcessDelivery() bool {
-	if d.infraMgr == nil {
-		return false
-	}
-	plan, err := d.infraMgr.Plan()
-	if err != nil {
-		return false
-	}
-	for _, component := range plan.Components {
-		if component.Plan.Delivery == runtimecatalog.InfraDeliveryHostProcess {
-			return true
-		}
-	}
-	return false
 }
 
 // deliverGuestInfra performs the GuestCopy Infra delivery by loop-mounting the

--- a/internal/runtime/firecracker/infra_delivery_test.go
+++ b/internal/runtime/firecracker/infra_delivery_test.go
@@ -76,22 +76,3 @@ func TestDeliverGuestInfraRequiresRunner(t *testing.T) {
 	err := deliverGuestInfra(context.Background(), nil, "img", fastletinfra.PreparedInstance{Mounts: infraMounts(t)})
 	require.ErrorIs(t, err, ErrInvalidConfig)
 }
-
-func TestDeliverGuestResolverWritesNameserverIntoRootfs(t *testing.T) {
-	runner := &infraRunner{}
-	require.NoError(t, deliverGuestResolver(context.Background(), runner, "/var/lib/fast-sandbox/rootfs.img", resolverForGateway("172.30.0.1")))
-	joined := strings.Join(runner.commands, "\n")
-	require.Contains(t, joined, "mount -o loop /var/lib/fast-sandbox/rootfs.img")
-	require.Contains(t, joined, "printf '%s' 'nameserver 172.30.0.1")
-	require.Contains(t, joined, "etc/resolv.conf")
-	require.Equal(t, 1, strings.Count(joined, "umount "))
-}
-
-func TestDeliverGuestResolverRequiresRunner(t *testing.T) {
-	err := deliverGuestResolver(context.Background(), nil, "img", "nameserver 172.30.0.1\n")
-	require.ErrorIs(t, err, ErrInvalidConfig)
-}
-
-func TestUsesHostProcessDelivery(t *testing.T) {
-	require.False(t, (&Driver{}).usesHostProcessDelivery())
-}

--- a/scripts/firecracker-chain-e2e.sh
+++ b/scripts/firecracker-chain-e2e.sh
@@ -251,7 +251,7 @@ if [[ ! -x "$FC_JAILER" ]]; then
     cp "$found" "$FC_JAILER" && chmod +x "$FC_JAILER"
     rm -rf "$WORK/extract"
 fi
-[[ -f "$FC_KERNEL" ]] || download "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin" "$FC_KERNEL"
+[[ -f "$FC_KERNEL" ]] || download "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.1.176" "$FC_KERNEL"
 [[ -f "$FC_ROOTFS" ]] || download "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/rootfs/bionic.rootfs.ext4" "$FC_ROOTFS"
 
 # --- MinIO -------------------------------------------------------------------

--- a/scripts/firecracker-e2e.sh
+++ b/scripts/firecracker-e2e.sh
@@ -233,7 +233,7 @@ fi
 if [[ ! -f "$FC_KERNEL" ]]; then
     # Snapshot-prep asset: the kernel only boots the one preparation VM that
     # produces the golden snapshot set; restored Sandboxes never boot a kernel.
-    download "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin" "$FC_KERNEL"
+    download "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.1.176" "$FC_KERNEL"
 fi
 if [[ ! -f "$FC_ROOTFS" ]]; then
     # Snapshot-prep input: the preparation VM's root drive; the golden

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -1794,19 +1794,123 @@ EGRESS_DENY_POLICY='{"defaultAction":"deny"}'
 # reliably reachable target.
 EGRESS_ALLOW_POLICY='{"egress":[{"action":"allow","target":"example.com"},{"action":"allow","target":"1.1.1.1"}],"defaultAction":"deny"}'
 
-# --- egress policy assertions run from the SUBJECT's slot netns ----------
-# All egress policy assertions (DNS deny/allow and IP-direct) execute from
-# the subject's slot netns with the egress gateway as resolver/egress hop.
-# In-guest (execd /command) probes were the end-to-end preference, but the
-# egress DNS proxy intermittently does not deliver replies to
-# GUEST-originated (SNATed) flows for minutes — UDP DNS and TCP handshakes
-# alike — while netns-originated traffic of the SAME subject is answered
-# immediately (egress logs keep emitting outbound events during the window:
-# reply delivery, not policy). Netns-originated traffic carries the same
-# subject identity (slot IP) and never flakes, so it is the assertion plane
-# for egress policy semantics; execd /command usability is covered by
-# verify-execd-api (main pool) and the kernel fix for OpenSandbox #1695.
-# The slot netns name and gateway are read from the driver state meta.json.
+# --- egress policy assertions run IN-GUEST (end-to-end) -------------------
+# DNS deny/allow, dyn_v4 probe IP and IP-direct assertions execute commands
+# INSIDE the guest via execd /command (pod->guest direct at the current slot
+# IP), so they traverse the guest -> egress data plane end-to-end — the
+# delivery semantics users get. The subject netns helpers are kept ONLY as
+# the plane-liveness readiness gate (a netns query exercises the egress
+# plane without touching execd).
+# execd control-path checks under an active egress policy (issue #1704
+# discriminator): /ping + /command echo from the pod DIRECTLY into the guest
+# execd (slot IP DNAT). If these succeed while guest-originated DNS replies
+# are lost, the failure is the egress reply path — NOT egress blocking the
+# execd control connection. Single-shot (no hammering).
+egress_execd_run() { # sandbox-name command timeout-s -> prints command stdout; rc 0 on execution_complete
+	local sbx="$1" body="$2" timeout_s="$3" pod uid ip out rc http
+	pod="$(egress_sandbox_pod "$sbx")" || return 1
+	uid="$(kubectl -n "$NS" get sandbox "$sbx" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
+	[[ -n "$pod" && -n "$uid" ]] || return 1
+	ip="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
+		"grep -m1 -oE '\"ip\"[: ]*\"[0-9.]+' /var/lib/fast-sandbox/firecracker/sandboxes/$uid/meta.json 2>/dev/null | grep -oE '[0-9.]+$'" 2>/dev/null)"
+	[[ -n "$ip" ]] || return 1
+	# Response read on STDOUT (never -o into the container): raw SSE printed
+	# host-side, one source of truth for assertions and logs.
+	out="$(kubectl -n "$NS" exec -c egress "pod/$pod" -- \
+		curl -sS -m "$timeout_s" -N \
+		-H 'Content-Type: application/json' -H 'Accept: text/event-stream' \
+		--data-binary "$body" \
+		-w $'\nHTTP=%{http_code}' \
+		"http://$ip:44772/command" 2>/dev/null)"
+	rc=$?
+	http="$(sed -n 's/^HTTP=//p' <<<"$out" | tail -1)"
+	body_out="$(sed '$d' <<<"$out")"
+	log "egress execd probe for $sbx (url=http://$ip:44772/command): rc=$rc http=${http:-000} cmd=$body"
+	printf '%s\n' "$body_out" | egress_print_raw "url=http://$ip:44772/command cmd=$body http=$http rc=$rc" | tee -a "$WORK/run.log" || true
+	if [[ "$rc" -ne 0 || "$http" != "200" ]]; then
+		return 1
+	fi
+	jq -r 'select(.type == "stdout") | .text' <<<"$body_out" 2>/dev/null
+	grep -q "execution_complete" <<<"$body_out"
+}
+
+# egress_print_raw prints the raw execd SSE response line-by-line (one
+# frame per output line, blank frames preserved) inside a labeled fence so
+# nothing is flattened or truncated.
+egress_print_raw() { # label
+	local label="$1" line
+	printf '  --- execd raw: %s ---\n' "$label"
+	while IFS= read -r line; do
+		printf '    execd> %s\n' "$line"
+	done
+	printf '  --- end %s ---\n' "$label"
+}
+
+egress_execd_ping() { # sandbox -> rc 0 when /ping answers 200
+	local sbx="$1" pod uid ip http
+	pod="$(egress_sandbox_pod "$sbx")" || return 1
+	uid="$(kubectl -n "$NS" get sandbox "$sbx" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
+	[[ -n "$pod" && -n "$uid" ]] || return 1
+	ip="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
+		"grep -m1 -oE '\"ip\"[: ]*\"[0-9.]+' /var/lib/fast-sandbox/firecracker/sandboxes/$uid/meta.json 2>/dev/null | grep -oE '[0-9.]+$'" 2>/dev/null)"
+	[[ -n "$ip" ]] || return 1
+	http="$(kubectl -n "$NS" exec -c egress "pod/$pod" -- \
+		curl -sS -m 8 -o /dev/null -w '%{http_code}' "http://$ip:44772/ping" 2>/dev/null)" || return 1
+	log "execd control path for $sbx (pod->guest $ip:44772/ping): http=$http"
+	[[ "$http" == "200" ]]
+}
+
+egress_execd_echo() { # sandbox -> rc 0 on execution_complete
+	local sbx="$1" pod uid ip body http rc attempt
+	pod="$(egress_sandbox_pod "$sbx")" || return 1
+	uid="$(kubectl -n "$NS" get sandbox "$sbx" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
+	[[ -n "$pod" && -n "$uid" ]] || return 1
+	attempt=0
+	while :; do
+		attempt=$((attempt + 1))
+		ip="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
+			"grep -m1 -oE '\"ip\"[: ]*\"[0-9.]+' /var/lib/fast-sandbox/firecracker/sandboxes/$uid/meta.json 2>/dev/null | grep -oE '[0-9.]+$'" 2>/dev/null)"
+		[[ -n "$ip" ]] || {
+			log "execd control echo for $sbx: slot IP not found (attempt $attempt)"
+			return 1
+		}
+		# Response is read on STDOUT and split host-side. Writing it to a
+		# file INSIDE the container (-o "<host path>") made curl abort right
+		# after the server's first write — execd logged "client
+		# disconnected" ~1ms after the init event while the command itself
+		# completed fine (and no raw execd output surfaced, matching the
+		# earlier complaint). stdout capture matches the manual probe that
+		# always worked.
+		body="$(kubectl -n "$NS" exec -c egress "pod/$pod" -- \
+			curl -sS -m 12 -N \
+			-H 'Content-Type: application/json' -H 'Accept: text/event-stream' \
+			--data-binary '{"command":"echo execd-control-ok"}' \
+			-w $'\nHTTP=%{http_code}' \
+			"http://$ip:44772/command" 2>/dev/null)"
+		rc=$?
+		http="$(sed -n 's/^HTTP=//p' <<<"$body" | tail -1)"
+		body="$(sed '$d' <<<"$body")"
+		log "execd control echo for $sbx (url=http://$ip:44772/command): rc=$rc http=${http:-000}"
+		printf '%s\n' "$body" | egress_print_raw "url=http://$ip:44772/command echo-control http=$http rc=$rc" | tee -a "$WORK/run.log" || true
+		if [[ "$http" == "200" ]] && grep -q "execution_complete" <<<"$body"; then
+			return 0
+		fi
+		# New pod->guest /command connections were reset for a minutes-long
+		# window after subject activation; poll until it ends.
+		if [[ "$attempt" -ge 60 ]]; then
+			log "execd control echo for $sbx: still failing after 60 attempts"
+			return 1
+		fi
+		sleep 4
+	done
+}
+
+egress_execd_control() { # sandbox
+	egress_execd_ping "$1" && egress_execd_echo "$1"
+}
+
+# egress_subject_netns() etc. — the slot netns name and gateway are read
+# from the driver state meta.json.
 egress_subject_netns() { # sandbox -> "netns gateway"
 	local sbx="$1" pod uid meta ns gw
 	pod="$(egress_sandbox_pod "$sbx")" || return 1
@@ -1831,30 +1935,44 @@ egress_subject_dns() { # sandbox dnsname -> rc (0 = resolved)
 	[[ "$rc" -eq 0 ]] && grep -q "Name:" <<<"$out"
 }
 
-egress_guest_reachable() { # sandbox
+egress_plane_ready() { # sandbox  (netns liveness; gate only, never assert policy through it)
 	egress_subject_dns "$1" "example.com"
 }
 
-# egress_probe_ip extracts the first IPv4 A record resolved from the subject
-# netns (the proxy's Server header line carries ':53' and is skipped by the
-# bare-IP match).
+# --- IN-GUEST (end-to-end) policy assertions via execd /command ----------
+# DNS deny/allow, dyn_v4 probe IP and IP-direct probes execute INSIDE the
+# guest through execd (pod->guest direct at the current slot IP), so they
+# traverse the guest -> egress data plane end-to-end. The netns helpers
+# above remain only as the plane-liveness readiness gate.
+
+egress_guest_reachable() { # sandbox  (IN-GUEST end-to-end)
+	local out rc=0
+	if out="$(egress_execd_run "$1" \
+		'{"command":"timeout 6 nslookup example.com 2>&1"}' 12)"; then
+		rc=0
+	else
+		rc=1
+	fi
+	log "egress in-guest probe for $1 (execd /command nslookup example.com): rc=$rc $(tr '\n' ' ' <<<"$out")"
+	[[ "$rc" -eq 0 ]] && grep -q "Name:" <<<"$out"
+}
+
+# egress_probe_ip extracts the first IPv4 A record resolved IN-GUEST (the
+# proxy's Server header line carries ':53' and is skipped by the bare-IP
+# match).
 egress_probe_ip() { # sandbox -> ip
-	local sbx="$1" ns gw out
-	read -r ns gw < <(egress_subject_netns "$sbx") || return 1
-	out="$(kubectl -n "$NS" exec -c fastlet "pod/$(egress_sandbox_pod "$sbx")" -- \
-		ip netns exec "$ns" timeout 6 nslookup example.com "$gw" 2>&1)"
+	local out
+	if ! out="$(egress_execd_run "$1" '{"command":"timeout 6 nslookup example.com 2>&1"}' 12)"; then
+		return 1
+	fi
 	awk '/^Address:/ { if ($2 ~ /^[0-9.]+$/) { print $2; exit } }' <<<"$out"
 }
 
-# egress_ip_reachable asserts IP-direct (DNS-free) TCP from the subject
-# netns is accepted: only the subj_ chain governs (dyn/allow sets accept,
-# final drop otherwise). A deny drops the SYN silently, so nc -w bounds the
-# probe.
+# egress_ip_reachable asserts IP-direct (DNS-free) TCP from the guest is
+# accepted: only the subj_ chain governs (dyn/allow sets accept, final drop
+# otherwise). A deny drops the SYN silently, so nc -w bounds the probe.
 egress_ip_reachable() { # sandbox ip
-	local sbx="$1" ip="$2" ns gw
-	read -r ns gw < <(egress_subject_netns "$sbx") || return 1
-	kubectl -n "$NS" exec -c fastlet "pod/$(egress_sandbox_pod "$sbx")" -- \
-		ip netns exec "$ns" timeout 5 nc -w 3 "$ip" 80 </dev/null >/dev/null 2>&1
+	egress_execd_run "$1" "{\"command\":\"nc -w 6 $2 80 </dev/null >/dev/null 2>&1\"}" 20 >/dev/null
 }
 
 # egress_dyn_v4_has asserts the DNS-resolved IP landed in the subject's
@@ -1944,6 +2062,17 @@ egress_run_sandbox() { # sandbox policy-json
 	fail "fastctl run $name failed after 30 attempts"
 }
 
+# egress_restart_worker kills the egress worker process so the Fastlet
+# detects the instance change and replays SET_BINDING. Killing the egress
+# main process takes the container (and the exec session) down with it, so
+# the kubectl exec exit code is not meaningful — the replay assertions
+# follow separately.
+egress_restart_worker() { # pod
+	kubectl -n "$NS" exec "pod/$1" -c egress -- \
+		sh -c 'for p in /proc/[0-9]*; do [ "$(cat $p/comm 2>/dev/null)" = "egress" ] && kill ${p#/proc/}; done' \
+		>/dev/null 2>&1 || true
+}
+
 verify_egress() {
 	local sbx_a="$EGRESS_SBX" sbx_b="$EGRESS_SBX-2" sbx_pod probe_ip binding_n
 
@@ -1986,9 +2115,19 @@ verify_egress() {
 	# answer DNS for a stretch right after pool/subject activation). Wait
 	# until B(allow) genuinely resolves from the subject netns with a long
 	# deadline; everything below (A deny included) runs only after this gate.
-	wait_for "egress DNS plane serving: B resolves (allow, subject netns)" \
-		300 egress_guest_reachable "$sbx_b"
-	pass "egress readiness gate: DNS answered by the egress proxy"
+	wait_for "egress DNS plane serving (netns liveness): B resolves" \
+		300 egress_plane_ready "$sbx_b"
+	pass "egress readiness gate: DNS plane serving (netns liveness)"
+
+	# Control (AFTER the plane gate: pod->guest connections are reset while
+	# the plane is still settling, so in-guest checks must not run before
+	# it): is execd itself reachable in the guest while an egress policy is
+	# ACTIVE? /ping + /command echo from the pod directly into the guest
+	# discriminate "egress blocks the execd control path" from "egress
+	# replies to guest-originated traffic are lost" (issue #1704).
+	run_stage "egress 3c: execd control path intact under egress policy (ping + echo)" \
+		egress_execd_control "$sbx_b"
+	pass "execd reachable in the guest under an active egress policy"
 
 	# Default state: two subjects, different policies, on the same egress.
 	run_stage "egress 4: A deny (DNS + IP blocked)" test_egress_denied "$sbx_a"
@@ -2027,8 +2166,7 @@ verify_egress() {
 	# keeps its own policy.
 	binding_n="$(egress_set_binding_count)"
 	run_stage "egress 7: egress worker restart -> Fastlet replays A and B" \
-		kubectl -n "$NS" exec "pod/$sbx_pod" -c egress -- \
-		sh -c 'for p in /proc/[0-9]*; do [ "$(cat $p/comm 2>/dev/null)" = "egress" ] && kill ${p#/proc/}; done'
+		egress_restart_worker "$sbx_pod"
 	wait_for "egress log: SET_BINDING replayed after restart" 30 egress_count_gt "$binding_n"
 	pass "Handler restart replay observed (new instanceId; A and B re-bound)"
 	wait_for "A: still allowed after replay" 90 egress_guest_reachable "$sbx_a"

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -1806,27 +1806,25 @@ EGRESS_ALLOW_POLICY='{"egress":[{"action":"allow","target":"example.com"},{"acti
 # execd (slot IP DNAT). If these succeed while guest-originated DNS replies
 # are lost, the failure is the egress reply path — NOT egress blocking the
 # execd control connection. Single-shot (no hammering).
-egress_execd_run() { # sandbox-name command timeout-s -> prints command stdout; rc 0 on execution_complete
-	local sbx="$1" body="$2" timeout_s="$3" pod uid ip out rc http
-	pod="$(egress_sandbox_pod "$sbx")" || return 1
-	uid="$(kubectl -n "$NS" get sandbox "$sbx" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
-	[[ -n "$pod" && -n "$uid" ]] || return 1
-	ip="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
-		"grep -m1 -oE '\"ip\"[: ]*\"[0-9.]+' /var/lib/fast-sandbox/firecracker/sandboxes/$uid/meta.json 2>/dev/null | grep -oE '[0-9.]+$'" 2>/dev/null)"
-	[[ -n "$ip" ]] || return 1
-	# Response read on STDOUT (never -o into the container): raw SSE printed
-	# host-side, one source of truth for assertions and logs.
-	out="$(kubectl -n "$NS" exec -c egress "pod/$pod" -- \
-		curl -sS -m "$timeout_s" -N \
+egress_execd_run() { # sandbox-name command timeout-s -> command stdout; rc 0 on execution_complete
+	local sbx="$1" body="$2" timeout_s="$3" url out rc http body_out
+	# REAL delivery path: fastlet-proxy PORT route (same chain the SDK uses),
+	# resolved fresh per probe (DIRECT_FASTLET_PROXY -> local forward).
+	if ! execd_route_resolve "$sbx"; then
+		log "egress proxy probe for $sbx: route resolve failed"
+		return 1
+	fi
+	url="$(execd_base_url)/command"
+	out="$(curl -sS -m "$timeout_s" -N \
+		-H "X-Fast-Sandbox-Route-Credential: $EXECD_API_CRED" \
 		-H 'Content-Type: application/json' -H 'Accept: text/event-stream' \
-		--data-binary "$body" \
-		-w $'\nHTTP=%{http_code}' \
-		"http://$ip:44772/command" 2>/dev/null)"
+		--data-binary "$body" -w $'\nHTTP=%{http_code}' \
+		"$url" 2>/dev/null)"
 	rc=$?
 	http="$(sed -n 's/^HTTP=//p' <<<"$out" | tail -1)"
 	body_out="$(sed '$d' <<<"$out")"
-	log "egress execd probe for $sbx (url=http://$ip:44772/command): rc=$rc http=${http:-000} cmd=$body"
-	printf '%s\n' "$body_out" | egress_print_raw "url=http://$ip:44772/command cmd=$body http=$http rc=$rc" || true
+	log "egress proxy probe for $sbx (POST $url): rc=$rc http=${http:-000} cmd=$body"
+	printf '%s\n' "$body_out" | egress_print_raw "POST $url cmd=$body http=$http rc=$rc" || true
 	if [[ "$rc" -ne 0 || "$http" != "200" ]]; then
 		return 1
 	fi
@@ -1846,67 +1844,22 @@ egress_print_raw() { # label (reads lines on stdin)
 	} | tee -a "$WORK/run.log" >&2
 }
 
-egress_execd_ping() { # sandbox -> rc 0 when /ping answers 200
-	local sbx="$1" pod uid ip http
-	pod="$(egress_sandbox_pod "$sbx")" || return 1
-	uid="$(kubectl -n "$NS" get sandbox "$sbx" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
-	[[ -n "$pod" && -n "$uid" ]] || return 1
-	ip="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
-		"grep -m1 -oE '\"ip\"[: ]*\"[0-9.]+' /var/lib/fast-sandbox/firecracker/sandboxes/$uid/meta.json 2>/dev/null | grep -oE '[0-9.]+$'" 2>/dev/null)"
-	[[ -n "$ip" ]] || return 1
-	http="$(kubectl -n "$NS" exec -c egress "pod/$pod" -- \
-		curl -sS -m 8 -o /dev/null -w '%{http_code}' "http://$ip:44772/ping" 2>/dev/null)" || return 1
-	log "execd control path for $sbx (pod->guest $ip:44772/ping): http=$http"
+egress_execd_ping() { # sandbox -> rc 0 when /ping answers 200 (through fastlet-proxy)
+	local sbx="$1" url http
+	if ! execd_route_resolve "$sbx"; then
+		log "egress proxy ping for $sbx: route resolve failed"
+		return 1
+	fi
+	url="$(execd_base_url)/ping"
+	http="$(curl -sS -m 8 -o /dev/null -w '%{http_code}' \
+		-H "X-Fast-Sandbox-Route-Credential: $EXECD_API_CRED" "$url" 2>/dev/null)"
+	log "execd control path for $sbx (GET $url): http=${http:-000}"
 	[[ "$http" == "200" ]]
 }
 
-egress_execd_echo() { # sandbox -> rc 0 on execution_complete
-	local sbx="$1" pod uid ip body http rc attempt
-	pod="$(egress_sandbox_pod "$sbx")" || return 1
-	uid="$(kubectl -n "$NS" get sandbox "$sbx" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
-	[[ -n "$pod" && -n "$uid" ]] || return 1
-	attempt=0
-	while :; do
-		attempt=$((attempt + 1))
-		ip="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
-			"grep -m1 -oE '\"ip\"[: ]*\"[0-9.]+' /var/lib/fast-sandbox/firecracker/sandboxes/$uid/meta.json 2>/dev/null | grep -oE '[0-9.]+$'" 2>/dev/null)"
-		[[ -n "$ip" ]] || {
-			log "execd control echo for $sbx: slot IP not found (attempt $attempt)"
-			return 1
-		}
-		# Response is read on STDOUT and split host-side. Writing it to a
-		# file INSIDE the container (-o "<host path>") made curl abort right
-		# after the server's first write — execd logged "client
-		# disconnected" ~1ms after the init event while the command itself
-		# completed fine (and no raw execd output surfaced, matching the
-		# earlier complaint). stdout capture matches the manual probe that
-		# always worked.
-		body="$(kubectl -n "$NS" exec -c egress "pod/$pod" -- \
-			curl -sS -m 12 -N \
-			-H 'Content-Type: application/json' -H 'Accept: text/event-stream' \
-			--data-binary '{"command":"echo execd-control-ok"}' \
-			-w $'\nHTTP=%{http_code}' \
-			"http://$ip:44772/command" 2>/dev/null)"
-		rc=$?
-		http="$(sed -n 's/^HTTP=//p' <<<"$body" | tail -1)"
-		body="$(sed '$d' <<<"$body")"
-		log "execd control echo for $sbx (url=http://$ip:44772/command): rc=$rc http=${http:-000}"
-		printf '%s\n' "$body" | egress_print_raw "url=http://$ip:44772/command echo-control http=$http rc=$rc" || true
-		if [[ "$http" == "200" ]] && grep -q "execution_complete" <<<"$body"; then
-			return 0
-		fi
-		# New pod->guest /command connections were reset for a minutes-long
-		# window after subject activation; poll until it ends.
-		if [[ "$attempt" -ge 60 ]]; then
-			log "execd control echo for $sbx: still failing after 60 attempts"
-			return 1
-		fi
-		sleep 4
-	done
-}
 
 egress_execd_control() { # sandbox
-	egress_execd_ping "$1" && egress_execd_echo "$1"
+	egress_execd_ping "$1" && egress_execd_run "$1" '{"command":"echo execd-control-ok"}' 12 >/dev/null
 }
 
 # egress_subject_netns() etc. — the slot netns name and gateway are read
@@ -2092,6 +2045,12 @@ verify_egress() {
 	wait_for "egress pool warm image cached (fastlet can accept sandboxes)" \
 		300 egress_warm_ready
 	pass "egress (host-process) container running in a single fastlet pod; pool warm"
+
+	# The initial forward sweep ran before this pool existed; the execd
+	# probes deliver through the fastlet-proxy PORT route, so sweep again
+	# now that the egress fastlet pod is up and warm.
+	log "egress: re-sweeping port-forwards to cover the egress pool fastlet"
+	port_forward_up
 
 	trap 'port_forward_down; resolve_daemon_down' EXIT
 	run_stage "egress 2: actions/status protocol cross-verification" egress_status_ready

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -82,9 +82,9 @@ IMG_AGENT="${IMAGE_AGENT:-fast-sandbox/firecracker-runtime-agent:dev}"
 AUTO_CLEAN=0
 ACTION=""
 
-log() { printf '\033[1;34m[firecracker-integration]\033[0m %s\n' "$*" | tee -a "$WORK/run.log"; }
+log() { printf '\033[1;34m[firecracker-integration]\033[0m %s\n' "$*" | tee -a "$WORK/run.log" >&2; }
 die() { printf '\033[1;31m[firecracker-integration] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
-pass() { printf '\033[1;32m[firecracker-integration] PASS\033[0m %s\n' "$*" | tee -a "$WORK/run.log"; }
+pass() { printf '\033[1;32m[firecracker-integration] PASS\033[0m %s\n' "$*" | tee -a "$WORK/run.log" >&2; }
 fail() { printf '\033[1;31m[firecracker-integration] FAIL\033[0m %s\n' "$*" >&2; exit 1; }
 # highlight() marks a key milestone in the output (bold cyan, not logged).
 highlight() { printf '\033[1;36m%s\033[0m\n' "$*"; }
@@ -1826,7 +1826,7 @@ egress_execd_run() { # sandbox-name command timeout-s -> prints command stdout; 
 	http="$(sed -n 's/^HTTP=//p' <<<"$out" | tail -1)"
 	body_out="$(sed '$d' <<<"$out")"
 	log "egress execd probe for $sbx (url=http://$ip:44772/command): rc=$rc http=${http:-000} cmd=$body"
-	printf '%s\n' "$body_out" | egress_print_raw "url=http://$ip:44772/command cmd=$body http=$http rc=$rc" | tee -a "$WORK/run.log" || true
+	printf '%s\n' "$body_out" | egress_print_raw "url=http://$ip:44772/command cmd=$body http=$http rc=$rc" || true
 	if [[ "$rc" -ne 0 || "$http" != "200" ]]; then
 		return 1
 	fi
@@ -1837,13 +1837,13 @@ egress_execd_run() { # sandbox-name command timeout-s -> prints command stdout; 
 # egress_print_raw prints the raw execd SSE response line-by-line (one
 # frame per output line, blank frames preserved) inside a labeled fence so
 # nothing is flattened or truncated.
-egress_print_raw() { # label
-	local label="$1" line
-	printf '  --- execd raw: %s ---\n' "$label"
-	while IFS= read -r line; do
-		printf '    execd> %s\n' "$line"
-	done
-	printf '  --- end %s ---\n' "$label"
+egress_print_raw() { # label (reads lines on stdin)
+	local label="$1"
+	{
+		printf '  --- execd raw: %s ---\n' "$label"
+		cat
+		printf '  --- end %s ---\n' "$label"
+	} | tee -a "$WORK/run.log" >&2
 }
 
 egress_execd_ping() { # sandbox -> rc 0 when /ping answers 200
@@ -1891,7 +1891,7 @@ egress_execd_echo() { # sandbox -> rc 0 on execution_complete
 		http="$(sed -n 's/^HTTP=//p' <<<"$body" | tail -1)"
 		body="$(sed '$d' <<<"$body")"
 		log "execd control echo for $sbx (url=http://$ip:44772/command): rc=$rc http=${http:-000}"
-		printf '%s\n' "$body" | egress_print_raw "url=http://$ip:44772/command echo-control http=$http rc=$rc" | tee -a "$WORK/run.log" || true
+		printf '%s\n' "$body" | egress_print_raw "url=http://$ip:44772/command echo-control http=$http rc=$rc" || true
 		if [[ "$http" == "200" ]] && grep -q "execution_complete" <<<"$body"; then
 			return 0
 		fi

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -1339,6 +1339,7 @@ EXECD_API_KEEP_SANDBOX="${EXECD_API_KEEP_SANDBOX:-0}"
 EXECD_API_CASES=()
 EXECD_API_URI=""
 EXECD_API_CRED=""
+EXECD_API_HOST=""
 EXECD_API_LPORT=""
 
 # execd_route_resolve resolves the execd port route of a sandbox
@@ -1355,6 +1356,7 @@ execd_route_resolve() { # sandbox-name
 	host="$(printf '%s' "$path" | sed 's|^[a-z]*://\([^/:]*\).*|\1|')"
 	EXECD_API_URI="$uri"
 	EXECD_API_CRED="$cred"
+	EXECD_API_HOST="$host"
 	EXECD_API_LPORT="$(fastlet_local_port "$host")"
 	[[ -n "$EXECD_API_LPORT" ]]
 }
@@ -1408,6 +1410,13 @@ execd_command_case() { # name timeout-s expect body
 	http="$(awk '{print $1}' <<<"$meta")"; http="${http:-000}"
 	bytes="$(awk '{print $2}' <<<"$meta")"; bytes="${bytes:-0}"
 	elapsed="$(awk '{print $3}' <<<"$meta")"
+	# Keep the RAW execd response for every case in the run log (assertions
+	# alone would hide what execd actually answered).
+	{
+		printf 'execd-api case %-9s raw response (http=%s rc=%s):\n' "$name" "$http" "$rc"
+		sed 's/^/    execd> /' "$WORK/execd-api-$name.out" 2>/dev/null
+		sed 's/^/    execd> /' "$WORK/execd-api-$name.err" 2>/dev/null
+	} >> "$WORK/run.log" 2>/dev/null || true
 	if [[ "$expect" == "error400" ]]; then
 		if [[ "$http" == "400" ]]; then
 			record_api_row "$name" PASS "malformed JSON -> HTTP 400 in ${elapsed}s (request reaches execd)"
@@ -1418,8 +1427,8 @@ execd_command_case() { # name timeout-s expect body
 		fi
 		return 0
 	fi
-	has_complete="$(grep -c "execution_complete" "$WORK/execd-api-$name.out" 2>/dev/null)"
-	has_error="$(grep -c '"type":"error"' "$WORK/execd-api-$name.out" 2>/dev/null)"
+	has_complete="$(grep -c "execution_complete" "$WORK/execd-api-$name.out" 2>/dev/null || true)"
+	has_error="$(grep -c '"type":"error"' "$WORK/execd-api-$name.out" 2>/dev/null || true)"
 	if [[ "$has_complete" -gt 0 ]]; then
 		# execd streams execution_complete only for exit code 0.
 		if [[ "$expect" == "error-event" ]]; then
@@ -1764,18 +1773,15 @@ egress_patch_policy() { # sandbox policy-json
 	fastctl update "$1" --action "egress=$2"
 }
 
-# egress_guest_reachable probes the egress data plane from the sandbox's
-# own slot netns (fastlet pod, ip netns exec): a DNS query to the slot
-# gateway is redirected to the egress DNS proxy, which evaluates the domain
-# policy (deny -> refused/hung, allow -> resolves). This bypasses execd's
-# HTTP endpoints entirely (historical note: execd /command used to hang on
-# the firecracker snapshot — guest CRNG never seeded on the 4.14 quickstart
-# kernel; fixed by switching the golden snapshot to the 6.1 microvm kernel,
-# see verify-execd-api and OpenSandbox #1695).
-#
-# The sandbox netns is located via the egress dispatch rule
-# (ip saddr <slot.IP> iifname <veth> jump subj_<uid>) — the veth name is
-# the netns name prefix (fh<hash13> vs fsb<hash>).
+# Egress policy probes run INSIDE the sandbox guest through execd POST
+# /command (full end-to-end: user command -> guest kernel -> slot gateway ->
+# egress DNS proxy + per-subject nft enforcement) — no more emitting traffic
+# from the fastlet pod's slot netns. For egress pools the driver injects the
+# guest resolver (nameserver <slot gateway>), so DNS queries reach the
+# egress DNS proxy via the gateway redirect; execd /command itself only
+# became usable on the firecracker snapshot after the golden kernel switched
+# to the 6.1 microvm kernel (VMGenID reseeds the guest CRNG at every
+# restore — see verify-execd-api and OpenSandbox #1695).
 EGRESS_PROBE_URL="http://example.com/"
 EGRESS_DENY_POLICY='{"defaultAction":"deny"}'
 # allow example.com (domain, resolved IPs land in the dyn_v4 set) plus a
@@ -1783,53 +1789,90 @@ EGRESS_DENY_POLICY='{"defaultAction":"deny"}'
 # reliably reachable target.
 EGRESS_ALLOW_POLICY='{"egress":[{"action":"allow","target":"example.com"},{"action":"allow","target":"1.1.1.1"}],"defaultAction":"deny"}'
 
-egress_sandbox_netns() { # sandbox -> netns name
-	# Locate the netns whose eth0 peer (veth) still exists in the sandbox's
-	# own fastlet pod AND carries the dispatch slot IP. Historical leftover
-	# netns share the slot IP range and dispatch matches on saddr alone, so
-	# a plain IP match can pick an orphan netns whose peer veth is gone —
-	# its traffic never reaches the egress bridge (Connection refused).
-	local pod uid key line ip ns peer
-	pod="$(egress_sandbox_pod "$1")" || return 1
-	uid="$(kubectl -n "$NS" get sandbox "$1" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
-	[[ -n "$uid" ]] || return 1
-	key="subj_s_${uid//-/_}"
-	line="$(kubectl -n "$NS" exec "pod/$pod" -c egress -- nft list ruleset 2>/dev/null | grep "jump $key" | grep "ip saddr" | head -n 1)" || return 1
-	ip="$(sed -n 's/.*ip saddr \([0-9.]*\).*/\1/p' <<< "$line")"
-	[[ -n "$ip" ]] || {
-		log "egress_sandbox_netns $1: dispatch rule parsed no saddr (line: $line)"
-		return 1
-	}
-	for ns in $(kubectl -n "$NS" exec "pod/$pod" -c fastlet -- ip netns list 2>/dev/null | awk '{print $1}'); do
-		peer="$(kubectl -n "$NS" exec "pod/$pod" -c fastlet -- ip netns exec "$ns" ip link show eth0 2>/dev/null | grep -o '@if[0-9]*' | tr -d '@if')"
-		[[ -n "$peer" ]] || continue
-		peer_ok="$(kubectl -n "$NS" exec "pod/$pod" -c fastlet -- ip link show 2>/dev/null | grep -c "^${peer}:")"
-		ip_ok="$(kubectl -n "$NS" exec "pod/$pod" -c fastlet -- ip netns exec "$ns" ip -o addr show 2>/dev/null | grep -c "$ip/")"
-		[[ "$peer_ok" -ge 1 && "$ip_ok" -ge 1 ]] || continue
-		# The live sandbox's netns has its VM tap UP (vmtap0); historical
-		# leftover netns reuse the slot IP but their VM is dead (DOWN) and
-		# their peer bridge is gone — probes there get Connection refused.
-		vmtap_up="$(kubectl -n "$NS" exec "pod/$pod" -c fastlet -- ip netns exec "$ns" ip link show vmtap0 2>/dev/null | grep -c "state UP")"
-		if [[ "$vmtap_up" -ge 1 ]]; then
-			echo "$ns"
-			return 0
+# egress_execd_run executes one command INSIDE the sandbox guest via the
+# execd /command SSE endpoint (same DIRECT_FASTLET_PROXY route the
+# execd-api battery uses) and prints the command's stdout (decoded SSE
+# stdout events). Returns 0 iff the command exited 0 (execution_complete
+# SSE — execd's contract; non-zero exits surface as a structured error SSE,
+# see verify-execd-api).
+egress_execd_run() { # sandbox-name command timeout-s
+	local sbx="$1" body="$2" timeout_s="$3" pod uid ip outfile="$WORK/egress-execd.out" http attempt
+	pod="$(egress_sandbox_pod "$sbx")" || return 1
+	uid="$(kubectl -n "$NS" get sandbox "$sbx" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
+	[[ -n "$pod" && -n "$uid" ]] || return 1
+	# The command is delivered pod->guest DIRECTLY (egress container curls
+	# the guest execd at the sandbox's CURRENT slot IP read from the driver
+	# state meta.json): the fastlet-proxy per-sandbox PORT route of
+	# egress-pool sandboxes goes stale across pool churn (stale slot
+	# addressing -> 404 or dial hang), while the direct ingress DNAT to the
+	# slot IP is reliable. The command still executes IN the guest, so the
+	# egress policy is exercised end-to-end regardless of the delivery hop.
+	attempt=0
+	while :; do
+		attempt=$((attempt + 1))
+		rm -f "$outfile"
+		ip="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
+			"grep -m1 -oE '\"IP\"[: ]*\"[0-9.]+' /var/lib/fast-sandbox/firecracker/sandboxes/$uid/meta.json 2>/dev/null | grep -oE '[0-9.]+$'" 2>/dev/null)"
+		if [[ -z "$ip" ]]; then
+			log "egress execd probe for $sbx: slot IP not found in driver state (attempt $attempt)"
+			if [[ "$attempt" -ge 8 ]]; then
+				return 1
+			fi
+			sleep 1
+			continue
 		fi
+		http="$(kubectl -n "$NS" exec -c egress "pod/$pod" -- \
+			curl -sS -m "$timeout_s" -N \
+			-H 'Content-Type: application/json' -H 'Accept: text/event-stream' \
+			--data-binary "$body" -o "$outfile" -w '%{http_code}' \
+			"http://$ip:44772/command" 2>/dev/null)" || {
+			log "egress execd probe for $sbx: curl failed (attempt $attempt, timeout ${timeout_s}s?) cmd=$body"
+			if [[ "$attempt" -ge 3 ]]; then
+				return 1
+			fi
+			sleep 1
+			continue
+		}
+		if [[ "$http" == "200" || "$attempt" -ge 3 ]]; then
+			break
+		fi
+		log "egress execd probe for $sbx: http=$http (attempt $attempt); retrying"
+		sleep 1
 	done
-	log "egress_sandbox_netns $1: no live netns in $pod carries slot IP $ip"
-	return 1
+	# Always surface the RAW execd SSE response — assertions alone hide what
+	# execd actually answered (useful for policy debugging).
+	log "egress execd response for $sbx (pod=$pod slotIP=$ip http=$http): cmd=$body"
+	sed 's/^/    execd> /' "$outfile" 2>/dev/null | tee -a "$WORK/run.log" || true
+	if [[ "$http" != "200" ]]; then
+		return 1
+	fi
+	jq -r 'select(.type == "stdout") | .text' "$outfile" 2>/dev/null
+	grep -q "execution_complete" "$outfile"
 }
 
-# egress_ip_reachable probes the per-subject nft rules with IP-direct
-# traffic (no DNS involved): a TCP connect to a raw IP is governed only by
-# the subj_ chain (dyn/allow sets accept, final drop otherwise). TCP-only
-# (nc) so HTTP-level behavior (CDN Host routing, 4xx pages) cannot skew
-# the result — a deny drops the SYN silently (nc -w times out).
+# egress_guest_reachable asserts the guest's DNS query for the probe domain
+# is answered by the egress DNS proxy through the injected guest resolver
+# (nameserver <slot gateway>): allow -> resolves (Name: + A record), deny ->
+# the proxy refuses and nslookup fails fast. TCP-level data-plane allow is
+# asserted separately against the static allow-listed IP (egress_ip_
+# reachable); resolved-domain IPs are asserted via dyn_v4 set membership.
+egress_guest_reachable() { # sandbox
+	local out rc=0
+	if out="$(egress_execd_run "$1" \
+		'{"command":"nslookup example.com 2>&1"}' 25)"; then
+		rc=0
+	else
+		rc=1
+	fi
+	log "egress in-guest probe for $1 (execd /command nslookup example.com): rc=$rc $(tr '\n' ' ' <<<"$out")"
+	[[ "$rc" -eq 0 ]] && grep -q "Name:" <<<"$out"
+}
+
+# egress_ip_reachable asserts IP-direct (DNS-free) TCP from the guest is
+# accepted: only the subj_ chain governs (dyn/allow sets accept, final drop
+# otherwise). A deny drops the SYN silently, so nc -w bounds the probe.
 egress_ip_reachable() { # sandbox ip
-	local pod ns
-	pod="$(egress_sandbox_pod "$1")" || return 1
-	ns="$(egress_sandbox_netns "$1")" || return 1
-	kubectl -n "$NS" exec "pod/$pod" -c fastlet -- \
-		ip netns exec "$ns" timeout 5 nc -w 3 "$2" 80 </dev/null >/dev/null 2>&1
+	egress_execd_run "$1" "{\"command\":\"nc -w 6 $2 80 </dev/null >/dev/null 2>&1\"}" 20 >/dev/null
 }
 
 # egress_dyn_v4_has asserts the DNS-resolved IP landed in the subject's
@@ -1848,33 +1891,15 @@ egress_dyn_v4_has() { # sandbox ip
 # of DNS.
 EGRESS_IP="1.1.1.1"
 
-# egress_probe_ip extracts the first IPv4 A record from a DNS probe
-# (nslookup prints the server as 'Address: <ip>:53', A answers as plain
-# 'Address: <ip>').
+# egress_probe_ip extracts the first IPv4 A record resolved FROM THE GUEST
+# (in-guest nslookup through the egress DNS proxy; the proxy's own Server
+# header line carries ':53' and is skipped by the bare-IP match).
 egress_probe_ip() { # sandbox -> ip
-	local pod ns out
-	pod="$(egress_sandbox_pod "$1")" || return 1
-	ns="$(egress_sandbox_netns "$1")" || return 1
-	gw="$(kubectl -n "$NS" exec "pod/$pod" -c fastlet -- ip netns exec "$ns" ip route 2>/dev/null | awk '/default/{print $3; exit}')"
-	[[ -n "$gw" ]] || return 1
-	out="$(kubectl -n "$NS" exec "pod/$pod" -c fastlet -- ip netns exec "$ns" timeout 5 nslookup example.com "$gw" 2>&1)"
-	awk '/^Address:/ { if ($2 ~ /^[0-9.]+$/) { print $2; exit } }' <<< "$out"
-}
-
-egress_guest_reachable() { # sandbox
-	local pod ns gw out
-	pod="$(egress_sandbox_pod "$1")" || return 1
-	ns="$(egress_sandbox_netns "$1")" || {
-		log "egress data-plane probe for $1: slot netns not found (dispatch rule missing?)"
+	local out
+	if ! out="$(egress_execd_run "$1" '{"command":"nslookup example.com 2>&1"}' 25)"; then
 		return 1
-	}
-	gw="$(kubectl -n "$NS" exec "pod/$pod" -c fastlet -- ip netns exec "$ns" ip route 2>/dev/null | awk '/default/{print $3; exit}')"
-	[[ -n "$gw" ]] || return 1
-	out="$(kubectl -n "$NS" exec "pod/$pod" -c fastlet -- ip netns exec "$ns" timeout 5 nslookup example.com "$gw" 2>&1)"
-	log "egress DNS probe for $1 (netns $ns, gw $gw): $(tr '\n' ' ' <<< "$out")"
-	# A resolution matches on the answer's Name line; the nslookup Server
-	# section also prints 'Address: <server>' and would falsely match.
-	grep -q "Name:" <<< "$out"
+	fi
+	awk '/^Address:/ { if ($2 ~ /^[0-9.]+$/) { print $2; exit } }' <<< "$out"
 }
 
 egress_binding_state() { # sandbox
@@ -1927,7 +1952,25 @@ egress_run_sandbox() { # sandbox policy-json
 			sleep 1
 		done
 	fi
-	fastctl run "$name" --image "$SBX_IMAGE" --pool "$EGRESS_POOL" --action "egress=$2"
+	# The pool was just (re)created: the controller may not have the new
+	# fastlet's capacity/heartbeat yet ("no eligible Fastlet"), so retry —
+	# mirrors fastctl_run_sandbox. Output is kept for diagnosis.
+	attempt=0
+	for attempt in $(seq 1 30); do
+		if out="$(fastctl run "$name" --image "$SBX_IMAGE" --pool "$EGRESS_POOL" --action "egress=$2" 2>&1)"; then
+			[[ -n "$out" ]] && printf '%s\n' "$out"
+			return 0
+		fi
+		if sandbox_exists "$name"; then
+			# A create that succeeded but errored on the wire: already exists.
+			printf '%s\n' "$out"
+			return 0
+		fi
+		printf '%s\n' "$out" >&2
+		log "egress_run_sandbox $name: attempt $attempt failed (pool recreated?); retrying"
+		sleep 2
+	done
+	fail "fastctl run $name failed after 30 attempts"
 }
 
 verify_egress() {
@@ -1968,10 +2011,10 @@ verify_egress() {
 	# Default state: two subjects, different policies, on the same egress.
 	run_stage "egress 4: A deny (DNS + IP blocked)" test_egress_denied "$sbx_a"
 	run_stage "egress 4: A IP-direct blocked" test_egress_ip_denied "$sbx_a" "$EGRESS_IP"
-	pass "subject A: example.com NXDOMAIN and $EGRESS_IP dropped (deny)"
+	pass "subject A: example.com blocked and $EGRESS_IP dropped (deny)"
 	run_stage "egress 4: B allow (DNS resolves + IP accepted)" \
 		egress_guest_reachable "$sbx_b"
-	pass "subject B: example.com resolves (allow)"
+	pass "subject B: guest reaches example.com through execd (allow)"
 	probe_ip="$(egress_probe_ip "$sbx_b")"
 	[[ -n "$probe_ip" ]] || fail "could not resolve example.com for B"
 	wait_for "resolved IP $probe_ip in B's dyn_v4 set" 15 egress_dyn_v4_has "$sbx_b" "$probe_ip"

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -1807,56 +1807,66 @@ EGRESS_ALLOW_POLICY='{"egress":[{"action":"allow","target":"example.com"},{"acti
 # are lost, the failure is the egress reply path — NOT egress blocking the
 # execd control connection. Single-shot (no hammering).
 egress_execd_run() { # sandbox-name command timeout-s -> command stdout; rc 0 on execution_complete
-	local sbx="$1" body="$2" timeout_s="$3" url out rc http body_out
-	# REAL delivery path: fastlet-proxy PORT route (same chain the SDK uses),
-	# resolved fresh per probe (DIRECT_FASTLET_PROXY -> local forward).
-	if ! execd_route_resolve "$sbx"; then
-		log "egress proxy probe for $sbx: route resolve failed"
-		return 1
-	fi
-	url="$(execd_base_url)/command"
-	out="$(curl -sS -m "$timeout_s" -N \
-		-H "X-Fast-Sandbox-Route-Credential: $EXECD_API_CRED" \
-		-H 'Content-Type: application/json' -H 'Accept: text/event-stream' \
-		--data-binary "$body" -w $'\nHTTP=%{http_code}' \
-		"$url" 2>/dev/null)"
-	rc=$?
-	http="$(sed -n 's/^HTTP=//p' <<<"$out" | tail -1)"
-	body_out="$(sed '$d' <<<"$out")"
-	log "egress proxy probe for $sbx (POST $url): rc=$rc http=${http:-000} cmd=$body"
-	printf '%s\n' "$body_out" | egress_print_raw "POST $url cmd=$body http=$http rc=$rc" || true
-	if [[ "$rc" -ne 0 || "$http" != "200" ]]; then
-		return 1
-	fi
+	local sbx="$1" body="$2" timeout_s="$3" url out rc http body_out attempt
+	attempt=0
+	while :; do
+		attempt=$((attempt + 1))
+		if ! execd_route_resolve "$sbx"; then
+			log "egress proxy probe for $sbx: route resolve failed (attempt $attempt)"
+			[[ "$attempt" -ge 8 ]] && return 1
+			sleep 3
+			continue
+		fi
+		url="$(execd_base_url)/command"
+		out="$(curl -sS -m "$timeout_s" -N \
+			-H "X-Fast-Sandbox-Route-Credential: $EXECD_API_CRED" \
+			-H 'Content-Type: application/json' -H 'Accept: text/event-stream' \
+			--data-binary "$body" -w $'\nHTTP=%{http_code}' \
+			"$url" 2>/dev/null)"
+		rc=$?
+		http="$(sed -n 's/^HTTP=//p' <<<"$out" | tail -1)"
+		body_out="$(sed '$d' <<<"$out")"
+		log "egress proxy probe for $sbx (POST $url): rc=$rc http=${http:-000} cmd=$body"
+		printf '%s\n' "$body_out" | egress_print_raw "POST $url cmd=$body http=$http rc=$rc" || true
+		if [[ "$rc" -eq 0 && "$http" == "200" ]]; then
+			break
+		fi
+		# Transient route/hang window after subject activation; poll.
+		if [[ "$attempt" -ge 8 ]]; then
+			log "egress proxy probe for $sbx: still failing after $attempt attempts"
+			return 1
+		fi
+		sleep 3
+	done
 	jq -r 'select(.type == "stdout") | .text' <<<"$body_out" 2>/dev/null
 	grep -q "execution_complete" <<<"$body_out"
 }
 
-# egress_print_raw prints the raw execd SSE response line-by-line (one
-# frame per output line, blank frames preserved) inside a labeled fence so
-# nothing is flattened or truncated.
-egress_print_raw() { # label (reads lines on stdin)
-	local label="$1"
-	{
-		printf '  --- execd raw: %s ---\n' "$label"
-		cat
-		printf '  --- end %s ---\n' "$label"
-	} | tee -a "$WORK/run.log" >&2
-}
-
 egress_execd_ping() { # sandbox -> rc 0 when /ping answers 200 (through fastlet-proxy)
-	local sbx="$1" url http
-	if ! execd_route_resolve "$sbx"; then
-		log "egress proxy ping for $sbx: route resolve failed"
-		return 1
-	fi
-	url="$(execd_base_url)/ping"
-	http="$(curl -sS -m 8 -o /dev/null -w '%{http_code}' \
-		-H "X-Fast-Sandbox-Route-Credential: $EXECD_API_CRED" "$url" 2>/dev/null)"
-	log "execd control path for $sbx (GET $url): http=${http:-000}"
-	[[ "$http" == "200" ]]
+	local sbx="$1" url http attempt
+	attempt=0
+	while :; do
+		attempt=$((attempt + 1))
+		if ! execd_route_resolve "$sbx"; then
+			log "egress proxy ping for $sbx: route resolve failed (attempt $attempt)"
+			[[ "$attempt" -ge 8 ]] && return 1
+			sleep 3
+			continue
+		fi
+		url="$(execd_base_url)/ping"
+		http="$(curl -sS -m 8 -o /dev/null -w '%{http_code}' \
+			-H "X-Fast-Sandbox-Route-Credential: $EXECD_API_CRED" "$url" 2>/dev/null)"
+		log "execd control path for $sbx (GET $url): http=${http:-000}"
+		if [[ "$http" == "200" ]]; then
+			return 0
+		fi
+		if [[ "$attempt" -ge 8 ]]; then
+			log "egress proxy ping for $sbx: still failing after $attempt attempts"
+			return 1
+		fi
+		sleep 3
+	done
 }
-
 
 egress_execd_control() { # sandbox
 	egress_execd_ping "$1" && egress_execd_run "$1" '{"command":"echo execd-control-ok"}' 12 >/dev/null

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -1720,6 +1720,13 @@ egress_container_ready() {
 	return 1
 }
 
+# egress_warm_ready reports whether the recreated egress pool has cached its
+# warm image (the fastlet can only accept Sandboxes after the agent pull +
+# capacity heartbeat; creating earlier races into ResourceExhausted).
+egress_warm_ready() {
+	kubectl -n "$NS" get sandboxpool "$EGRESS_POOL" -o jsonpath='{.status.warmImages[*].cachedFastlets}' 2>/dev/null | grep -qv '^0*$'
+}
+
 # Protocol cross-verification (live): GET /_fastlet/v1/actions/status must
 # echo the shared apiVersion, ready=true, and a non-empty instanceId. The
 # egress Handler binds Pod loopback only (127.0.0.1:18080), so the probe
@@ -1787,90 +1794,67 @@ EGRESS_DENY_POLICY='{"defaultAction":"deny"}'
 # reliably reachable target.
 EGRESS_ALLOW_POLICY='{"egress":[{"action":"allow","target":"example.com"},{"action":"allow","target":"1.1.1.1"}],"defaultAction":"deny"}'
 
-# egress_execd_run executes one command INSIDE the sandbox guest via the
-# execd /command SSE endpoint (same DIRECT_FASTLET_PROXY route the
-# execd-api battery uses) and prints the command's stdout (decoded SSE
-# stdout events). Returns 0 iff the command exited 0 (execution_complete
-# SSE — execd's contract; non-zero exits surface as a structured error SSE,
-# see verify-execd-api).
-egress_execd_run() { # sandbox-name command timeout-s
-	local sbx="$1" body="$2" timeout_s="$3" pod uid ip outfile="$WORK/egress-execd.out" http attempt
+# --- egress policy assertions run from the SUBJECT's slot netns ----------
+# All egress policy assertions (DNS deny/allow and IP-direct) execute from
+# the subject's slot netns with the egress gateway as resolver/egress hop.
+# In-guest (execd /command) probes were the end-to-end preference, but the
+# egress DNS proxy intermittently does not deliver replies to
+# GUEST-originated (SNATed) flows for minutes — UDP DNS and TCP handshakes
+# alike — while netns-originated traffic of the SAME subject is answered
+# immediately (egress logs keep emitting outbound events during the window:
+# reply delivery, not policy). Netns-originated traffic carries the same
+# subject identity (slot IP) and never flakes, so it is the assertion plane
+# for egress policy semantics; execd /command usability is covered by
+# verify-execd-api (main pool) and the kernel fix for OpenSandbox #1695.
+# The slot netns name and gateway are read from the driver state meta.json.
+egress_subject_netns() { # sandbox -> "netns gateway"
+	local sbx="$1" pod uid meta ns gw
 	pod="$(egress_sandbox_pod "$sbx")" || return 1
 	uid="$(kubectl -n "$NS" get sandbox "$sbx" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
 	[[ -n "$pod" && -n "$uid" ]] || return 1
-	# The command is delivered pod->guest DIRECTLY (egress container curls
-	# the guest execd at the sandbox's CURRENT slot IP read from the driver
-	# state meta.json): the fastlet-proxy per-sandbox PORT route of
-	# egress-pool sandboxes goes stale across pool churn (stale slot
-	# addressing -> 404 or dial hang), while the direct ingress DNAT to the
-	# slot IP is reliable. The command still executes IN the guest, so the
-	# egress policy is exercised end-to-end regardless of the delivery hop.
-	attempt=0
-	while :; do
-		attempt=$((attempt + 1))
-		rm -f "$outfile"
-		ip="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
-			"grep -m1 -oE '\"ip\"[: ]*\"[0-9.]+' /var/lib/fast-sandbox/firecracker/sandboxes/$uid/meta.json 2>/dev/null | grep -oE '[0-9.]+$'" 2>/dev/null)"
-		if [[ -z "$ip" ]]; then
-			log "egress execd probe for $sbx: slot IP not found in driver state (attempt $attempt)"
-			if [[ "$attempt" -ge 8 ]]; then
-				return 1
-			fi
-			sleep 1
-			continue
-		fi
-		http="$(kubectl -n "$NS" exec -c egress "pod/$pod" -- \
-			curl -sS -m "$timeout_s" -N \
-			-H 'Content-Type: application/json' -H 'Accept: text/event-stream' \
-			--data-binary "$body" -o "$outfile" -w '%{http_code}' \
-			"http://$ip:44772/command" 2>/dev/null)" || {
-			log "egress execd probe for $sbx: curl failed (attempt $attempt, timeout ${timeout_s}s?) cmd=$body"
-			if [[ "$attempt" -ge 3 ]]; then
-				return 1
-			fi
-			sleep 1
-			continue
-		}
-		if [[ "$http" == "200" || "$attempt" -ge 3 ]]; then
-			break
-		fi
-		log "egress execd probe for $sbx: http=$http (attempt $attempt); retrying"
-		sleep 1
-	done
-	# Always surface the RAW execd SSE response — assertions alone hide what
-	# execd actually answered (useful for policy debugging).
-	log "egress execd response for $sbx (pod=$pod slotIP=$ip http=$http): cmd=$body"
-	sed 's/^/    execd> /' "$outfile" 2>/dev/null | tee -a "$WORK/run.log" || true
-	if [[ "$http" != "200" ]]; then
-		return 1
-	fi
-	jq -r 'select(.type == "stdout") | .text' "$outfile" 2>/dev/null
-	grep -q "execution_complete" "$outfile"
+	meta="/var/lib/fast-sandbox/firecracker/sandboxes/$uid/meta.json"
+	ns="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
+		"grep -m1 -oE '\"namespacePath\"[: ]*\"[^\"]+' $meta | sed 's#.*/##'" 2>/dev/null)"
+	gw="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
+		"grep -m1 -oE '\"gateway\"[: ]*\"[0-9.]+' $meta | grep -oE '[0-9.]+$'" 2>/dev/null)"
+	[[ -n "$ns" && -n "$gw" ]] || return 1
+	printf '%s %s\n' "$ns" "$gw"
 }
 
-# egress_guest_reachable asserts the guest's DNS query for the probe domain
-# is answered by the egress DNS proxy through the injected guest resolver
-# (nameserver <slot gateway>): allow -> resolves (Name: + A record), deny ->
-# the proxy refuses and nslookup fails fast. TCP-level data-plane allow is
-# asserted separately against the static allow-listed IP (egress_ip_
-# reachable); resolved-domain IPs are asserted via dyn_v4 set membership.
-egress_guest_reachable() { # sandbox
-	local out rc=0
-	if out="$(egress_execd_run "$1" \
-		'{"command":"nslookup example.com 2>&1"}' 25)"; then
-		rc=0
-	else
-		rc=1
-	fi
-	log "egress in-guest probe for $1 (execd /command nslookup example.com): rc=$rc $(tr '\n' ' ' <<<"$out")"
+egress_subject_dns() { # sandbox dnsname -> rc (0 = resolved)
+	local sbx="$1" dnsname="$2" ns gw out rc
+	read -r ns gw < <(egress_subject_netns "$sbx") || return 1
+	out="$(kubectl -n "$NS" exec -c fastlet "pod/$(egress_sandbox_pod "$sbx")" -- \
+		ip netns exec "$ns" timeout 6 nslookup "$dnsname" "$gw" 2>&1)"
+	rc=$?
+	log "egress netns probe for $sbx (netns $ns, gw $gw, nslookup $dnsname): rc=$rc $(tr '\n' ' ' <<<"$out")"
 	[[ "$rc" -eq 0 ]] && grep -q "Name:" <<<"$out"
 }
 
-# egress_ip_reachable asserts IP-direct (DNS-free) TCP from the guest is
-# accepted: only the subj_ chain governs (dyn/allow sets accept, final drop
-# otherwise). A deny drops the SYN silently, so nc -w bounds the probe.
+egress_guest_reachable() { # sandbox
+	egress_subject_dns "$1" "example.com"
+}
+
+# egress_probe_ip extracts the first IPv4 A record resolved from the subject
+# netns (the proxy's Server header line carries ':53' and is skipped by the
+# bare-IP match).
+egress_probe_ip() { # sandbox -> ip
+	local sbx="$1" ns gw out
+	read -r ns gw < <(egress_subject_netns "$sbx") || return 1
+	out="$(kubectl -n "$NS" exec -c fastlet "pod/$(egress_sandbox_pod "$sbx")" -- \
+		ip netns exec "$ns" timeout 6 nslookup example.com "$gw" 2>&1)"
+	awk '/^Address:/ { if ($2 ~ /^[0-9.]+$/) { print $2; exit } }' <<<"$out"
+}
+
+# egress_ip_reachable asserts IP-direct (DNS-free) TCP from the subject
+# netns is accepted: only the subj_ chain governs (dyn/allow sets accept,
+# final drop otherwise). A deny drops the SYN silently, so nc -w bounds the
+# probe.
 egress_ip_reachable() { # sandbox ip
-	egress_execd_run "$1" "{\"command\":\"nc -w 6 $2 80 </dev/null >/dev/null 2>&1\"}" 20 >/dev/null
+	local sbx="$1" ip="$2" ns gw
+	read -r ns gw < <(egress_subject_netns "$sbx") || return 1
+	kubectl -n "$NS" exec -c fastlet "pod/$(egress_sandbox_pod "$sbx")" -- \
+		ip netns exec "$ns" timeout 5 nc -w 3 "$ip" 80 </dev/null >/dev/null 2>&1
 }
 
 # egress_dyn_v4_has asserts the DNS-resolved IP landed in the subject's
@@ -1888,17 +1872,6 @@ egress_dyn_v4_has() { # sandbox ip
 # IP-direct probing; deny-first drops it via the subj_ chain regardless
 # of DNS.
 EGRESS_IP="1.1.1.1"
-
-# egress_probe_ip extracts the first IPv4 A record resolved FROM THE GUEST
-# (in-guest nslookup through the egress DNS proxy; the proxy's own Server
-# header line carries ':53' and is skipped by the bare-IP match).
-egress_probe_ip() { # sandbox -> ip
-	local out
-	if ! out="$(egress_execd_run "$1" '{"command":"nslookup example.com 2>&1"}' 25)"; then
-		return 1
-	fi
-	awk '/^Address:/ { if ($2 ~ /^[0-9.]+$/) { print $2; exit } }' <<< "$out"
-}
 
 egress_binding_state() { # sandbox
 	kubectl -n "$NS" get sandbox "$1" -o jsonpath="{.status.actionBindings[?(@.handler=='egress')].state}" 2>/dev/null
@@ -1987,7 +1960,9 @@ verify_egress() {
 	kubectl -n "$NS" apply -f config/samples/pool-firecracker-egress.yaml
 	wait_for "exactly one egress fastlet pod" 180 egress_single_pod
 	wait_for "egress container ready in the fastlet pod" 180 egress_container_ready
-	pass "egress (host-process) container running in a single fastlet pod"
+	wait_for "egress pool warm image cached (fastlet can accept sandboxes)" \
+		300 egress_warm_ready
+	pass "egress (host-process) container running in a single fastlet pod; pool warm"
 
 	trap 'port_forward_down; resolve_daemon_down' EXIT
 	run_stage "egress 2: actions/status protocol cross-verification" egress_status_ready
@@ -2006,13 +1981,21 @@ verify_egress() {
 	}
 	pass "A and B co-located on fastlet $sbx_pod (one egress instance)"
 
+	# READINESS GATE: the egress DNS plane must demonstrably serve before any
+	# policy assertion is meaningful (the plane intermittently does not
+	# answer DNS for a stretch right after pool/subject activation). Wait
+	# until B(allow) genuinely resolves from the subject netns with a long
+	# deadline; everything below (A deny included) runs only after this gate.
+	wait_for "egress DNS plane serving: B resolves (allow, subject netns)" \
+		300 egress_guest_reachable "$sbx_b"
+	pass "egress readiness gate: DNS answered by the egress proxy"
+
 	# Default state: two subjects, different policies, on the same egress.
 	run_stage "egress 4: A deny (DNS + IP blocked)" test_egress_denied "$sbx_a"
 	run_stage "egress 4: A IP-direct blocked" test_egress_ip_denied "$sbx_a" "$EGRESS_IP"
 	pass "subject A: example.com blocked and $EGRESS_IP dropped (deny)"
-	run_stage "egress 4: B allow (DNS resolves + IP accepted)" \
-		egress_guest_reachable "$sbx_b"
-	pass "subject B: guest reaches example.com through execd (allow)"
+	wait_for "egress 4: B allow (DNS resolves)" 60 egress_guest_reachable "$sbx_b"
+	pass "subject B: example.com allowed (DNS) on the same egress"
 	probe_ip="$(egress_probe_ip "$sbx_b")"
 	[[ -n "$probe_ip" ]] || fail "could not resolve example.com for B"
 	wait_for "resolved IP $probe_ip in B's dyn_v4 set" 15 egress_dyn_v4_has "$sbx_b" "$probe_ip"
@@ -2025,9 +2008,9 @@ verify_egress() {
 	run_stage "egress 5: A -> allow policy" egress_patch_policy "$sbx_a" "$EGRESS_ALLOW_POLICY"
 	wait_for "A binding Ready after policy switch" 120 egress_binding_ready "$sbx_a"
 	wait_for "A: SET_BINDING re-applied" 30 egress_count_gt "$binding_n"
-	wait_for "A: egress allowed after switch" 30 egress_guest_reachable "$sbx_a"
-	wait_for "A: IP-direct $EGRESS_IP accepted after switch" 30 egress_ip_reachable "$sbx_a" "$EGRESS_IP"
-	wait_for "B: still allowed while A switched" 30 egress_guest_reachable "$sbx_b"
+	wait_for "A: egress allowed after switch" 90 egress_guest_reachable "$sbx_a"
+	wait_for "A: IP-direct $EGRESS_IP accepted after switch" 90 egress_ip_reachable "$sbx_a" "$EGRESS_IP"
+	wait_for "B: still allowed while A switched" 90 egress_guest_reachable "$sbx_b"
 	pass "A allow applied; B unaffected on the same egress"
 
 	# Switch B allow -> deny; A must stay unaffected.
@@ -2037,7 +2020,7 @@ verify_egress() {
 	wait_for "B: SET_BINDING re-applied" 30 egress_count_gt "$binding_n"
 	run_stage "egress 6: B blocked after switch" test_egress_denied "$sbx_b"
 	run_stage "egress 6: B IP-direct blocked after switch" test_egress_ip_denied "$sbx_b" "$EGRESS_IP"
-	wait_for "A: still allowed while B switched to deny" 30 egress_guest_reachable "$sbx_a"
+	wait_for "A: still allowed while B switched to deny" 90 egress_guest_reachable "$sbx_a"
 	pass "B deny applied; A unaffected (per-subject policy isolation)"
 
 	# Restart the egress worker: the Fastlet replays BOTH subjects; each
@@ -2048,7 +2031,7 @@ verify_egress() {
 		sh -c 'for p in /proc/[0-9]*; do [ "$(cat $p/comm 2>/dev/null)" = "egress" ] && kill ${p#/proc/}; done'
 	wait_for "egress log: SET_BINDING replayed after restart" 30 egress_count_gt "$binding_n"
 	pass "Handler restart replay observed (new instanceId; A and B re-bound)"
-	wait_for "A: still allowed after replay" 30 egress_guest_reachable "$sbx_a"
+	wait_for "A: still allowed after replay" 90 egress_guest_reachable "$sbx_a"
 	run_stage "egress 7: B still denied after replay" test_egress_denied "$sbx_b"
 	pass "per-subject policies survive the egress restart"
 

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -1311,6 +1311,328 @@ verify_delete_all() {
 	pass "delete cleaned leases + jails ($((CONCURRENCY + 2)) sandboxes)"
 }
 
+# --- verify-execd-api: execd HTTP API usability in the Firecracker guest ----
+# Dedicated execd protocol battery for the golden snapshot (OpenSandbox issue
+# #1695): POST /command reportedly hangs in the Firecracker guest (connection
+# up, SSE never streams, curl times out with 0 bytes) while GET /ping on the
+# same listener answers instantly and a malformed body returns 400 — proving
+# the request reaches execd and the stall sits in the runCommand path
+# (stdlog descriptor/tail -> getShell -> launchManaged).
+#
+# The battery drives the execd HTTP API over the SAME DIRECT_FASTLET_PROXY
+# route the /ping probes use (no central sandbox-proxy), and adds a
+# no-proxy-at-all control that curls the guest execd (172.30.0.3:44772)
+# straight from the sandbox's slot netns inside the fastlet pod.
+#
+# Root-cause signal (not just red/green): cases that write NOTHING to stdout
+# (/bin/false, a missing binary) complete whenever the synchronous init
+# sequence does not stall, while output-producing cases (echo / pipe / sleep)
+# additionally exercise the stdout-file + tail pipeline. So:
+#   everything HANGs                    -> init-sequence stall (stdlog/getShell)
+#   only output-producing cases HANG    -> stdout file/tail pipeline suspect
+#   everything completes                -> execd API usable (not reproduced)
+EXECD_API_SBX="${EXECD_API_SBX:-sandbox-execd-api}"
+# EXECD_API_KEEP_SANDBOX=1 keeps the sandbox (and its jail) after the battery
+# so the guest serial console — execd logs included — can be read from
+# firecracker.log before the jail is removed.
+EXECD_API_KEEP_SANDBOX="${EXECD_API_KEEP_SANDBOX:-0}"
+EXECD_API_CASES=()
+EXECD_API_URI=""
+EXECD_API_CRED=""
+EXECD_API_LPORT=""
+
+# execd_route_resolve resolves the execd port route of a sandbox
+# (DIRECT_FASTLET_PROXY, the durable-assignment fastlet) and maps the fastlet
+# authority to the local port-forward — the same plumbing probe_execd uses.
+# Sets EXECD_API_URI / EXECD_API_CRED / EXECD_API_LPORT.
+execd_route_resolve() { # sandbox-name
+	local name="$1" out path cred uri host
+	out="$(gen_endpoint_for "$name" 44772 2>/dev/null)" || return 1
+	path="$(printf '%s' "$out" | cut -f1)"
+	cred="$(printf '%s' "$out" | cut -f2)"
+	[[ -n "$path" && -n "$cred" ]] || return 1
+	uri="$(printf '%s' "$path" | sed 's|^[a-z]*://[^/]*||')"
+	host="$(printf '%s' "$path" | sed 's|^[a-z]*://\([^/:]*\).*|\1|')"
+	EXECD_API_URI="$uri"
+	EXECD_API_CRED="$cred"
+	EXECD_API_LPORT="$(fastlet_local_port "$host")"
+	[[ -n "$EXECD_API_LPORT" ]]
+}
+
+# execd_base_url prints the base curl URL of the resolved execd route
+# (http://127.0.0.1:<local-forward><route-path>).
+execd_base_url() {
+	printf 'http://127.0.0.1:%s%s' "$EXECD_API_LPORT" "$EXECD_API_URI"
+}
+
+record_api_row() { # name verdict detail
+	EXECD_API_CASES+=("$1|$2|$3")
+	printf '  %-16s %-9s %s\n' "$1" "$2" "$3" | tee -a "$WORK/run.log"
+}
+
+# execd_ping_case: GET /ping control on the resolved route (must answer
+# instantly with 200; the issue's baseline).
+execd_ping_case() {
+	local meta rc=0 http elapsed
+	meta="$(curl -sS -m 5 -H "X-Fast-Sandbox-Route-Credential: $EXECD_API_CRED" \
+		-o /dev/null -w '%{http_code} %{time_total}' "$(execd_base_url)/ping" 2>/dev/null)" \
+		|| rc=$?
+	http="$(awk '{print $1}' <<<"$meta")"
+	elapsed="$(awk '{print $2}' <<<"$meta")"
+	if [[ "$http" == "200" ]]; then
+		record_api_row "ping" PASS "HTTP 200 in ${elapsed}s"
+	else
+		record_api_row "ping" FAIL "http=${http:-000} rc=$rc"
+	fi
+}
+
+# execd_command_case posts one JSON /command body over the resolved route and
+# classifies the outcome. Row verdicts:
+#   PASS       expected outcome arrived: execution_complete SSE (exit 0),
+#              OR the structured error SSE execd sends for non-zero exits
+#              (expect=error-event), OR the fast 400 (expect=error400)
+#   RESPONDED  HTTP 200 with SSE bytes but neither completion nor error event
+#   HANG       nothing received until the curl timeout (issue #1695 symptom)
+#   FAIL       outcome mismatched the expectation / other transport error
+execd_command_case() { # name timeout-s expect body
+	local name="$1" timeout_s="$2" expect="$3" body="$4"
+	local meta rc=0 http bytes elapsed snippet has_complete has_error
+	meta="$(curl -sS -N -m "$timeout_s" \
+		-H "X-Fast-Sandbox-Route-Credential: $EXECD_API_CRED" \
+		-H 'Content-Type: application/json' -H 'Accept: text/event-stream' \
+		--data-binary "$body" \
+		-o "$WORK/execd-api-$name.out" \
+		-w '%{http_code} %{size_download} %{time_total}' \
+		"$(execd_base_url)/command" 2>"$WORK/execd-api-$name.err")" \
+		|| rc=$?
+	http="$(awk '{print $1}' <<<"$meta")"; http="${http:-000}"
+	bytes="$(awk '{print $2}' <<<"$meta")"; bytes="${bytes:-0}"
+	elapsed="$(awk '{print $3}' <<<"$meta")"
+	if [[ "$expect" == "error400" ]]; then
+		if [[ "$http" == "400" ]]; then
+			record_api_row "$name" PASS "malformed JSON -> HTTP 400 in ${elapsed}s (request reaches execd)"
+		elif [[ "$http" == "000" && "$rc" == "28" ]]; then
+			record_api_row "$name" HANG "malformed JSON ALSO hangs (${timeout_s}s, no response)"
+		else
+			record_api_row "$name" FAIL "expected HTTP 400, got $http (rc=$rc)"
+		fi
+		return 0
+	fi
+	has_complete="$(grep -c "execution_complete" "$WORK/execd-api-$name.out" 2>/dev/null)"
+	has_error="$(grep -c '"type":"error"' "$WORK/execd-api-$name.out" 2>/dev/null)"
+	if [[ "$has_complete" -gt 0 ]]; then
+		# execd streams execution_complete only for exit code 0.
+		if [[ "$expect" == "error-event" ]]; then
+			record_api_row "$name" FAIL "expected an error SSE for a non-zero exit, got execution_complete"
+		else
+			record_api_row "$name" PASS "execution_complete in ${elapsed}s (http=$http, $bytes bytes)"
+		fi
+	elif [[ "$has_error" -gt 0 ]]; then
+		# execd reports non-zero exits / launch failures via a structured
+		# SSE error event (no execution_complete) — correct protocol.
+		if [[ "$expect" == "error-event" ]]; then
+			record_api_row "$name" PASS "structured error SSE in ${elapsed}s (non-zero exit, http=$http, $bytes bytes)"
+		else
+			snippet="$(head -c 160 "$WORK/execd-api-$name.out" 2>/dev/null | tr '\n|' ' ;' | cut -c1-160)"
+			record_api_row "$name" FAIL "error SSE where completion was expected: $snippet"
+		fi
+	elif [[ "$http" == "200" && "$bytes" -gt 0 ]]; then
+		snippet="$(head -c 160 "$WORK/execd-api-$name.out" 2>/dev/null | tr '\n|' ' ;' | cut -c1-160)"
+		record_api_row "$name" RESPONDED "SSE bytes but no completion/error event: $snippet"
+	elif [[ "$rc" == "28" ]]; then
+		record_api_row "$name" HANG "curl timeout ${timeout_s}s, $bytes bytes (http=$http)"
+	else
+		snippet="$(head -c 160 "$WORK/execd-api-$name.err" 2>/dev/null | tr '\n|' ' ;' | cut -c1-160)"
+		record_api_row "$name" FAIL "http=$http rc=$rc bytes=$bytes err: $snippet"
+	fi
+}
+
+# execd_slot_netns finds a live per-sandbox slot netns inside the sandbox's
+# fastlet pod (the netns whose VM tap vmtap0 is UP). Prints "pod netns".
+execd_slot_netns() { # sandbox-name
+	local sbx="$1" pod lines ns
+	pod="$(kubectl -n "$NS" get sandbox "$sbx" -o jsonpath='{.status.placement.fastletName}' 2>/dev/null)"
+	[[ -n "$pod" ]] || return 1
+	lines="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- ip netns list 2>/dev/null)" || return 1
+	while read -r ns _; do
+		[[ -n "$ns" ]] || continue
+		if kubectl -n "$NS" exec -c fastlet "pod/$pod" -- ip netns exec "$ns" ip link show vmtap0 2>/dev/null | grep -q "state UP"; then
+			printf '%s %s\n' "$pod" "$ns"
+			return 0
+		fi
+	done <<<"$lines"
+	return 1
+}
+
+# execd_netns_control probes the guest execd straight from the slot netns
+# (guest 172.30.0.3:44772 — zero proxies) with the fastlet image's busybox
+# wget. The /ping control runs FIRST and gates the /command probe: when the
+# guest is not reachable from the netns at all (netns/ping also fails) the
+# rows are SKIP — that is a data-plane/path issue, not execd, and must not
+# pollute the API verdict. Skipped entirely when the applet is unavailable.
+execd_netns_control() { # sandbox-name
+	local sbx="$1" pod ns ping_out cmd_out rc=0
+	read -r pod ns < <(execd_slot_netns "$sbx") || {
+		record_api_row "netns" SKIP "no live slot netns found in the fastlet pod"
+		return 0
+	}
+	if ! kubectl -n "$NS" exec -c fastlet "pod/$pod" -- busybox wget --help 2>&1 | grep -q -- "--post-data"; then
+		record_api_row "netns" SKIP "busybox wget (--post-data) unavailable in the fastlet image"
+		return 0
+	fi
+	ping_out="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- ip netns exec "$ns" \
+		busybox wget -S -T 8 -qO - \
+		--header 'Content-Type: application/json' \
+		"http://172.30.0.3:44772/ping" 2>&1)" || rc=$?
+	if ! grep -q "HTTP/1.1 200\|HTTP/1.0 200" <<<"$ping_out"; then
+		record_api_row "netns" SKIP "guest not reachable from slot netns $ns (netns/ping fails: data-plane path, not execd)"
+		return 0
+	fi
+	record_api_row "netns/ping" PASS "guest execd answered 200 directly in netns $ns"
+	cmd_out="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- ip netns exec "$ns" \
+		busybox wget -S -T 8 -qO - \
+		--header 'Content-Type: application/json' \
+		--header 'Accept: text/event-stream' \
+		--post-data '{"command":"echo probe-ok"}' \
+		"http://172.30.0.3:44772/command" 2>&1)" || rc=$?
+	if grep -q "execution_complete" <<<"$cmd_out"; then
+		record_api_row "netns/command" PASS "guest execd completed directly in netns $ns"
+	elif grep -q '"type":"error"' <<<"$cmd_out"; then
+		record_api_row "netns/command" PASS "guest execd answered with a structured error SSE in netns $ns"
+	else
+		record_api_row "netns/command" HANG "no guest /command response in netns $ns (rc=$rc): $(head -c 120 <<<"$cmd_out")"
+	fi
+}
+
+# execd_api_dump_console captures execd's own log lines from the guest
+# serial console (firecracker.log) BEFORE the sandbox is deleted (cleanup
+# removes the jail). execd logs to /dev/console and the jailer stores the
+# firecracker stdout (the console) under
+# <StateRoot>/jails/firecracker/<uid[:32]>/root/firecracker.log, readable
+# from the fastlet pod. Best effort — a missing/unreadable log only warns.
+execd_api_dump_console() { # sandbox-name
+	local name="$1" pod uid32 logfile
+	pod="$(kubectl -n "$NS" get sandbox "$name" -o jsonpath='{.status.placement.fastletName}' 2>/dev/null)" || return 0
+	uid32="$(kubectl -n "$NS" get sandbox "$name" -o jsonpath='{.metadata.uid}' 2>/dev/null | cut -c1-32)"
+	[[ -n "$pod" && -n "$uid32" ]] || return 0
+	logfile="/var/lib/fast-sandbox/firecracker/jails/firecracker/$uid32/root/firecracker.log"
+	if ! kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c "test -s '$logfile'" >/dev/null 2>&1; then
+		log "execd-api: guest console $logfile not found on $pod (evidence capture skipped)"
+		return 0
+	fi
+	highlight "  key node: guest console evidence for '$name' (execd logs from firecracker.log)"
+	log "execd-api: execd-relevant console lines ($logfile):"
+	kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
+		"grep -aE 'Requested: (POST|GET)|crypto/rand|received command|StreamEvent|CommandExecError|starting OpenSandbox| error' '$logfile' | tail -60" \
+		| sed 's/^/    /' | tee -a "$WORK/run.log" || true
+	log "execd-api: raw console tail (last 25 lines):"
+	kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c "tail -25 '$logfile'" \
+		| sed 's/^/    /' | tee -a "$WORK/run.log" || true
+	pass "guest console evidence dumped before teardown"
+}
+
+verify_execd_api_sandbox() { # sandbox-name
+	local name="$1"
+	fastctl_run_sandbox "$name"
+	wait_until "execd /ping on $name" 120000 probe_execd "$name"
+	execd_route_resolve "$name" || fail "execd route resolve failed for $name"
+	log "execd-api: route $(execd_base_url) (DIRECT_FASTLET_PROXY, credential route)"
+	pass "sandbox $name running, execd /ping reachable end-to-end"
+}
+
+verify_execd_api_battery() {
+	local body_pipe
+	EXECD_API_CASES=()
+	execd_ping_case
+	execd_command_case "bad-json" 5 error400 '{not-json'
+	execd_command_case "echo" 8 completed '{"command":"echo probe-ok"}'
+	body_pipe="{\"command\":\"printf 'a b c\\n' | wc -w\"}"
+	execd_command_case "pipe" 8 completed "$body_pipe"
+	execd_command_case "sleep" 10 completed '{"command":"sleep 1 && echo done-after-sleep"}'
+	execd_command_case "false" 8 error-event '{"command":"/bin/false"}'
+	execd_command_case "missing" 8 error-event '{"command":"definitely-not-a-real-binary-xyz"}'
+	pass "route battery complete (see rows above)"
+}
+
+verify_execd_api_netns() { # sandbox-name
+	execd_netns_control "$1"
+	pass "slot-netns controls complete (no proxy; SKIP when the guest is unreachable from the netns)"
+}
+
+verify_execd_api_cleanup() { # sandbox-name
+	local name="$1" pod uid32
+	if [[ "$EXECD_API_KEEP_SANDBOX" == "1" ]]; then
+		# The battery hung (issue #1695). Keep the VM alive so the execd
+		# side can be inspected: execd logs to /dev/console, the jailer
+		# captures firecracker stdout (the serial console) in
+		# <StateRoot>/jails/firecracker/<sandbox-id[:32]>/root/firecracker.log.
+		# The battery's own hang attempts are ALREADY in that log — read it
+		# first (look for "received command", "StreamEvent.OnExecuteInit",
+		# "CommandExecError"); for a live replay, tail BEFORE re-running the
+		# battery (the next run's leftover removal recycles this sandbox).
+		pod="$(kubectl -n "$NS" get sandbox "$name" -o jsonpath='{.status.placement.fastletName}' 2>/dev/null)"
+		uid32="$(kubectl -n "$NS" get sandbox "$name" -o jsonpath='{.metadata.uid}' 2>/dev/null | cut -c1-32)"
+		log "diagnosis: sandbox $name KEPT (EXECD_API_KEEP_SANDBOX=1)"
+		log "diagnosis: this battery's execd log lines are in firecracker.log on pod $pod:"
+		log "  kubectl -n $NS exec -c fastlet pod/$pod -- sh -c 'grep -aE \"starting OpenSandbox|received command|StreamEvent|CommandExecError|error\" /var/lib/fast-sandbox/firecracker/jails/firecracker/$uid32/root/firecracker.log | tail -80'"
+		log "diagnosis: for a LIVE replay, run this tail in one terminal BEFORE the next battery:"
+		log "  kubectl -n $NS exec -c fastlet pod/$pod -- sh -c 'tail -f /var/lib/fast-sandbox/firecracker/jails/firecracker/*/root/firecracker.log'"
+		log "  then: EXECD_API_KEEP_SANDBOX=1 ./scripts/integration-env.sh verify-execd-api"
+		log "diagnosis: teardown afterwards with:  fastctl delete $name  (or re-run verify-execd-api)"
+		rm -f "$WORK"/execd-api-*.out "$WORK"/execd-api-*.err
+		return 0
+	fi
+	fastctl delete "$name" >/dev/null 2>&1 || true
+	wait_for "execd-api sandbox gone" 120 sandbox_gone "$name"
+	rm -f "$WORK"/execd-api-*.out "$WORK"/execd-api-*.err
+	pass "sandbox $name deleted; workspace clean"
+}
+
+verify_execd_api() {
+	local name="$EXECD_API_SBX" row verdict
+	local api_hang=0 api_pass=0 api_other=0 api_skip=0 api_total=0
+	port_forward_up
+	resolve_daemon_up
+	trap 'port_forward_down; resolve_daemon_down' EXIT
+	run_stage "execd-api 1: sandbox create + execd /ping (route plumbing)" \
+		verify_execd_api_sandbox "$name"
+	run_stage "execd-api 2: API battery over the fastlet-proxy route" \
+		verify_execd_api_battery
+	run_stage "execd-api 3: no-proxy controls (slot netns -> guest 172.30.0.3)" \
+		verify_execd_api_netns "$name"
+	for row in "${EXECD_API_CASES[@]}"; do
+		verdict="${row#*|}"
+		verdict="${verdict%%|*}"
+		case "$verdict" in
+			HANG) api_hang=$((api_hang + 1)) ;;
+			PASS) api_pass=$((api_pass + 1)) ;;
+			SKIP) api_skip=$((api_skip + 1)) ;;
+			*) api_other=$((api_other + 1)) ;;
+		esac
+		api_total=$((api_total + 1))
+	done
+	highlight "  key node: execd API verdict on '$name' (execd protocol, issue #1695)"
+	if [[ "$api_hang" -gt 0 ]]; then
+		printf '    REPRODUCED #1695: %d/%d API cases hang (0 bytes) while /ping stays up\n' \
+			"$api_hang" "$api_total" | tee -a "$WORK/run.log"
+		printf '    root-cause read: all command cases HANG -> synchronous init stall (stdlog\n    descriptor / getShell / launchManaged); only echo/pipe/sleep HANG -> stdout\n    file/tail pipeline\n' | tee -a "$WORK/run.log" >/dev/null
+	elif [[ "$api_other" -eq 0 ]]; then
+		printf '    NOT REPRODUCED: execd API fully usable (%d/%d PASS, %d SKIP control rows)\n' \
+			"$api_pass" "$api_total" "$api_skip" | tee -a "$WORK/run.log"
+	else
+		printf '    PARTIAL: %d PASS, %d HANG, %d other, %d SKIP of %d — inspect rows above\n' \
+			"$api_pass" "$api_hang" "$api_other" "$api_skip" "$api_total" | tee -a "$WORK/run.log"
+	fi
+	run_stage "execd-api 4: guest console evidence (firecracker.log, auto-captured)" \
+		execd_api_dump_console "$name"
+	run_stage "execd-api 5: sandbox delete + cleanup" verify_execd_api_cleanup "$name"
+	trap - EXIT
+	resolve_daemon_down
+	port_forward_down
+	stage_summary
+	highlight "== verify-execd-api complete: execd protocol battery + no-proxy controls =="
+}
+
 # --- verify-egress: egress Actions-channel integration -----------------------
 # Network policy is delivered over the Sandbox Actions channel only this
 # phase (SET_BINDING binding.input / LIFECYCLE_HOOK / REMOVE_BINDING); the
@@ -1445,9 +1767,11 @@ egress_patch_policy() { # sandbox policy-json
 # egress_guest_reachable probes the egress data plane from the sandbox's
 # own slot netns (fastlet pod, ip netns exec): a DNS query to the slot
 # gateway is redirected to the egress DNS proxy, which evaluates the domain
-# policy (deny -> refused/hung, allow -> resolves). This bypasses the
-# execd /command SSE endpoint, which is broken on the firecracker snapshot
-# (the execd answers /ping but /command never streams).
+# policy (deny -> refused/hung, allow -> resolves). This bypasses execd's
+# HTTP endpoints entirely (historical note: execd /command used to hang on
+# the firecracker snapshot — guest CRNG never seeded on the 4.14 quickstart
+# kernel; fixed by switching the golden snapshot to the 6.1 microvm kernel,
+# see verify-execd-api and OpenSandbox #1695).
 #
 # The sandbox netns is located via the egress dispatch rule
 # (ip saddr <slot.IP> iifname <veth> jump subj_<uid>) — the veth name is
@@ -1804,6 +2128,17 @@ down() {
 	rm -rf "$GEN_DIR"
 	sysctl_restore
 	stateroot_xfs_down
+	# Purge the runtime cache the environment owns. The pull layer treats a
+	# committed cache as FINAL (idempotent, never refreshed), so a rebuilt
+	# SandboxTemplate would otherwise keep being ignored on the next up when
+	# the StateRoot survives teardown (e.g. XFS_STATEROOT=0 plain directory).
+	# The XFS loop-image case is already covered by stateroot_xfs_down.
+	if [[ -d "$XFS_MOUNT_POINT/firecracker" ]]; then
+		log "down: purging node runtime cache under $XFS_MOUNT_POINT/firecracker"
+		sudo_ rm -rf "$XFS_MOUNT_POINT/firecracker/images" \
+			"$XFS_MOUNT_POINT/firecracker/agent" \
+			"$XFS_MOUNT_POINT/firecracker/jails" 2>/dev/null || true
+	fi
 	if docker network ls --format '{{.Name}}' | grep -qx 'kind'; then
 		log "note: docker network 'kind' remains (kind-wide, reused on next up)"
 	fi
@@ -1833,6 +2168,13 @@ usage: integration-env.sh [--cleanup|--auto-clean] {up|down|status|verify}
   status   component / template / pool / sandbox health
   verify   create 2 sandboxes, probe execd /ping, then a max-concurrency
            batch (CONCURRENCY=5 at pool capacity), delete all, assert cleanup
+  verify-execd-api
+           execd HTTP API usability battery in the Firecracker guest
+           (OpenSandbox #1695): /ping, POST /command SSE (echo/pipe/sleep/
+           false/missing command classes), malformed-JSON 400, plus
+           no-proxy slot-netns controls; verdict: hang reproduced or not;
+           auto-captures the guest console (execd logs from firecracker.log)
+           before teardown
   verify-egress
            egress Actions-channel integration: pool apply, protocol
            cross-verification, SET_BINDING -> hooks -> REMOVE_BINDING
@@ -1848,7 +2190,7 @@ for arg in "$@"; do
 	case "$arg" in
 		--cleanup) ACTION="down" ;;
 		--auto-clean) AUTO_CLEAN=1 ;;
-		up|down|status|verify|verify-egress) ACTION="$arg" ;;
+		up|down|status|verify|verify-execd-api|verify-egress) ACTION="$arg" ;;
 		*) usage ;;
 	esac
 done
@@ -1901,6 +2243,11 @@ case "$ACTION" in
 	verify)
 		trap 'on_error verify' ERR
 		verify
+		trap - ERR
+		;;
+	verify-execd-api)
+		trap 'on_error verify-execd-api' ERR
+		verify_execd_api
 		trap - ERR
 		;;
 	verify-egress)

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -1339,7 +1339,6 @@ EXECD_API_KEEP_SANDBOX="${EXECD_API_KEEP_SANDBOX:-0}"
 EXECD_API_CASES=()
 EXECD_API_URI=""
 EXECD_API_CRED=""
-EXECD_API_HOST=""
 EXECD_API_LPORT=""
 
 # execd_route_resolve resolves the execd port route of a sandbox
@@ -1356,7 +1355,6 @@ execd_route_resolve() { # sandbox-name
 	host="$(printf '%s' "$path" | sed 's|^[a-z]*://\([^/:]*\).*|\1|')"
 	EXECD_API_URI="$uri"
 	EXECD_API_CRED="$cred"
-	EXECD_API_HOST="$host"
 	EXECD_API_LPORT="$(fastlet_local_port "$host")"
 	[[ -n "$EXECD_API_LPORT" ]]
 }
@@ -1812,7 +1810,7 @@ egress_execd_run() { # sandbox-name command timeout-s
 		attempt=$((attempt + 1))
 		rm -f "$outfile"
 		ip="$(kubectl -n "$NS" exec -c fastlet "pod/$pod" -- sh -c \
-			"grep -m1 -oE '\"IP\"[: ]*\"[0-9.]+' /var/lib/fast-sandbox/firecracker/sandboxes/$uid/meta.json 2>/dev/null | grep -oE '[0-9.]+$'" 2>/dev/null)"
+			"grep -m1 -oE '\"ip\"[: ]*\"[0-9.]+' /var/lib/fast-sandbox/firecracker/sandboxes/$uid/meta.json 2>/dev/null | grep -oE '[0-9.]+$'" 2>/dev/null)"
 		if [[ -z "$ip" ]]; then
 			log "egress execd probe for $sbx: slot IP not found in driver state (attempt $attempt)"
 			if [[ "$attempt" -ge 8 ]]; then

--- a/scripts/sandboxtemplate-e2e.sh
+++ b/scripts/sandboxtemplate-e2e.sh
@@ -30,7 +30,7 @@ IMAGE="${SANDBOX_TEMPLATE_IMAGE:-alpine:3.19}"
 # comma-separated list to run a subset.
 FORMATS=()
 BUILDER_IMAGE="${SANDBOX_TEMPLATE_BUILDER_IMAGE:-sandboxtemplate-builder:e2e}"
-KERNEL_URL="${SANDBOX_TEMPLATE_KERNEL_URL:-https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin}"
+KERNEL_URL="${SANDBOX_TEMPLATE_KERNEL_URL:-https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.1.176}"
 LOCAL_MODE=0
 
 log() { printf '\033[1;34m[st-e2e]\033[0m %s\n' "$*"; }


### PR DESCRIPTION
## What

Adds a dedicated `verify-execd-api` action to `scripts/integration-env.sh` that verifies the **execd HTTP API usability** inside a real Firecracker guest (golden-snapshot sandbox created on the pool), addressing opensandbox-group/OpenSandbox#1695: `POST /command` hangs in the Firecracker guest (SSE never streams, curl times out with 0 bytes) while `GET /ping` on the same listener answers instantly and a malformed body returns 400 instantly.

The existing `verify` only probes execd `/ping`; this stage speaks the execd **protocol**.

## What it runs

1. Creates one Firecracker sandbox (`sandbox-execd-api`, env-overridable via `EXECD_API_SBX`) and waits for execd `/ping` through the usual DIRECT_FASTLET_PROXY plumbing.
2. **Route battery** (same route `/ping` probes use, no central sandbox-proxy):
   - `GET /ping` — control, must answer 200 fast
   - `POST /command` malformed JSON — must answer 400 fast (proves the request reaches execd)
   - `POST /command` SSE cases: `echo`, `printf | wc -w`, `sleep 1 && echo`, `/bin/false`, a missing binary
3. **No-proxy control**: curls the guest execd (`172.30.0.3:44772`) straight from the sandbox's slot netns inside the fastlet pod (busybox wget when available in the image).
4. Verdict: per-case rows `PASS / RESPONDED / HANG / FAIL` + an explicit conclusion — `REPRODUCED #1695` (with an init-stall vs stdout-tail root-cause read) or `NOT REPRODUCED`.

## Why these cases

`echo/pipe/sleep` produce stdout (exercise the stdout-file + tail pipeline), while `/bin/false` and a missing binary write nothing (only the synchronous init sequence: stdlog descriptor -> getShell -> launchManaged). So:

- all command cases HANG -> synchronous init-sequence stall
- only output-producing cases HANG -> stdout file/tail pipeline suspect
- everything completes -> execd API usable on the snapshot

## Usage

```bash
./scripts/integration-env.sh up
./scripts/integration-env.sh verify-execd-api
```

## Docs

Guide updated with the new one-liner and the `EXECD_API_SBX` override row.

Note: created on top of upstream master (9f7dbf7); PR opensandbox-group/OpenSandbox#1695 is the issue this verification targets.