### PR TITLE
feat(scripts): optional task 0 host-level chain E2E in integration-env

### DIFF
--- a/docs/guides/firecracker-integration-env.md
+++ b/docs/guides/firecracker-integration-env.md
@@ -24,11 +24,19 @@ SandboxTemplate (builder Pod, in-cluster)
 One-liners:
 
 ```bash
-./scripts/integration-env.sh up        # full environment (tasks 1-8)
+./scripts/integration-env.sh up                    # full environment (tasks 1-8)
+CHAIN_E2E=1 ./scripts/integration-env.sh up        # task 0 (host-level component chain E2E) + full environment
 ./scripts/integration-env.sh verify    # 2 + 5 sandboxes, proxy-chain probe, teardown asserts
 ./scripts/integration-env.sh status    # component / template / pool health
 ./scripts/integration-env.sh down      # host left clean
 ```
+
+`up` runs the optional **task 0** first when `CHAIN_E2E=1`: the host-level
+component chain E2E (`scripts/firecracker-chain-e2e.sh`, builder → MinIO →
+runtime-agent → driver restore with **no Kubernetes**) gates the cluster run
+on a green component chain. Off by default: it rebuilds the builder image
+and re-downloads the firecracker set (~10 min). It self-cleans on exit and
+its leftover resources are also detected and purged by `down`.
 
 `up` and the plain `verify` only prove execd `/ping` delivery. For execd
 **protocol** usability in the guest (OpenSandbox issue #1695: `POST
@@ -66,6 +74,14 @@ SandboxTemplate controller) and `fast-sandbox.io/firecracker-node=true`
 
 ## 3. What `up` actually does (stage order matters)
 
+0. **task 0 — host-level component chain E2E** (only with `CHAIN_E2E=1`):
+   `firecracker-chain-e2e.sh` validates the bare chain (builder publish →
+   real MinIO SigV4 pull → PinImage idempotency → driver restore → lease
+   lifecycle) before any cluster resource exists. Its exit leaves the host
+   clean (own MinIO container, fsb bridge/netns/MASQUERADE, agent, jails all
+   removed); its `chain-e2e-minio` container / fsb leftovers are also part
+   of `up`'s leftover detection and `down`'s cleanup. Workspace and
+   re-downloadable artifacts stay under `$WORK/chain-e2e` for reuse.
 1. **preflight + tooling** — installs kind/kubectl/jq/xfsprogs when missing.
 2. **sysctl** — `fs.inotify.max_user_instances=8192`.
 3. **images** — `make images` for 7 images + host `fastctl`/`gen-endpoint`.
@@ -267,6 +283,7 @@ Baseline on the reference node (XFS StateRoot):
 | `KIND_CLUSTER` / `KIND_NODE_IMAGE` / `KIND_RETAIN` | firecracker / - / 0 | kind knobs; mirror override, retain-for-debug |
 | `MINIO_PORT` / `MINIO_AK` / `MINIO_SK` / `MINIO_ENDPOINT` | 9000 / ... | store credentials; endpoint auto = container IP |
 | `SBX_IMAGE` / `EXECD` / `FC_VERSION` | alpine:3.19 / execd:1.1.0 / v1.16.1 | the chain keys |
+| `CHAIN_E2E` | 0 | 1 runs task 0: the host-level component chain E2E (`firecracker-chain-e2e.sh`) before the cluster tasks (~10 min; forwards `SBX_IMAGE`/`EXECD`/`ROOTFS_SIZE`/`FC_VERSION`) |
 | `CONCURRENCY` | 5 | per-fastlet slot capacity for the batch |
 | `EXECD_API_SBX` | sandbox-execd-api | sandbox name used by `verify-execd-api` |
 | `EXECD_API_KEEP_SANDBOX` | 0 | 1 keeps the sandbox + jail after the battery and prints the guest-console (firecracker.log) tail command for execd-side diagnosis |

--- a/docs/guides/firecracker-integration-environment.md
+++ b/docs/guides/firecracker-integration-environment.md
@@ -223,11 +223,16 @@ curl http://<slot.IP>:44772/ping                     # execd /ping OK
 新增 `scripts/integration-env.sh`（对齐 chain-e2e.sh 风格）：
 
 ```text
-up     # 环境准备 + Kind + MinIO + controller + 节点资产 + agent + 模板 + pool
-down   # 清理（kind delete + MinIO 容器）
+up     # [task 0 可选] host-level 组件链 E2E（CHAIN_E2E=1，chain-e2e.sh）+ 环境准备 + Kind + MinIO + controller + 节点资产 + agent + 模板 + pool
+down   # 清理（kind delete + MinIO 容器 + 残留的 chain-e2e 资源）
 status # 各组件健康 + 模板状态 + warmImages 状态
 verify # 步骤 9 的断言链（sandbox Running + execd /ping）
 ```
+
+任务 0（`CHAIN_E2E=1` 可选）复用 `firecracker-chain-e2e.sh` 裸组件级全链路
+验证（builder publish → 真实 MinIO SigV4 拉取 → PinImage 幂等 → driver
+restore → lease 生命周期），作为集群级运行的组件前置门禁；退出自清理，
+残留由 `up` 的 leftover 检测与 `down` 兜底。
 
 ## 关键实现细节
 

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -20,7 +20,8 @@
 #
 # Environment overrides (all optional):
 #   WORK, KIND_CLUSTER, MINIO_PORT, MINIO_AK, MINIO_SK, MINIO_IMAGE,
-#   MINIO_ENDPOINT, IMAGE_<NAME> (image tags), FC_VERSION, SBX_IMAGE
+#   MINIO_ENDPOINT, IMAGE_<NAME> (image tags), FC_VERSION, SBX_IMAGE,
+#   CHAIN_E2E (=1 runs task 0, the host-level component chain E2E, first)
 #
 # Every task logs to $WORK/logs/; failures dump component logs to
 # logs/failure-<task>-<ts>.txt before exiting (never silently).
@@ -60,6 +61,16 @@ ROOTFS_SIZE="${ROOTFS_SIZE:-2Gi}"
 SBX_TEMPLATE="ai-office-sandbox"
 SBX_POOL="firecracker-pool"
 SBX_SANDBOX="sandbox-firecracker"
+
+# Task 0 (optional): run the host-level component chain E2E
+# (scripts/firecracker-chain-e2e.sh) before the cluster tasks. It validates
+# the bare chain builder -> MinIO -> runtime-agent -> driver restore with no
+# Kubernetes (publish layout, SigV4 over the wire, credential mapping,
+# PinImage idempotency, lease lifecycle). Off by default because it rebuilds
+# the builder image and re-downloads the firecracker set (~10 min); when
+# enabled it also gates the cluster run on a green component chain.
+CHAIN_E2E="${CHAIN_E2E:-0}"
+CHAIN_E2E_CONTAINER="chain-e2e-minio"
 
 # Node labels. The KVM label key is hardcoded by the SandboxTemplate
 # reconciler (sandbox.fast.io/kvm); the firecracker label selects installer/
@@ -226,7 +237,7 @@ failure_dump() { # task
 	mkdir -p "$LOGS_DIR"
 	{
 		echo "=== integration-env failure: $task ($(date -u +%FT%TZ)) ==="
-		env | grep -E '^(MINIO|KIND|FC_|SBX|IMG_|EXECD|WORK)=' || true
+		env | grep -E '^(MINIO|KIND|FC_|SBX|IMG_|EXECD|WORK|CHAIN_E2E)=' || true
 		echo "--- kind nodes ---"
 		kind get nodes --name "$KIND_CLUSTER" 2>&1 || true
 		echo "--- kind-create.log (tail) ---"
@@ -2487,6 +2498,9 @@ down() {
 	docker rm -f "$MINIO_CONTAINER" >/dev/null 2>&1 || true
 	[[ -z "$(docker ps -a --filter "name=$MINIO_CONTAINER" --format '{{.Names}}' || true)" ]] \
 		|| fail "MinIO container still present"
+	if chain_e2e_leftover; then
+		chain_e2e_cleanup
+	fi
 	rm -f "$WORK/agent-registry.json" "$WORK/registry.json"
 	rm -rf "$GEN_DIR"
 	sysctl_restore
@@ -2508,6 +2522,46 @@ down() {
 	pass "host cleanup complete"
 }
 
+# --- task 0: host-level component chain E2E (firecracker-chain-e2e.sh) --------
+chain_e2e_workdir() { printf '%s' "$WORK/chain-e2e"; }
+
+chain_e2e_leftover() {
+	# Resources of a crashed firecracker-chain-e2e.sh run that would break
+	# either the next chain run (stale fsb netns/VMs) or this environment's
+	# MinIO (host :9000 taken): the chain MinIO container, fsb* netns, and
+	# the fsb0 bridge / 172.30/24 MASQUERADE rule it owns.
+	docker ps -a --format '{{.Names}}' | grep -qx "$CHAIN_E2E_CONTAINER" \
+		|| ls /var/run/netns/fsb* >/dev/null 2>&1
+}
+
+chain_e2e_cleanup() {
+	local chain_work
+	chain_work="$(chain_e2e_workdir)"
+	mkdir -p "$chain_work"
+	log "cleaning leftover host-level chain E2E resources (firecracker-chain-e2e.sh --cleanup)"
+	( cd "$REPO_ROOT" && WORK="$chain_work" bash scripts/firecracker-chain-e2e.sh --cleanup ) || true
+}
+
+chain_e2e_host() {
+	local chain_work
+	chain_work="$(chain_e2e_workdir)"
+	mkdir -p "$chain_work"
+	# The chain script self-cleans every resource it creates on exit (MinIO
+	# container, fsb netns/bridge/MASQUERADE, agent, jails), so the cluster
+	# tasks below start from a clean host. Its workspace is kept so the
+	# downloaded firecracker set is reused on the next CHAIN_E2E=1 run.
+	# Image/execd/rootfs/FC knobs are forwarded so the host-level run
+	# validates the same inputs as the cluster-level chain.
+	log "host-level chain E2E workspace: $chain_work"
+	if ! ( cd "$REPO_ROOT" && WORK="$chain_work" \
+		CHAIN_SOURCE_IMAGE="$SBX_IMAGE" CHAIN_EXECD="$EXECD" \
+		CHAIN_ROOTFS_SIZE="$ROOTFS_SIZE" FC_VERSION="$FC_VERSION" \
+		bash scripts/firecracker-chain-e2e.sh ); then
+		die "host-level chain E2E failed (component logs: $chain_work/builder.log, $chain_work/agent.log, $chain_work/driver-e2e.log)"
+	fi
+	log "host-level component chain E2E green (artifacts under $chain_work)"
+}
+
 # --- main ------------------------------------------------------------------------------------------
 # env_summary prints the reachable facts of the environment for hand-off.
 env_summary() {
@@ -2526,8 +2580,10 @@ usage() {
 	cat <<'EOF'
 usage: integration-env.sh [--cleanup|--auto-clean] {up|down|status|verify}
 
-  up       build the whole environment (tasks 1-9) and report status
+  up       build the whole environment: optional task 0 (host-level
+           component chain E2E, CHAIN_E2E=1) + tasks 1-9, report status
   down     teardown: kind cluster + MinIO container + credentials + sysctl
+           (+ leftover host-level chain E2E resources if present)
   status   component / template / pool / sandbox health
   verify   create 2 sandboxes, probe execd /ping, then a max-concurrency
            batch (CONCURRENCY=5 at pool capacity), delete all, assert cleanup
@@ -2573,10 +2629,12 @@ case "$ACTION" in
 			docker --version
 			echo "minio=$MINIO_IMAGE minioPort=$MINIO_PORT bucket=$MINIO_BUCKET"
 			echo "fcVersion=$FC_VERSION sbxImage=$SBX_IMAGE execd=$EXECD"
+			echo "chainE2e=$CHAIN_E2E (host-level component chain before the cluster tasks)"
 			echo "images: controller=$IMG_CONTROLLER agent=$IMG_AGENT builder=$IMG_BUILDER"
 		} > "$LOGS_DIR/environment.txt" 2>&1 || true
 		if [[ -n "$(kind get clusters 2>/dev/null | grep -x "$KIND_CLUSTER" || true)" ]] \
-			|| docker ps -a --format '{{.Names}}' | grep -qx "$MINIO_CONTAINER"; then
+			|| docker ps -a --format '{{.Names}}' | grep -qx "$MINIO_CONTAINER" \
+			|| chain_e2e_leftover; then
 			if [[ "$SKIP_LEFTOVER_CLEAN" == 1 ]]; then
 				log "leftover resources detected; aborting (SKIP_LEFTOVER_CLEAN=1). Run 'integration-env.sh down' first"
 				exit 1
@@ -2585,6 +2643,11 @@ case "$ACTION" in
 			down
 		fi
 		trap 'on_error up' ERR
+		if [[ "$CHAIN_E2E" == "1" ]]; then
+			run_stage "task 0: host-level component chain E2E (firecracker-chain-e2e.sh)" chain_e2e_host
+		else
+			log "task 0 skipped: host-level component chain E2E (CHAIN_E2E=1 runs it before the cluster tasks)"
+		fi
 		run_stage "task 1: preflight + tooling" preflight
 		run_stage "task 1: sysctl (fs.inotify)" sysctl_set
 		run_stage "task 1: build images (7)" build_images


### PR DESCRIPTION
## 变更

`scripts/integration-env.sh up` 支持可选的 **task 0**（`CHAIN_E2E=1`，默认关）：在集群任务前跑 `scripts/firecracker-chain-e2e.sh`（裸组件级全链路 E2E：builder publish → 真实 MinIO SigV4 拉取 → PinImage 幂等 → driver restore → lease 生命周期，无 Kubernetes），作为集群级链路的组件前置门禁。

### 集成内容

- **task 0**：leftover 清理后、task 1 preflight 之前插入；关闭时打 skip 提示让选项可见
- **参数对齐**：`SBX_IMAGE/EXECD/ROOTFS_SIZE/FC_VERSION` → `CHAIN_SOURCE_IMAGE/CHAIN_EXECD/CHAIN_ROOTFS_SIZE/FC_VERSION`，两个层级验证同一输入
- **工作目录**：chain-e2e 在 `$WORK/chain-e2e/`（firecracker 套件保留复用）；退出自清理
- **残留兜底**：chain-e2e 崩溃残留（`chain-e2e-minio` 容器、`fsb*` netns/桥/MASQUERADE、host :9000 占用）纳入 `up` 的 leftover 检测；`down` 检测到残留时自动执行 `firecracker-chain-e2e.sh --cleanup`；`--auto-clean` 失败路径同样覆盖
- **可观测**：`environment.txt` 记录 `chainE2e`、failure dump 带 `CHAIN_E2E`、失败信息指向三个组件日志

### 冲突面（已分析）

integration-env 的 MinIO 也发布 `127.0.0.1:9000`，但 task 0 在其之前运行、chain-e2e EXIT trap 自清理（容器/桥/netns/MASQUERADE/agent/jails），顺序执行无冲突；kind 网络上的 MinIO 为容器 IP，无宿主端口占用。

### 用法

```bash
sudo ./scripts/integration-env.sh up               # 原样（task 0 跳过）
sudo CHAIN_E2E=1 ./scripts/integration-env.sh up   # 组件链 E2E + 完整环境
sudo ./scripts/integration-env.sh down             # 含 chain 残留清理
```

### 验证

- `bash -n` 两脚本通过
- 文档同步：`firecracker-integration-env.md`（one-liner、§3 stage 顺序、env 表）、`firecracker-integration-environment.md`（步骤 10 任务清单）

> 注：完整运行需 KVM 参考主机（task 0 ~10 min；本机 macOS arm64 无法执行 KVM 场景）。