### PR TITLE
feat(agent): stage-2 P2P data plane via DART for artifact pulls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,3 +282,6 @@ generated/
 # Local E2E workspaces and helpers
 /.firecracker-chain-e2e/
 /.chain-e2e-gen/
+
+# stray agent binary built by ad-hoc go build
+/firecracker-runtime-agent

--- a/build/Dockerfile.firecracker-runtime-agent
+++ b/build/Dockerfile.firecracker-runtime-agent
@@ -1,7 +1,35 @@
 # firecracker-runtime-agent — node-level artifact cache + lease service for
 # the Firecracker on-demand loading chain (UDS JSON-over-HTTP API).
+#
+# The image also carries the DART P2P daemon (stage 2): the agent
+# orchestrates it as a child process serving the prefix cache API on the
+# loopback address. DART is built from a pinned upstream commit (zero
+# external dependencies, Apache-2.0); the pin is recorded in the image
+# label com.fast-sandbox.dart-rev and the version file below.
+
+ARG DART_REV=a85f39f13d81241b3d57f7f7fe7b7c84d58b7aa2
+
+# --- dart (P2P daemon, pinned) ------------------------------------------------
+FROM golang:1.25 AS dart-build
+
+ARG DART_REV
+
+RUN git init /src/dart \
+    && cd /src/dart \
+    && git remote add origin https://github.com/data-accelerator/dart \
+    && git fetch --depth 1 origin "$DART_REV" \
+    && git checkout --detach FETCH_HEAD \
+    && CGO_ENABLED=0 go build -o /out/dart ./cmd/dart
+
+# --- runtime image -----------------------------------------------------------
 FROM alpine:3.19
 RUN apk add --no-cache curl
+
+ARG DART_REV
+COPY --from=dart-build /out/dart /usr/local/bin/dart
+RUN echo "$DART_REV" > /usr/local/share/dart-rev
+LABEL com.fast-sandbox.dart-rev="$DART_REV"
+
 WORKDIR /workspace
 COPY .build/linux-amd64/firecracker-runtime-agent .
 

--- a/cmd/firecracker-runtime-agent/main.go
+++ b/cmd/firecracker-runtime-agent/main.go
@@ -9,13 +9,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"fast-sandbox/internal/registryconfig"
 	agentpull "fast-sandbox/internal/runtime/firecracker/agent"
+	agentdart "fast-sandbox/internal/runtime/firecracker/agent/dart"
 	agentserver "fast-sandbox/internal/runtime/firecracker/agent/server"
 	agentstate "fast-sandbox/internal/runtime/firecracker/agent/state"
 
@@ -31,6 +34,15 @@ const (
 )
 
 func main() {
+	if err := run(); err != nil {
+		klog.ErrorS(err, "firecracker-runtime-agent failed")
+		os.Exit(1)
+	}
+}
+
+// run assembles the agent. It returns an error when the agent cannot serve;
+// deferred cleanup (lease state close, DART child stop) runs on the way out.
+func run() error {
 	socketPath := getEnv("FAST_SANDBOX_RUNTIME_AGENT_SOCKET", defaultSocketPath)
 	storeRoot := getEnv("FAST_SANDBOX_ARTIFACT_STORE", "")
 	stateRoot := getEnv("FAST_SANDBOX_STATE_ROOT", defaultStateRoot)
@@ -41,40 +53,102 @@ func main() {
 	endpoint := getEnv("FAST_SANDBOX_ARTIFACT_ENDPOINT", "")
 
 	if storeRoot == "" {
-		klog.ErrorS(errors.New("missing store root"), "FAST_SANDBOX_ARTIFACT_STORE is required (s3://bucket/prefix)")
-		os.Exit(1)
+		return errors.New("FAST_SANDBOX_ARTIFACT_STORE is required (s3://bucket/prefix)")
 	}
 
 	registryProvider := registryconfig.NewFileProvider(registryPath)
 	credential, err := resolveCredential(registryProvider, storeRoot, endpoint)
 	if err != nil {
-		klog.ErrorS(err, "Failed to resolve the artifact store credential")
-		os.Exit(1)
+		return fmt.Errorf("resolve the artifact store credential: %w", err)
 	}
-	pull, err := agentpull.NewClient(storeRoot, credential)
+
+	// DART P2P gateway (stage 2). FAST_SANDBOX_DART_ADDR empty = local
+	// mode: artifact pulls stay on the direct header-signed S3 path.
+	// Non-empty = the node-local DART daemon is orchestrated as a child
+	// process and artifact bytes route through its prefix API as presigned
+	// URLs (with direct-S3 fallback when DART is unreachable).
+	dartAddr := getEnv("FAST_SANDBOX_DART_ADDR", "")
+	var pullOptions []agentpull.Option
+	var dartManager *agentdart.Manager
+	if dartAddr != "" {
+		listen, err := dartListenAddress(dartAddr)
+		if err != nil {
+			return err
+		}
+		peerPort := "9000"
+		config := agentdart.Config{
+			Binary:    getEnv("FAST_SANDBOX_DART_BIN", "dart"),
+			Listen:    listen,
+			Admin:     getEnv("FAST_SANDBOX_DART_ADMIN", "127.0.0.1:8147"),
+			CacheDir:  filepath.Join(stateRoot, "cache", "dart"),
+			CacheSize: getEnv("FAST_SANDBOX_DART_CACHE_SIZE", "20GiB"),
+			Discover:  getEnv("FAST_SANDBOX_DART_DISCOVER", ""),
+			// A stable identity (the node name; hostname works for
+			// hostNetwork daemons) anchors the HRW keyspace.
+			SelfID: getEnv("FAST_SANDBOX_DART_SELF_ID", hostnameOrEmpty()),
+			Log:    os.Stderr,
+		}
+		if nodeIP := getEnv("FAST_SANDBOX_NODE_IP", ""); nodeIP != "" {
+			config.PeerAdvertise = net.JoinHostPort(nodeIP, peerPort)
+		}
+		dartManager = agentdart.New(config)
+		pullOptions = append(pullOptions, agentpull.WithDART(dartAddr))
+		klog.InfoS("DART P2P gateway enabled", "addr", dartAddr,
+			"discover", config.Discover, "cacheDir", config.CacheDir, "peerAdvertise", config.PeerAdvertise)
+	}
+
+	pull, err := agentpull.NewClient(storeRoot, credential, pullOptions...)
 	if err != nil {
-		klog.ErrorS(err, "Failed to build the artifact pull client")
-		os.Exit(1)
+		return fmt.Errorf("build the artifact pull client: %w", err)
 	}
 	state, err := agentstate.New(stateRoot)
 	if err != nil {
-		klog.ErrorS(err, "Failed to open the lease state", "stateRoot", stateRoot)
-		os.Exit(1)
+		return fmt.Errorf("open the lease state: %w", err)
 	}
 	defer func() { _ = state.Close() }()
 
-	service := agentserver.NewService(pull, state, stateRoot)
+	serviceOptions := []agentserver.ServiceOption{}
+	if dartManager != nil {
+		serviceOptions = append(serviceOptions, agentserver.WithDARTProbe(dartManager.Healthy))
+	}
+	service := agentserver.NewService(pull, state, stateRoot, serviceOptions...)
 	server := agentserver.New(service, socketPath)
 	klog.InfoS("firecracker-runtime-agent starting",
-		"socket", socketPath, "store", storeRoot, "stateRoot", stateRoot, "registry", registryPath)
+		"socket", socketPath, "store", storeRoot, "stateRoot", stateRoot,
+		"registry", registryPath, "dart", dartAddr)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
+	if dartManager != nil {
+		go func() {
+			if err := dartManager.Run(ctx); err != nil {
+				klog.ErrorS(err, "DART supervisor stopped with an error")
+			}
+		}()
+	}
 	if err := server.Serve(ctx); err != nil && !errors.Is(err, context.Canceled) {
-		klog.ErrorS(err, "firecracker-runtime-agent stopped")
-		os.Exit(1)
+		return err
 	}
 	klog.InfoS("firecracker-runtime-agent stopped")
+	return nil
+}
+
+// dartListenAddress derives the DART client-plane listen address from the
+// FAST_SANDBOX_DART_ADDR base (http://127.0.0.1:8145 -> 127.0.0.1:8145).
+func dartListenAddress(dartAddr string) (string, error) {
+	parsed, err := url.Parse(dartAddr)
+	if err != nil || parsed.Host == "" || parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("invalid FAST_SANDBOX_DART_ADDR %q: expected http://host:port", dartAddr)
+	}
+	return parsed.Host, nil
+}
+
+func hostnameOrEmpty() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	return hostname
 }
 
 // resolveCredential matches the store endpoint host against the compiled

--- a/cmd/firecracker-runtime-agent/main.go
+++ b/cmd/firecracker-runtime-agent/main.go
@@ -76,12 +76,17 @@ func run() error {
 		if err != nil {
 			return err
 		}
-		// A stable identity (the node name; hostname works for hostNetwork
-		// daemons) anchors the HRW keyspace AND names the per-node block
-		// cache: the StateRoot can be shared (multi-node kind mounts one
-		// host filesystem into every node container), but two DART arenas
-		// must never point at the same directory.
-		nodeID := getEnv("FAST_SANDBOX_DART_SELF_ID", hostnameOrEmpty())
+		// A stable identity anchors the HRW keyspace AND names the per-node
+		// block cache: the StateRoot can be shared (multi-node kind mounts
+		// one host filesystem into every node container), but two DART
+		// arenas must never point at the same directory. The node's
+		// hostname is read from /etc/hostname (mounted from the node by the
+		// DaemonSet) because a regular pod's own hostname is its pod name,
+		// which changes on restart.
+		nodeID := getEnv("FAST_SANDBOX_DART_SELF_ID", "")
+		if nodeID == "" {
+			nodeID = nodeHostID()
+		}
 		peerPort := "9000"
 		config := agentdart.Config{
 			Binary:    getEnv("FAST_SANDBOX_DART_BIN", "dart"),
@@ -146,6 +151,19 @@ func dartListenAddress(dartAddr string) (string, error) {
 		return "", fmt.Errorf("invalid FAST_SANDBOX_DART_ADDR %q: expected http://host:port", dartAddr)
 	}
 	return parsed.Host, nil
+}
+
+// nodeHostID derives the stable node identity: the node hostname file
+// (FAST_SANDBOX_HOSTNAME_FILE, mounted from the node by the DaemonSet),
+// falling back to the process hostname.
+func nodeHostID() string {
+	path := getEnv("FAST_SANDBOX_HOSTNAME_FILE", "/etc/hostname")
+	if payload, err := os.ReadFile(path); err == nil {
+		if name := strings.TrimSpace(string(payload)); name != "" {
+			return name
+		}
+	}
+	return hostnameOrEmpty()
 }
 
 func hostnameOrEmpty() string {

--- a/cmd/firecracker-runtime-agent/main.go
+++ b/cmd/firecracker-runtime-agent/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"fast-sandbox/internal/registryconfig"
@@ -75,18 +76,22 @@ func run() error {
 		if err != nil {
 			return err
 		}
+		// A stable identity (the node name; hostname works for hostNetwork
+		// daemons) anchors the HRW keyspace AND names the per-node block
+		// cache: the StateRoot can be shared (multi-node kind mounts one
+		// host filesystem into every node container), but two DART arenas
+		// must never point at the same directory.
+		nodeID := getEnv("FAST_SANDBOX_DART_SELF_ID", hostnameOrEmpty())
 		peerPort := "9000"
 		config := agentdart.Config{
 			Binary:    getEnv("FAST_SANDBOX_DART_BIN", "dart"),
 			Listen:    listen,
 			Admin:     getEnv("FAST_SANDBOX_DART_ADMIN", "127.0.0.1:8147"),
-			CacheDir:  filepath.Join(stateRoot, "cache", "dart"),
-			CacheSize: getEnv("FAST_SANDBOX_DART_CACHE_SIZE", "20GiB"),
+			CacheDir:  filepath.Join(stateRoot, "cache", "dart-"+strings.ReplaceAll(nodeID, "/", "-")),
+			CacheSize: getEnv("FAST_SANDBOX_DART_CACHE_SIZE", "8GiB"),
 			Discover:  getEnv("FAST_SANDBOX_DART_DISCOVER", ""),
-			// A stable identity (the node name; hostname works for
-			// hostNetwork daemons) anchors the HRW keyspace.
-			SelfID: getEnv("FAST_SANDBOX_DART_SELF_ID", hostnameOrEmpty()),
-			Log:    os.Stderr,
+			SelfID:    nodeID,
+			Log:       os.Stderr,
 		}
 		if nodeIP := getEnv("FAST_SANDBOX_NODE_IP", ""); nodeIP != "" {
 			config.PeerAdvertise = net.JoinHostPort(nodeIP, peerPort)

--- a/config/dev/agent-daemonset.yaml
+++ b/config/dev/agent-daemonset.yaml
@@ -32,7 +32,13 @@ spec:
     spec:
       nodeSelector:
         fast-sandbox.io/firecracker-node: "true"
-      hostNetwork: true
+      # The agent runs on the cluster network (NOT hostNetwork): its dart
+      # child needs the cluster DNS (CoreDNS search domains) to resolve the
+      # headless Service peers. It talks to fastlets over the shared UDS
+      # hostPath and to MinIO over the cluster network, so no host network
+      # capability is required. The node hostname file is mounted read-only
+      # for the stable HRW self-id (hostNetwork used to provide it via the
+      # node UTS namespace; a regular pod's hostname is its pod name).
       containers:
       - name: agent
         image: fast-sandbox/firecracker-runtime-agent:dev
@@ -63,11 +69,12 @@ spec:
         - name: FAST_SANDBOX_DART_ADDR
           value: http://127.0.0.1:8145
         # Peer discovery via the headless Service (config/dev/dart-service.yaml);
-        # the agent falls back to direct S3 when DART is unreachable.
+        # the FQDN resolves on the cluster network. The agent falls back to
+        # direct S3 when DART is unreachable.
         - name: FAST_SANDBOX_DART_DISCOVER
-          value: dns:dart.fast-sandbox-system.svc:9000
-        # hostNetwork pods share the node network: podIP == node IP and the
-        # hostname is the node's, so HRW self-id stays stable across restarts.
+          value: dns:dart.fast-sandbox-system.svc.cluster.local:9000
+        # Regular pods get their own cluster IP; the dart peer-listen binds
+        # it and the headless Service hands it out to peers.
         - name: FAST_SANDBOX_NODE_IP
           valueFrom:
             fieldRef:
@@ -88,6 +95,9 @@ spec:
         - name: agent-registry
           mountPath: /etc/fast-sandbox/agent
           readOnly: true
+        - name: node-hostname
+          mountPath: /etc/hostname
+          readOnly: true
       volumes:
       - name: agent-socket
         hostPath:
@@ -100,3 +110,9 @@ spec:
       - name: agent-registry
         secret:
           secretName: fast-sandbox-agent-registry
+      # The stable node identity for the HRW keyspace (hostNetwork used to
+      # provide it through the node UTS namespace).
+      - name: node-hostname
+        hostPath:
+          path: /etc/hostname
+          type: File

--- a/config/dev/agent-daemonset.yaml
+++ b/config/dev/agent-daemonset.yaml
@@ -56,6 +56,22 @@ spec:
           value: /var/lib/fast-sandbox/firecracker
         - name: FAST_SANDBOX_REGISTRY_CONFIG_PATH
           value: /etc/fast-sandbox/agent/registry.json
+        # DART P2P gateway (stage 2): non-empty enables the node-local DART
+        # child process and routes artifact pulls through its prefix API.
+        # The image carries the pinned dart binary; see
+        # build/Dockerfile.firecracker-runtime-agent.
+        - name: FAST_SANDBOX_DART_ADDR
+          value: http://127.0.0.1:8145
+        # Peer discovery via the headless Service (config/dev/dart-service.yaml);
+        # the agent falls back to direct S3 when DART is unreachable.
+        - name: FAST_SANDBOX_DART_DISCOVER
+          value: dns:dart.fast-sandbox-system.svc:9000
+        # hostNetwork pods share the node network: podIP == node IP and the
+        # hostname is the node's, so HRW self-id stays stable across restarts.
+        - name: FAST_SANDBOX_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         securityContext:
           privileged: true
         readinessProbe:

--- a/config/dev/dart-service.yaml
+++ b/config/dev/dart-service.yaml
@@ -1,0 +1,30 @@
+# dart-service.yaml — headless Service backing DART peer discovery.
+#
+# The node-local DART daemons discover each other via DNS seeding
+# (dns:dart.<namespace>.svc:9000): each instance resolves the Service to the
+# agent pod IPs (hostNetwork pods: podIP == node IP), contacts one seed, and
+# learns the rest of the roster over the peer connections. clusterIP: None
+# makes the DNS answer the ready pod IPs instead of a stable virtual IP —
+# discovery needs addresses, not load balancing.
+#
+# Apply with the agent DaemonSet:
+#   kubectl apply -f config/dev/dart-service.yaml
+#   kubectl apply -f config/dev/agent-daemonset.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: dart
+  namespace: fast-sandbox-system
+  labels:
+    app: fast-sandbox
+    component: firecracker-runtime-agent
+spec:
+  clusterIP: None
+  selector:
+    app: fast-sandbox
+    component: firecracker-runtime-agent
+  ports:
+  - name: peer
+    port: 9000
+    targetPort: 9000
+    protocol: TCP

--- a/config/dev/kind-firecracker.yaml
+++ b/config/dev/kind-firecracker.yaml
@@ -1,13 +1,21 @@
-# kind-firecracker.yaml — single-node Kind cluster with the host devices the
-# Firecracker runtime needs, passed through into the node container:
-# KVM (vmm) and /dev/net/tun (tap devices). vhost-vsock is intentionally NOT
-# mounted: the firecracker driver probes only /dev/kvm and /dev/net/tun, and
-# hosts without a vhost-vsock device fail kind create when docker tries to
-# create the mount source under /sys.
+# kind-firecracker.yaml — two-node Kind cluster (P2P is the standard
+# topology) with the host devices the Firecracker runtime needs, passed
+# through into every node container: KVM (vmm) and /dev/net/tun (tap
+# devices). vhost-vsock is intentionally NOT mounted: the firecracker
+# driver probes only /dev/kvm and /dev/net/tun, and hosts without a
+# vhost-vsock device fail kind create when docker tries to create the mount
+# source under /sys.
+#
+# Two nodes are required for the P2P assertions: each node runs its own
+# runtime-agent + DART daemon, and the second node's warm pull must be
+# served by the first node's peer (origin fetched ~once for the cluster).
+# The StateRoot host mount is shared by both node containers (single XFS
+# loop image on the host); the DART block caches stay per-node because the
+# agent keys them by hostname (<state>/cache/dart-<hostname>).
 #
 # Usage: kind create cluster --config config/dev/kind-firecracker.yaml
-# Then label the node (required by the SandboxTemplate builder and the
-# fastlet scheduling):
+# Then label the nodes (required by the SandboxTemplate builder and the
+# fastlet scheduling; integration-env.sh up does this):
 #   kubectl label node <node> sandbox.fast.io/kvm=true
 #   kubectl label node <node> fast-sandbox.io/firecracker-node=true
 #
@@ -36,5 +44,17 @@ nodes:
   # reflinks (~ms) instead of full copies (~2.5s on ext4). The host mount
   # must exist before `kind create`; the path is also used without XFS when
   # XFS_STATEROOT=0 (plain directory).
+  - hostPath: /var/lib/fast-sandbox
+    containerPath: /var/lib/fast-sandbox
+- role: worker
+  extraMounts:
+  - hostPath: /dev/kvm
+    containerPath: /dev/kvm
+  - hostPath: /sys/devices/virtual/misc/kvm
+    containerPath: /sys/devices/virtual/misc/kvm
+  - hostPath: /dev/net/tun
+    containerPath: /dev/net/tun
+  - hostPath: /dev/shm
+    containerPath: /dev/shm
   - hostPath: /var/lib/fast-sandbox
     containerPath: /var/lib/fast-sandbox

--- a/config/samples/pool-firecracker.yaml
+++ b/config/samples/pool-firecracker.yaml
@@ -50,6 +50,21 @@ spec:
           type: DirectoryOrCreate
       nodeSelector:
         fast-sandbox.io/firecracker-node: "true"
+      # P2P is the standard topology: the pool keeps ONE fastlet per node
+      # (podAntiAffinity spreads the poolMin=2 fastlets across the two
+      # firecracker nodes), so the warmImages preheat on each node pulls
+      # through the node-local DART peer of the OTHER node — the second
+      # pull is the P2P event the stage-2 assertions measure. On a single
+      # node this is a no-op (only one eligible node exists).
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: sandbox-fastlet
+              topologyKey: kubernetes.io/hostname
   capacity:
     poolMin: 2
     poolMax: 2

--- a/docs/guides/firecracker-integration-env.md
+++ b/docs/guides/firecracker-integration-env.md
@@ -267,7 +267,7 @@ Baseline on the reference node (XFS StateRoot):
 | `KIND_CLUSTER` / `KIND_NODE_IMAGE` / `KIND_RETAIN` | firecracker / - / 0 | kind knobs; mirror override, retain-for-debug |
 | `MINIO_PORT` / `MINIO_AK` / `MINIO_SK` / `MINIO_ENDPOINT` | 9000 / ... | store credentials; endpoint auto = container IP |
 | `SBX_IMAGE` / `EXECD` / `FC_VERSION` | alpine:3.19 / execd:1.1.0 / v1.16.1 | the chain keys |
-| `WARM_IMAGES` | 1 | 0 skips the pool warmImages preheat: the agent cache starts empty and the first sandbox create pulls the artifact set on demand through DART (stage-2 cold-start scenario; verify then measures the cold pull in the delivery path) |
+| `WARM_IMAGES` | 0 | on-demand is standard: no pool preheat, the first sandbox create on each node pulls the artifact set through DART (peer distribution across the two nodes), evidenced in verify 4. 1 restores the preheat for fast delivery baselines |
 | `CONCURRENCY` | 5 | per-fastlet slot capacity for the batch |
 | `EXECD_API_SBX` | sandbox-execd-api | sandbox name used by `verify-execd-api` |
 | `EXECD_API_KEEP_SANDBOX` | 0 | 1 keeps the sandbox + jail after the battery and prints the guest-console (firecracker.log) tail command for execd-side diagnosis |

--- a/docs/guides/firecracker-integration-env.md
+++ b/docs/guides/firecracker-integration-env.md
@@ -267,6 +267,7 @@ Baseline on the reference node (XFS StateRoot):
 | `KIND_CLUSTER` / `KIND_NODE_IMAGE` / `KIND_RETAIN` | firecracker / - / 0 | kind knobs; mirror override, retain-for-debug |
 | `MINIO_PORT` / `MINIO_AK` / `MINIO_SK` / `MINIO_ENDPOINT` | 9000 / ... | store credentials; endpoint auto = container IP |
 | `SBX_IMAGE` / `EXECD` / `FC_VERSION` | alpine:3.19 / execd:1.1.0 / v1.16.1 | the chain keys |
+| `WARM_IMAGES` | 1 | 0 skips the pool warmImages preheat: the agent cache starts empty and the first sandbox create pulls the artifact set on demand through DART (stage-2 cold-start scenario; verify then measures the cold pull in the delivery path) |
 | `CONCURRENCY` | 5 | per-fastlet slot capacity for the batch |
 | `EXECD_API_SBX` | sandbox-execd-api | sandbox name used by `verify-execd-api` |
 | `EXECD_API_KEEP_SANDBOX` | 0 | 1 keeps the sandbox + jail after the battery and prints the guest-console (firecracker.log) tail command for execd-side diagnosis |

--- a/docs/guides/firecracker-integration-env.md
+++ b/docs/guides/firecracker-integration-env.md
@@ -10,13 +10,19 @@
 ## 1. What this environment is
 
 A bare-metal KVM host running the full fast-sandbox Firecracker chain with
-one command:
+one command. **P2P is the standard data plane**: the kind cluster carries
+TWO nodes, every node runs a runtime-agent with a node-local DART daemon,
+and artifact pulls are on-demand (no preheat) — the first sandbox create
+on each node pulls the golden snapshot set through DART, with the second
+node served by the first node's peer instead of the origin.
 
 ```
 SandboxTemplate (builder Pod, in-cluster)
   → golden snapshot published to MinIO
-  → node runtime-agent (DaemonSet) pulls + caches
-  → SandboxPool schedules fastlet Pods (×2, 5 slots each)
+  → node runtime-agent (DaemonSet ×2) — dart child per node
+  → on-demand PinImage at the first sandbox create (presign → DART:
+     cache → peer → origin; origin fetched ≈ once per 4MiB block)
+  → SandboxPool schedules fastlet Pods (×2, one per node, 5 slots each)
   → per-sandbox Firecracker VM restore (jailer --netns, shared snapshot)
   → execd :44772 /ping verified end-to-end (direct fastlet-proxy route)
 ```
@@ -24,11 +30,14 @@ SandboxTemplate (builder Pod, in-cluster)
 One-liners:
 
 ```bash
-./scripts/integration-env.sh up        # full environment (tasks 1-8)
-./scripts/integration-env.sh verify    # 2 + 5 sandboxes, proxy-chain probe, teardown asserts
-./scripts/integration-env.sh status    # component / template / pool health
+./scripts/integration-env.sh up        # two-node env + DART (tasks 1-8)
+./scripts/integration-env.sh verify    # 2 + 5 sandboxes; verify 4 = P2P evidence
+./scripts/integration-env.sh status    # component health + dart block_source counters
 ./scripts/integration-env.sh down      # host left clean
 ```
+
+`KIND_SINGLE=1` falls back to one node (cache-only, no peer traffic);
+`WARM_IMAGES=1` restores the preheat for fast delivery baselines.
 
 `up` and the plain `verify` only prove execd `/ping` delivery. For execd
 **protocol** usability in the guest (OpenSandbox issue #1695: `POST
@@ -53,16 +62,20 @@ root-cause read) or `NOT REPRODUCED` (API fully usable).
 |---|---|---|---|
 | MinIO | host Docker container | host | on the kind network (container IP = endpoint); publish + pull credentials |
 | controller | Deployment (1 replica) | control plane | CRDs + RBAC + route-keys; Fast-Path gRPC :9090 |
-| builder Pod | Job (on-demand) | KVM-labeled node | /dev/kvm, /dev/net/tun, self-mknod loop devices, publish creds |
-| runtime installer | DaemonSet (per-node) | firecracker-node | installs firecracker v1.16.1 + jailer + kernel → hostPath |
-| runtime-agent | DaemonSet (per-node) | firecracker-node | UDS socket + StateRoot shared with fastlets; MinIO pull creds |
-| fastlet Pod | pool-managed Pod ×2 | firecracker-node | profile hostPaths auto-injected; agent socket; registry plan |
+| builder Pod | Job (on-demand) | either KVM node | /dev/kvm, /dev/net/tun, self-mknod loop devices, publish creds |
+| runtime installer | DaemonSet (per-node) | firecracker-node ×2 | installs firecracker v1.16.1 + jailer + kernel → hostPath |
+| runtime-agent | DaemonSet (per-node) | firecracker-node ×2 | **cluster network** (not hostNetwork); UDS socket + StateRoot shared with fastlets; MinIO pull creds; orchestrates the dart child |
+| DART daemon | agent child process ×2 | inside each agent | prefix cache API :8145 (loopback), admin/metrics :8147, peer :9000 (pod IP); cache `cache/dart-<node>` under the shared StateRoot |
+| fastlet Pod | pool-managed Pod ×2 | one per node (anti-affinity) | profile hostPaths auto-injected; agent socket; registry plan |
 | firecracker VM | per-sandbox microVM | inside fastlet netns | golden restore, guest eth0 172.30.0.3, execd :44772 |
 | verify CLI | host binaries | host | fastctl + gen-endpoint + port-forwards |
 
 Node labels: `sandbox.fast.io/kvm=true` (builder, hardcoded by the
 SandboxTemplate controller) and `fast-sandbox.io/firecracker-node=true`
-(installer / agent / fastlet affinity).
+(installer / agent / fastlet affinity). On multi-node kind the
+control-plane taint is removed by `up` so every workload can schedule on
+both nodes — without it the P2P topology would strand one node and no peer
+traffic could ever happen.
 
 ## 3. What `up` actually does (stage order matters)
 
@@ -71,7 +84,9 @@ SandboxTemplate controller) and `fast-sandbox.io/firecracker-node=true`
 3. **images** — `make images` for 7 images + host `fastctl`/`gen-endpoint`.
 4. **XFS StateRoot** — sparse loop image mounted at `/var/lib/fast-sandbox`,
    reflink probe, **before** `kind create` (the node bind-mounts it).
-5. **kind cluster** — KVM/tun/shm passthrough; node labels.
+5. **kind cluster** — TWO nodes with KVM/tun/shm/StateRoot passthrough;
+   labels applied on every node; control-plane taint removed (both nodes
+   schedulable). `KIND_SINGLE=1` strips the worker (cache-only).
 6. **MinIO** — on the kind network (container IP), not the host gateway:
    docker-proxy reachability from the kind bridge is unreliable.
 7. **credentials** — publish secret (builder), agent registry.json (pull),
@@ -80,10 +95,15 @@ SandboxTemplate controller) and `fast-sandbox.io/firecracker-node=true`
 9. **installer** — binaries land before fastlet pods start (hostPath File
    mounts fail otherwise).
 10. **agent** — readiness = POST /v1/health with a real podUID (read routes
-    are POST-only and validate caller identity).
+    are POST-only and validate caller identity); per node: dart admin
+    `/healthz`, agent health `dartUp:true`, and the DART **roster** must
+    converge to all agent pods (DNS discovery via the headless Service).
 11. **template build** — builder Pod → publish → manifest assertions
     (index/manifest/artifactDigest/sizeBytes/guestNetwork).
-12. **pool** — 2 fastlet pods (poolMin=2), warmImages Cached on both.
+12. **pool** — 2 fastlet pods (poolMin=2, podAntiAffinity spreads them one
+    per node). Default **on-demand** (no warmImages): the first sandbox
+    create on each node pulls through DART. `WARM_IMAGES=1` preheats both
+    nodes and captures the same P2P evidence at `up` time.
 
 ## 4. Verification and the delivery baseline
 
@@ -121,6 +141,51 @@ Baseline on the reference node (XFS StateRoot):
 - `queue-to-probe` grows under sequential batch probing: it is the probe
   order, not system latency.
 
+### 4.1 On-demand loading and the P2P evidence (stage 2)
+
+The default flow is **on-demand** (`WARM_IMAGES=0`): the agent cache starts
+empty and the first sandbox create on each node triggers the pull. The
+firecracker driver asks the node runtime-agent for the image at create time
+(`PinImage` proxy) when the local cache misses — a create never fails with
+"image not ready" without trying the pull first. Artifact bytes flow
+`agent → presign → GET <dart>/dart/<url>`; DART serves from its block
+cache, then its peers, and only then the origin.
+
+`verify` ends with **stage 4 — P2P evidence**, read from each node's DART
+admin plane (`dart_block_source_total{source="cache|peer|origin"}`):
+
+- every node that served traffic contributed to a cluster total;
+- the cluster origin counter must equal the published artifact set's block
+  count (±4): rootfs/vmstate/memory pulled once per 4MiB block, not once
+  per node;
+- with ≥2 active nodes the peer counter must be > 0 (the second node's
+  pull came from the first node's DART, not the store).
+
+Reference result on the test host (alpine:3.19 golden set, 897 blocks):
+
+```text
+p2p evidence (verify delivery): expected origin=897 blocks;
+  cluster origin=897 peer=513 cache=0 active-nodes=2
+```
+
+- `origin=897` — the S3 store was fetched exactly once per block across
+  both nodes;
+- `peer=513` — 57% of the second node's cold pull was served by the first
+  node's DART peer;
+- `cache=0` is expected in this flow: each block passes through DART once
+  on its way to the agent's committed cache (origin), and later sandboxes
+  read the committed files, not DART blocks again. DART cache counters
+  only move when a block is re-read through the gateway (e.g. after a
+  cache purge).
+
+Delivery timing with on-demand loading (two nodes, XFS StateRoot):
+
+- first create on a node: run RPC ≈ 80-100 s — the cold pull of the
+  3.6 GiB set plus the ~33 ms restore. Subsequent creates on the same
+  node are unaffected (committed agent cache): run RPC ≈ 53-66 ms.
+- `verify 1` therefore takes ~1.5-2 min once per environment; every later
+  `verify` run is sub-10 s until `down` purges the caches.
+
 ## 5. Key implementation decisions (learned the hard way)
 
 - **MinIO joins the kind network**; endpoint = container IP. The kind
@@ -154,7 +219,28 @@ Baseline on the reference node (XFS StateRoot):
   must be pre-sized (`poolMin=2`) for the 7-sandbox batch.
 - **warm-pull idempotency is per-fastlet**: two fastlets warming the same
   image collided in the agent journal ("request id committed by pod X");
-  the key is now `warm-pull-<podUID>-<image-sha>`.
+  the key is now `warm-pull-<podUID>-<image-sha>`. On-demand creates reuse
+  the same pod-scoped key, so concurrent/replayed creates and warm pulls
+  dedupe in the agent journal instead of double-pulling.
+- **Control-plane taint strands the P2P topology**: multi-node kind keeps
+  `node-role.kubernetes.io/control-plane:NoSchedule`, which silently
+  concentrated every workload on the worker — `active-nodes=1` in the P2P
+  evidence was the tell. `up` removes the taint so agent/fastlet/builder
+  schedule on both nodes.
+- **The agent must not use hostNetwork**: its dart child discovers peers
+  through the cluster DNS; the hostNetwork pod resolved the headless
+  Service against the node's resolv.conf ("server misbehaving" from docker
+  DNS) and the roster never converged. The agent now runs on the cluster
+  network and resolves the Service FQDN.
+- **A normal pod's hostname is its pod name**: the stable HRW identity
+  (and the per-node dart cache directory name) comes from the node's
+  `/etc/hostname`, mounted into the agent DaemonSet. hostNetwork used to
+  provide it through the node UTS namespace.
+- **Creates do not pin; warm pulls pin once**: a cached image never
+  touches the agent at create time, so every `DeleteSandbox` unpin keeps
+  the reference count balanced (the pod-level warm pull is the single
+  pin). A cold create pulls with the pod-scoped warm key and still only
+  accounts for that one pin.
 - **The first request after a snapshot resume takes ~0.5-1 s** even though
   the VM and execd resume in ~33 ms: the guest's network stack needs a
   settle window before serving. A gateway-ARP refresh (raw-socket announce)
@@ -219,6 +305,17 @@ Baseline on the reference node (XFS StateRoot):
 - The agent is **per-node**; a node's cache is single-copy (PinImage
   dedup). The agent socket + StateRoot hostPath must be mounted
   identically in the agent DaemonSet and every fastlet.
+- **DART peers ride the cluster network**: the agent runs without
+  hostNetwork so the dart child can resolve the headless Service; the
+  peer listen binds the pod IP (`status.podIP`) and peers reach each
+  other across nodes through the CNI. The DART admin/metrics plane binds
+  the pod loopback and is unauthenticated — it belongs inside the cluster
+  trust domain (upstream model).
+- **DART block caches are per node, even on a shared StateRoot**: two node
+  containers may mount the same host filesystem (kind), but two arenas
+  must never share a directory — the agent keys the cache by node
+  (`<stateRoot>/cache/dart-<node-hostname>`). `down` purges the whole
+  `cache/` tree.
 
 ### 6.6 Control plane behavior to know
 - **fastpath fast-path rejects, never queues**: a full pool →
@@ -251,6 +348,12 @@ Baseline on the reference node (XFS StateRoot):
 - The store endpoint must be reachable from: builder Pod, agent DaemonSet
   (both in-cluster) — a host-side MinIO needs the same routing story as the
   kind-network container-IP trick.
+- The agent hands DART **presigned** origin URLs (SigV4 query signing, ~1 h
+  TTL); the access key pair never leaves the agent. The presigned signature
+  is validated server-side by real MinIO/OSS in the live checks
+  (`internal/runtime/firecracker/agent/live_minio_test.go`,
+  `FS_LIVE_MINIO_*` env) and end-to-end in every `up` (the origin counter
+  moving exactly once per block is itself signature evidence).
 
 ### 6.9 Logging & failure forensics
 - Every stage writes `$WORK/logs/`; failures dump component logs to
@@ -264,7 +367,7 @@ Baseline on the reference node (XFS StateRoot):
 | Variable | Default | Meaning |
 |---|---|---|
 | `WORK` | `$PWD/.integration-env` | workspace + logs |
-| `KIND_CLUSTER` / `KIND_NODE_IMAGE` / `KIND_RETAIN` | firecracker / - / 0 | kind knobs; mirror override, retain-for-debug |
+| `KIND_CLUSTER` / `KIND_NODE_IMAGE` / `KIND_RETAIN` / `KIND_SINGLE` | firecracker / - / 0 / 0 | kind knobs; mirror override, retain-for-debug; 1 = single node (no worker, no peer traffic) |
 | `MINIO_PORT` / `MINIO_AK` / `MINIO_SK` / `MINIO_ENDPOINT` | 9000 / ... | store credentials; endpoint auto = container IP |
 | `SBX_IMAGE` / `EXECD` / `FC_VERSION` | alpine:3.19 / execd:1.1.0 / v1.16.1 | the chain keys |
 | `WARM_IMAGES` | 0 | on-demand is standard: no pool preheat, the first sandbox create on each node pulls the artifact set through DART (peer distribution across the two nodes), evidenced in verify 4. 1 restores the preheat for fast delivery baselines |
@@ -272,5 +375,5 @@ Baseline on the reference node (XFS StateRoot):
 | `EXECD_API_SBX` | sandbox-execd-api | sandbox name used by `verify-execd-api` |
 | `EXECD_API_KEEP_SANDBOX` | 0 | 1 keeps the sandbox + jail after the battery and prints the guest-console (firecracker.log) tail command for execd-side diagnosis |
 | `DEBUG_PROBE` | 0 | print every probe attempt (resolve/host/curl code) for the batch window |
-| `XFS_STATEROOT` / `XFS_SIZE` | 1 / 16G | reflink layer on/off, virtual size |
+| `XFS_STATEROOT` / `XFS_SIZE` | 1 / 24G | reflink layer on/off, virtual size (24G default fits two nodes' caches) |
 | `SKIP_TOOL_INSTALL` / `SKIP_LEFTOVER_CLEAN` | 0 | manual tooling / refuse auto-rebuild |

--- a/internal/runtime/firecracker/agent/cache.go
+++ b/internal/runtime/firecracker/agent/cache.go
@@ -118,8 +118,9 @@ func cacheComplete(dir string) (bool, error) {
 // digest: an existing matching file is skipped (resume semantics), a
 // mismatching file is deleted and re-pulled, and the download lands in a
 // temporary file that is renamed into place only after the whole content
-// verifies.
-func stageFile(ctx context.Context, s3 *s3Client, dir, storeKey string, file nativeFile) error {
+// verifies. The object is fetched through the client, which routes artifact
+// bytes over DART when configured (falling back to direct S3).
+func stageFile(ctx context.Context, c *Client, dir, storeKey string, file nativeFile) error {
 	target := filepath.Join(dir, file.cache)
 	match, err := fileMatches(target, file)
 	if err == nil && match {
@@ -136,7 +137,7 @@ func stageFile(ctx context.Context, s3 *s3Client, dir, storeKey string, file nat
 		return err
 	}
 
-	body, err := s3.get(ctx, storeKey)
+	body, err := c.getArtifact(ctx, storeKey)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/firecracker/agent/dart/manager.go
+++ b/internal/runtime/firecracker/agent/dart/manager.go
@@ -1,0 +1,309 @@
+// Package dart supervises the node-local DART P2P daemon that backs the
+// stage-2 artifact data plane. DART runs as an independent process inside
+// the runtime-agent container (it cannot be imported: its code lives under
+// internal/ upstream), speaking the prefix HTTP API
+// (GET /dart/<presigned-s3-url>) on the loopback address and serving
+// peer-to-peer distribution on the node address.
+//
+// The manager owns the child lifecycle end to end: start, admin-plane
+// health probing, crash restart with exponential backoff, and graceful
+// shutdown (SIGTERM, bounded wait, then kill). A broken DART never fails
+// the agent: the pull client treats it as an opaque gateway and falls back
+// to the direct S3 path, and agent UDS health stays green with DartUp
+// reporting the daemon state.
+package dart
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultBinary     = "dart"
+	defaultListen     = "127.0.0.1:8145" // client plane (agent pulls)
+	defaultAdmin      = "127.0.0.1:8147" // admin plane (/healthz, /metrics)
+	defaultPeerListen = ":9000"          // peer block server (node address)
+	defaultCacheSize  = "20GiB"
+
+	// restartBackoffBase is the first delay before a crash restart; the
+	// delay doubles on every consecutive crash up to restartBackoffMax.
+	restartBackoffBase = time.Second
+	restartBackoffMax  = 30 * time.Second
+
+	gracefulStopTimeout = 5 * time.Second
+	healthProbeInterval = 2 * time.Second
+	healthProbeTimeout  = time.Second
+)
+
+// Config describes the DART child process. All paths and addresses may be
+// empty to take the defaults.
+type Config struct {
+	// Binary is the DART executable ("" = "dart" from PATH).
+	Binary string
+	// Listen is the client-plane listen address ("" = 127.0.0.1:8145), the
+	// address the pull client's WithDART base points at.
+	Listen string
+	// Admin is the admin-plane address serving /healthz and /metrics
+	// ("" = 127.0.0.1:8147). A full URL (http://host:port) is also
+	// accepted for tests.
+	Admin string
+	// PeerListen is the peer block-server listen address ("" = :9000).
+	PeerListen string
+	// PeerAdvertise is the advertise address peers connect back to
+	// (nodeIP:9000); empty omits the flag.
+	PeerAdvertise string
+	// SelfID is the stable node identity HRW placement is derived from
+	// (the node name); empty omits the flag.
+	SelfID string
+	// Discover seeds peer discovery (e.g. dns:dart.<ns>.svc:9000); empty
+	// omits the flag (single-node mode: cache only, no P2P).
+	Discover string
+	// CacheDir is the block cache directory under the StateRoot.
+	CacheDir string
+	// CacheSize bounds the block cache ("" = 20GiB).
+	CacheSize string
+	// Log receives the child's stdout/stderr (defaults to io.Discard).
+	Log io.Writer
+}
+
+// Manager supervises one DART child process.
+type Manager struct {
+	config Config
+	log    io.Writer
+	logMu  sync.Mutex // serializes manager logs and child output
+
+	mu         sync.Mutex
+	cmd        *exec.Cmd
+	startCount int
+	healthy    atomic.Bool
+	backoff    time.Duration
+}
+
+// New assembles the supervisor for config.
+func New(config Config) *Manager {
+	if config.Binary == "" {
+		config.Binary = defaultBinary
+	}
+	if config.Listen == "" {
+		config.Listen = defaultListen
+	}
+	if config.Admin == "" {
+		config.Admin = defaultAdmin
+	}
+	if config.PeerListen == "" {
+		config.PeerListen = defaultPeerListen
+	}
+	if config.CacheSize == "" {
+		config.CacheSize = defaultCacheSize
+	}
+	if config.Log == nil {
+		config.Log = io.Discard
+	}
+	return &Manager{config: config, log: config.Log}
+}
+
+// Args returns the DART command-line arguments the manager builds.
+func (m *Manager) Args() []string {
+	args := []string{
+		"-listen=" + m.config.Listen,
+		"-admin=" + m.config.Admin,
+		"-peer-listen=" + m.config.PeerListen,
+		"-cache-dir=" + m.config.CacheDir,
+		"-cache-size=" + m.config.CacheSize,
+	}
+	if m.config.PeerAdvertise != "" {
+		args = append(args, "-peer-advertise="+m.config.PeerAdvertise)
+	}
+	if m.config.SelfID != "" {
+		args = append(args, "-self-id="+m.config.SelfID)
+	}
+	if m.config.Discover != "" {
+		args = append(args, "-discover="+m.config.Discover)
+	}
+	return args
+}
+
+// StartCount reports how many times the child has been started (including
+// crash restarts). It is diagnostic: a climbing count means the child is
+// crash-looping, visible next to the agent's DartUp health.
+func (m *Manager) StartCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.startCount
+}
+
+// Healthy reports whether the DART admin plane answered its last probe. A
+// running child that has not bound its admin listener yet (or a crash
+// between probes) reports false, which keeps artifact pulls on the direct
+// S3 fallback path.
+func (m *Manager) Healthy() bool {
+	return m.healthy.Load()
+}
+
+// Run supervises the DART child until ctx is done: start, probe the admin
+// plane, restart on crash with backoff, and stop the child gracefully on
+// cancellation. Run returns nil after a clean stop.
+func (m *Manager) Run(ctx context.Context) error {
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		cmd, waitCh, err := m.start(ctx)
+		if err != nil {
+			// The binary is missing or not executable: retrying in a loop
+			// would only spin, but a container restart (image fix) should
+			// pick it up, so keep the backoff discipline and report.
+			if !m.backoffDelay(ctx) {
+				return nil
+			}
+			continue
+		}
+		m.runProbes(ctx, cmd, waitCh)
+		if ctx.Err() != nil {
+			return nil
+		}
+		if !m.backoffDelay(ctx) {
+			return nil
+		}
+	}
+}
+
+// lockedWriter serializes writes to the underlying writer: the child's
+// output pipe goroutine and the manager's own logs share the sink.
+type lockedWriter struct {
+	writer io.Writer
+	mu     *sync.Mutex
+}
+
+func (w *lockedWriter) Write(payload []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writer.Write(payload)
+}
+
+// logf writes a manager log line through the shared sink.
+func (m *Manager) logf(format string, arguments ...any) {
+	m.logMu.Lock()
+	defer m.logMu.Unlock()
+	fmt.Fprintf(m.log, format, arguments...)
+}
+
+// start spawns the child and returns its process and a channel that yields
+// the Wait error once it exits.
+func (m *Manager) start(ctx context.Context) (*exec.Cmd, <-chan error, error) {
+	command := exec.CommandContext(ctx, m.config.Binary, m.Args()...)
+	command.Stdout = &lockedWriter{writer: m.log, mu: &m.logMu}
+	command.Stderr = &lockedWriter{writer: m.log, mu: &m.logMu}
+	if err := command.Start(); err != nil {
+		m.logf("dart: start failed: %v\n", err)
+		return nil, nil, err
+	}
+	m.mu.Lock()
+	m.cmd = command
+	m.startCount++
+	m.mu.Unlock()
+	m.healthy.Store(false) // not probed yet
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- command.Wait() }()
+	m.logf("dart: started pid=%d args=%s\n", command.Process.Pid, strings.Join(m.Args(), " "))
+	return command, waitCh, nil
+}
+
+// runProbes loops the admin health probe while the child is alive; it
+// returns when the child exits or the context is canceled. On context
+// cancellation the child is stopped gracefully (SIGTERM, bounded wait).
+func (m *Manager) runProbes(ctx context.Context, cmd *exec.Cmd, waitCh <-chan error) {
+	ticker := time.NewTicker(healthProbeInterval)
+	defer ticker.Stop()
+	for {
+		m.probe()
+		select {
+		case <-ctx.Done():
+			m.stop(cmd, waitCh)
+			return
+		case <-ticker.C:
+		case err := <-waitCh:
+			m.healthy.Store(false)
+			if err != nil && !errors.Is(err, context.Canceled) {
+				m.logf("dart: process exited: %v\n", err)
+			}
+			return
+		}
+	}
+}
+
+// stop terminates the child: SIGTERM first, then a bounded wait, then SIGKILL.
+func (m *Manager) stop(cmd *exec.Cmd, waitCh <-chan error) {
+	if cmd.Process == nil {
+		return
+	}
+	m.logf("dart: stopping pid=%d\n", cmd.Process.Pid)
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	select {
+	case <-waitCh:
+	case <-time.After(gracefulStopTimeout):
+		_ = cmd.Process.Kill()
+		<-waitCh
+	}
+}
+
+// backoffDelay sleeps between crash restarts with exponential backoff; it
+// returns false when the context ends during the wait.
+func (m *Manager) backoffDelay(ctx context.Context) bool {
+	m.mu.Lock()
+	delay := m.backoff
+	if delay == 0 {
+		delay = restartBackoffBase
+	}
+	m.backoff = delay * 2
+	if m.backoff > restartBackoffMax {
+		m.backoff = restartBackoffMax
+	}
+	m.mu.Unlock()
+	if delay > 0 {
+		m.logf("dart: restarting in %s\n", delay)
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// probe checks the admin plane /healthz endpoint and records the result.
+// A successful probe also resets the restart backoff, so a long-running
+// healthy child restarts immediately after an isolated crash.
+func (m *Manager) probe() {
+	url := m.config.Admin
+	if !strings.Contains(url, "://") {
+		url = "http://" + url
+	}
+	url = strings.TrimRight(url, "/") + "/healthz"
+	client := &http.Client{Timeout: healthProbeTimeout}
+	response, err := client.Get(url)
+	if err != nil {
+		m.healthy.Store(false)
+		return
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		m.healthy.Store(false)
+		return
+	}
+	m.healthy.Store(true)
+	m.mu.Lock()
+	m.backoff = 0
+	m.mu.Unlock()
+}

--- a/internal/runtime/firecracker/agent/dart/manager_test.go
+++ b/internal/runtime/firecracker/agent/dart/manager_test.go
@@ -1,0 +1,160 @@
+package dart
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArgs(t *testing.T) {
+	manager := New(Config{
+		Listen:        "127.0.0.1:8145",
+		Admin:         "127.0.0.1:8147",
+		PeerListen:    ":9000",
+		PeerAdvertise: "10.0.0.5:9000",
+		SelfID:        "node-1",
+		Discover:      "dns:dart.fast-sandbox-system.svc:9000",
+		CacheDir:      "/var/lib/fast-sandbox/firecracker/cache/dart",
+		CacheSize:     "20GiB",
+	})
+	require.Equal(t, []string{
+		"-listen=127.0.0.1:8145",
+		"-admin=127.0.0.1:8147",
+		"-peer-listen=:9000",
+		"-cache-dir=/var/lib/fast-sandbox/firecracker/cache/dart",
+		"-cache-size=20GiB",
+		"-peer-advertise=10.0.0.5:9000",
+		"-self-id=node-1",
+		"-discover=dns:dart.fast-sandbox-system.svc:9000",
+	}, manager.Args())
+}
+
+func TestArgsDefaultsAndOptionalFlags(t *testing.T) {
+	manager := New(Config{CacheDir: "/tmp/dart-cache"})
+	args := manager.Args()
+	require.Contains(t, args, "-listen=127.0.0.1:8145")
+	require.Contains(t, args, "-admin=127.0.0.1:8147")
+	require.Contains(t, args, "-peer-listen=:9000")
+	require.Contains(t, args, "-cache-dir=/tmp/dart-cache")
+	require.Contains(t, args, "-cache-size=20GiB")
+	require.NotContains(t, args, "-peer-advertise=")
+	require.NotContains(t, args, "-self-id=")
+	require.NotContains(t, args, "-discover=")
+}
+
+// helperScript writes an executable shell child that either sleeps (until a
+// signal kills it) or exits immediately, standing in for the DART binary.
+func helperScript(t *testing.T, behavior string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dart")
+	body := "#!/bin/sh\n"
+	switch behavior {
+	case "sleep":
+		body += "trap 'exit 0' TERM INT\nwhile true; do sleep 1; done\n"
+	case "exit":
+		body += "exit 7\n"
+	}
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o755))
+	return path
+}
+
+// safeBuffer is a bytes.Buffer safe for concurrent writes and reads (the
+// manager and its child write logs while the test asserts on them).
+type safeBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *safeBuffer) Write(payload []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(payload)
+}
+
+func (s *safeBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+func TestManagerRestartsCrashingChild(t *testing.T) {
+	log := &safeBuffer{}
+	manager := New(Config{Binary: helperScript(t, "exit"), CacheDir: t.TempDir(), Log: log})
+	manager.backoff = time.Millisecond // shorten the crash-restart delay
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- manager.Run(ctx) }()
+
+	// The child exits instantly; the supervisor must restart it.
+	deadline := time.Now().Add(5 * time.Second)
+	for manager.StartCount() < 3 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.GreaterOrEqual(t, manager.StartCount(), 3, "crash-looping child must be restarted (log: %s)", log.String())
+
+	cancel()
+	require.NoError(t, <-done, "Run must return cleanly on cancel")
+	count := manager.StartCount()
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, count, manager.StartCount(), "no restart may happen after cancellation")
+}
+
+func TestManagerGracefulStopOnCancel(t *testing.T) {
+	log := &safeBuffer{}
+	manager := New(Config{Binary: helperScript(t, "sleep"), CacheDir: t.TempDir(), Log: log})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- manager.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return manager.StartCount() == 1 }, 5*time.Second, 10*time.Millisecond)
+	cancel()
+	require.NoError(t, <-done, "Run must stop the child and return on cancel")
+}
+
+func TestManagerHealthTracksAdminPlane(t *testing.T) {
+	admin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok\n"))
+	}))
+	t.Cleanup(admin.Close)
+	log := &safeBuffer{}
+	manager := New(Config{
+		Binary: helperScript(t, "sleep"), CacheDir: t.TempDir(), Log: log,
+		Admin: admin.URL, // a full URL is accepted for tests
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- manager.Run(ctx) }()
+
+	require.Eventually(t, manager.Healthy, 5*time.Second, 10*time.Millisecond,
+		"Healthy must become true once the admin plane answers")
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func TestManagerHealthyFalseWhenAdminDown(t *testing.T) {
+	log := &safeBuffer{}
+	manager := New(Config{Binary: helperScript(t, "sleep"), CacheDir: t.TempDir(), Log: log})
+	manager.healthy.Store(true) // start from "previously healthy"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- manager.Run(ctx) }()
+	// No admin plane answers: the first probe must flip Healthy to false
+	// while the child keeps running.
+	require.Eventually(t, func() bool { return !manager.Healthy() }, 5*time.Second, 10*time.Millisecond)
+	require.Equal(t, 1, manager.StartCount(), "child must stay up with an unreachable admin plane")
+	cancel()
+	require.NoError(t, <-done)
+}

--- a/internal/runtime/firecracker/agent/dart_test.go
+++ b/internal/runtime/firecracker/agent/dart_test.go
@@ -1,0 +1,303 @@
+package agent
+
+// Stage-2 P2P tests: SigV4 query presigning (B) and the DART routing of
+// artifact downloads with direct-S3 fallback (C). Metadata (image index,
+// manifest) intentionally stays on the direct header-signed path, so its
+// 404 semantics (ErrImageNotReady) survive DART's origin-error collapsing.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	runtimecontract "fast-sandbox/internal/runtime/contract"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDART stands in for a node-local DART instance: it accepts prefix-mode
+// requests (/dart/<full upstream URL>) and proxies them to the origin. The
+// gateway can be switched into a 502 "origin error" mode to simulate a
+// broken upstream path.
+type fakeDART struct {
+	mu     sync.Mutex
+	server *httptest.Server
+	hits   []string
+	fail   bool
+}
+
+func newFakeDART(t *testing.T) *fakeDART {
+	t.Helper()
+	gateway := &fakeDART{}
+	gateway.server = httptest.NewServer(http.HandlerFunc(gateway.ServeHTTP))
+	t.Cleanup(gateway.server.Close)
+	return gateway
+}
+
+func (d *fakeDART) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	uri := r.RequestURI
+	d.mu.Lock()
+	fail := d.fail
+	d.mu.Unlock()
+	if fail {
+		http.Error(w, "origin error: upstream fetch failed", http.StatusBadGateway)
+		return
+	}
+	if !strings.HasPrefix(uri, "/dart/") {
+		http.Error(w, "cannot resolve origin", http.StatusBadRequest)
+		return
+	}
+	upstream := uri[len("/dart/"):]
+	if !strings.HasPrefix(upstream, "http://") && !strings.HasPrefix(upstream, "https://") {
+		http.Error(w, "upstream URL must include a scheme", http.StatusBadRequest)
+		return
+	}
+	d.mu.Lock()
+	d.hits = append(d.hits, upstream)
+	d.mu.Unlock()
+	response, err := http.Get(upstream)
+	if err != nil {
+		http.Error(w, "origin error: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer response.Body.Close()
+	w.WriteHeader(response.StatusCode)
+	_, _ = io.Copy(w, response.Body)
+}
+
+func (d *fakeDART) url() string { return d.server.URL }
+
+// hitCount returns how many prefix-mode requests reached the gateway.
+func (d *fakeDART) hitCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.hits)
+}
+
+func (d *fakeDART) latestUpstream() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.hits) == 0 {
+		return ""
+	}
+	return d.hits[len(d.hits)-1]
+}
+
+// --- B: presigned URL construction and SigV4 query signature ---------------
+
+func TestPresignGETParametersAndSignature(t *testing.T) {
+	var received *http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(server.Close)
+	client := &s3Client{
+		endpoint: server.URL, region: "us-east-1", bucket: testBucket, prefix: testPrefix,
+		accessKey: "test-access-key", secretKey: "test-secret-key",
+		http: &http.Client{Timeout: time.Second},
+	}
+	presigned, err := client.presignGET("index/abc.json", time.Minute)
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(presigned)
+	require.NoError(t, err)
+	require.Equal(t, "/"+testBucket+"/"+testPrefix+"/index/abc.json", parsed.Path)
+	require.NotEmpty(t, parsed.Query().Get("X-Amz-Signature"))
+
+	// The presigned URL works with a plain (unauthenticated) client and
+	// carries no Authorization header — the signature is entirely in the
+	// query string.
+	response, err := http.Get(presigned)
+	require.NoError(t, err)
+	content, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	require.Equal(t, "ok", string(content))
+	require.Empty(t, received.Header.Get("Authorization"), "presigned GET must not carry header signing")
+
+	query := parsed.Query()
+	require.Equal(t, "AWS4-HMAC-SHA256", query.Get("X-Amz-Algorithm"))
+	require.True(t, strings.HasPrefix(query.Get("X-Amz-Credential"), "test-access-key/"))
+	require.Contains(t, query.Get("X-Amz-Credential"), "/us-east-1/s3/aws4_request")
+	require.Equal(t, "host", query.Get("X-Amz-SignedHeaders"))
+	require.Equal(t, "60", query.Get("X-Amz-Expires"))
+	require.NotEmpty(t, query.Get("X-Amz-Date"))
+	require.Len(t, query.Get("X-Amz-Signature"), 64)
+}
+
+func TestPresignGETSignatureValidatesServerSide(t *testing.T) {
+	// The server re-derives the SigV4 query signature from the received
+	// request (the same way MinIO/OSS do) and rejects a mismatch, proving
+	// the canonical request is correct, not just well-formed.
+	secret := "test-secret-key"
+	accessKey := "test-access-key"
+	verified := make(chan bool, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, verifyPresignedSignature(t, accessKey, secret, "us-east-1", r))
+		verified <- true
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(server.Close)
+	client := &s3Client{
+		endpoint: server.URL, region: "us-east-1", bucket: testBucket, prefix: "",
+		accessKey: accessKey, secretKey: secret,
+		http: &http.Client{Timeout: time.Second},
+	}
+	presigned, err := client.presignGET("digest16/rootfs.ext4", time.Hour)
+	require.NoError(t, err)
+	response, err := http.Get(presigned)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.NoError(t, response.Body.Close())
+	require.True(t, <-verified)
+}
+
+// verifyPresignedSignature recomputes the presigned GET signature from the
+// received request and compares it with the X-Amz-Signature parameter.
+func verifyPresignedSignature(t *testing.T, accessKey, secretKey, region string, r *http.Request) error {
+	t.Helper()
+	query := r.URL.Query()
+	algorithm := query.Get("X-Amz-Algorithm")
+	if algorithm != "AWS4-HMAC-SHA256" {
+		t.Fatalf("unexpected algorithm %q", algorithm)
+	}
+	scope := query.Get("X-Amz-Credential")
+	parts := strings.Split(scope, "/")
+	if len(parts) != 5 || parts[0] != accessKey || parts[4] != "aws4_request" {
+		t.Fatalf("unexpected credential scope %q", scope)
+	}
+	amzDate := query.Get("X-Amz-Date")
+	date := parts[1]
+	signedHeaders := query.Get("X-Amz-SignedHeaders")
+	if signedHeaders != "host" {
+		t.Fatalf("signed headers %q, want host", signedHeaders)
+	}
+	parameters := [][2]string{
+		{"X-Amz-Algorithm", algorithm},
+		{"X-Amz-Credential", scope},
+		{"X-Amz-Date", amzDate},
+		{"X-Amz-Expires", query.Get("X-Amz-Expires")},
+		{"X-Amz-SignedHeaders", signedHeaders},
+	}
+	canonicalRequest := strings.Join([]string{
+		http.MethodGet,
+		r.URL.EscapedPath(),
+		canonicalQueryString(parameters),
+		"host:" + r.Host + "\n",
+		"host",
+		unsignedPayload,
+	}, "\n")
+	scopeValue := date + "/" + region + "/s3/aws4_request"
+	stringToSign := "AWS4-HMAC-SHA256\n" + amzDate + "\n" + scopeValue + "\n" + sha256Hex([]byte(canonicalRequest))
+	expected := hmacHex(deriveSigningKey(secretKey, date, region), stringToSign)
+	if expected != query.Get("X-Amz-Signature") {
+		return &httpError{StatusCode: http.StatusForbidden, Body: "signature mismatch"}
+	}
+	return nil
+}
+
+// --- C: artifact routing through DART with direct-S3 fallback --------------
+
+func TestPullImageArtifactsViaDART(t *testing.T) {
+	store, client, _, artifacts := publishFixture(t)
+	gateway := newFakeDART(t)
+	dartClient := &Client{s3: client, dart: &dartGateway{
+		base: gateway.url(), ttl: time.Hour, http: &http.Client{Timeout: time.Minute},
+	}}
+	root := t.TempDir()
+
+	require.NoError(t, dartClient.PullImage(context.Background(), root, testImage))
+
+	dir := imageDir(root, testImage)
+	for cacheName, content := range map[string][]byte{
+		"rootfs.img":   artifacts["rootfs.ext4"],
+		"vmstate.snap": artifacts["vmstate.snap"],
+		"memory.snap":  artifacts["memory.snap"],
+	} {
+		got, err := os.ReadFile(filepath.Join(dir, cacheName))
+		require.NoError(t, err)
+		require.Equal(t, content, got, cacheName)
+	}
+
+	// Every object reached the store exactly once: the index and manifest
+	// DIRECT (metadata keeps exact 404 semantics), the three artifacts via
+	// the DART proxy forwarding the presigned upstream (a direct fetch would
+	// double the artifact keys).
+	buildDir := sha256Hex(testManifest(artifacts))[:16]
+	require.Equal(t, 1, store.countRequested("index/"+imageKey(testImage)+".json"))
+	require.Equal(t, 1, store.countRequested(buildDir+"/manifest.json"))
+	require.Equal(t, 1, store.countRequested(buildDir+"/rootfs.ext4"))
+	require.Equal(t, 1, store.countRequested(buildDir+"/vmstate.snap"))
+	require.Equal(t, 1, store.countRequested(buildDir+"/memory.snap"))
+
+	require.Equal(t, 3, gateway.hitCount(), "three artifacts must go through DART")
+	for _, upstream := range gateway.hits {
+		parsed, err := url.Parse(upstream)
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(upstream, "http://"), upstream)
+		query := parsed.Query()
+		require.NotEmpty(t, query.Get("X-Amz-Signature"), "DART upstream must be presigned")
+		require.Equal(t, "host", query.Get("X-Amz-SignedHeaders"))
+		require.NotContains(t, upstream, "index/", "metadata must not go through DART")
+		require.NotContains(t, upstream, "manifest.json", "metadata must not go through DART")
+	}
+}
+
+func TestPullImageDARTUnreachableFallsBackToDirect(t *testing.T) {
+	store, client, _, _ := publishFixture(t)
+	gateway := newFakeDART(t)
+	dartBase := gateway.url()
+	gateway.server.Close() // simulate a dead DART process
+
+	dartClient := &Client{s3: client, dart: &dartGateway{
+		base: dartBase, ttl: time.Hour, http: &http.Client{Timeout: time.Second},
+	}}
+	require.NoError(t, dartClient.PullImage(context.Background(), t.TempDir(), testImage))
+
+	// Transport failure to DART falls back to the direct path: every object
+	// (index + manifest + 3 artifacts) was fetched from the store directly.
+	require.Equal(t, 5, len(store.requested()))
+	require.Zero(t, gateway.hitCount())
+}
+
+func TestPullImageDARTGatewayErrorFallsBackToDirect(t *testing.T) {
+	store, client, _, _ := publishFixture(t)
+	gateway := newFakeDART(t)
+	gateway.mu.Lock()
+	gateway.fail = true // DART answers 502 "origin error"
+	gateway.mu.Unlock()
+
+	dartClient := &Client{s3: client, dart: &dartGateway{
+		base: gateway.url(), ttl: time.Hour, http: &http.Client{Timeout: time.Second},
+	}}
+	require.NoError(t, dartClient.PullImage(context.Background(), t.TempDir(), testImage))
+
+	require.Equal(t, 5, len(store.requested()), "gateway errors must fall back to direct S3")
+}
+
+func TestPullImageDARTKeepsImageNotReadySemantics(t *testing.T) {
+	// The index lives only in the store, and it is fetched DIRECT even in
+	// DART mode: a missing build must keep surfacing ErrImageNotReady
+	// (DART would collapse the origin 404 into a 502).
+	store, client, _, _ := publishFixture(t)
+	store.mu.Lock()
+	delete(store.objects, "index/"+imageKey(testImage)+".json")
+	store.mu.Unlock()
+	gateway := newFakeDART(t)
+
+	dartClient := &Client{s3: client, dart: &dartGateway{
+		base: gateway.url(), ttl: time.Hour, http: &http.Client{Timeout: time.Second},
+	}}
+	err := dartClient.PullImage(context.Background(), t.TempDir(), testImage)
+	require.ErrorIs(t, err, runtimecontract.ErrImageNotReady)
+	require.Zero(t, gateway.hitCount(), "no artifact request may reach DART without an index")
+}

--- a/internal/runtime/firecracker/agent/live_minio_test.go
+++ b/internal/runtime/firecracker/agent/live_minio_test.go
@@ -26,9 +26,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -105,4 +107,88 @@ func TestLivePullThroughDART(t *testing.T) {
 		}
 		t.Logf("read %d: %d bytes via DART (%s)", read, written, dartBase)
 	}
+}
+
+// dartAdmin reads one Prometheus counter line (dart_block_source_total).
+func dartCounter(t *testing.T, admin, source string) int {
+	t.Helper()
+	response, err := http.Get("http://" + admin + "/metrics")
+	require.NoError(t, err)
+	defer response.Body.Close()
+	payload, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	prefix := `dart_block_source_total{source="` + source + `"} `
+	for _, line := range strings.Split(string(payload), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			var value int
+			_, err := fmt.Sscanf(line, prefix+"%d", &value)
+			require.NoError(t, err)
+			return value
+		}
+	}
+	return 0
+}
+
+// TestLivePeerHitThroughTwoDARTNodes proves the P2P data plane itself: two
+// node-local DART instances (static peers, empty caches) serve the same
+// object to two cold agents, and the ORIGIN is fetched once for the whole
+// cluster — the second node is served from the peer, its origin counter
+// stays put. A single-node DART only proves caching; the peer leg is the
+// stage-2 value.
+//
+// Setup on the reference host (one MinIO, two dart processes):
+//
+//	dart -listen=127.0.0.1:8145 -admin=127.0.0.1:8146 \
+//	    -cache-dir=/tmp/dart-a -cache-size=1GiB \
+//	    -self-id=node-a -peers=node-a@127.0.0.1:9201,node-b@127.0.0.1:9202 \
+//	    -peer-listen=127.0.0.1:9201 &
+//	dart -listen=127.0.0.1:8147 -admin=127.0.0.1:8148 \
+//	    -cache-dir=/tmp/dart-b -cache-size=1GiB \
+//	    -self-id=node-b -peers=node-a@127.0.0.1:9201,node-b@127.0.0.1:9202 \
+//	    -peer-listen=127.0.0.1:9202 &
+func TestLivePeerHitThroughTwoDARTNodes(t *testing.T) {
+	endpoint, accessKey, secretKey, bucket, key, wantSHA := liveMinioEnv(t)
+	nodeA := os.Getenv("FS_LIVE_DART_NODE_A")   // http://127.0.0.1:8145
+	nodeB := os.Getenv("FS_LIVE_DART_NODE_B")   // http://127.0.0.1:8147
+	adminA := os.Getenv("FS_LIVE_DART_ADMIN_A") // 127.0.0.1:8146
+	adminB := os.Getenv("FS_LIVE_DART_ADMIN_B") // 127.0.0.1:8148
+	if nodeA == "" || nodeB == "" || adminA == "" || adminB == "" {
+		t.Skip("FS_LIVE_DART_NODE_A/B + ADMIN_A/B not set; the two-node peer check is opt-in")
+	}
+	origin := func() int { return dartCounter(t, adminA, "origin") + dartCounter(t, adminB, "origin") }
+	readVia := func(name, base string) {
+		client := &Client{s3: liveS3Client(endpoint, accessKey, secretKey, bucket), dart: &dartGateway{
+			base: base, ttl: time.Hour, http: &http.Client{Timeout: 10 * time.Minute},
+		}}
+		body, err := client.getArtifact(context.Background(), key)
+		require.NoError(t, err)
+		digest := sha256.New()
+		written, err := io.Copy(digest, body)
+		require.NoError(t, err)
+		require.NoError(t, body.Close())
+		if wantSHA != "" {
+			require.Equal(t, wantSHA, hex.EncodeToString(digest.Sum(nil)), "%s digest mismatch", name)
+		}
+		t.Logf("%s: %d bytes", name, written)
+	}
+	originBefore := origin()
+	readVia("node A (cold)", nodeA)
+	peerA := dartCounter(t, adminA, "peer")
+	cacheA := dartCounter(t, adminA, "cache")
+	originAfterA := origin()
+	readVia("node B (cold)", nodeB)
+	originAfterB := origin()
+	peerB := dartCounter(t, adminB, "peer")
+	cacheB := dartCounter(t, adminB, "cache")
+
+	t.Logf("cluster origin: before=%d after-A=%d after-B=%d", originBefore, originAfterA, originAfterB)
+	t.Logf("node A: peer=%d cache=%d origin=%d", peerA, cacheA, dartCounter(t, adminA, "origin"))
+	t.Logf("node B: peer=%d cache=%d origin=%d", peerB, cacheB, dartCounter(t, adminB, "origin"))
+
+	// The object was fetched from the origin exactly once cluster-wide: the
+	// second node's read must not touch the origin at all.
+	require.Equal(t, originAfterA, originAfterB,
+		"node B's cold read must be served by the peer, not the origin (single fetch for N nodes)")
+	require.Greater(t, originAfterA, originBefore, "node A's cold read must reach the origin")
+	require.True(t, peerB > 0 || cacheB > 0, "node B must be served by the peer or cache")
 }

--- a/internal/runtime/firecracker/agent/live_minio_test.go
+++ b/internal/runtime/firecracker/agent/live_minio_test.go
@@ -1,0 +1,108 @@
+package agent
+
+// Live stage-2 verification against a REAL MinIO (and optionally a REAL DART
+// instance). These tests are gated behind environment variables because they
+// need a seeded store and are meant for the reference host (or a local
+// MinIO container). They close the risk item "presigned URL signature
+// correctness against MinIO" that unit tests cannot (the fake servers
+// verify parameter construction; MinIO validates the signature server-side).
+//
+// Setup (local smoke):
+//
+//	docker run -d --name minio -p 19000:9000 -e MINIO_ROOT_USER=smoke \
+//	    -e MINIO_ROOT_PASSWORD=smoke-secret minio/minio server /data
+//	mc alias set smoke http://127.0.0.1:19000 smoke smoke-secret
+//	mc mb smoke/sandbox-images
+//	mc cp rootfs.bin smoke/sandbox-images/digest16/rootfs.ext4
+//	FS_LIVE_MINIO_ENDPOINT=http://127.0.0.1:19000 \
+//	FS_LIVE_MINIO_AK=smoke FS_LIVE_MINIO_SK=smoke-secret \
+//	FS_LIVE_MINIO_BUCKET=sandbox-images \
+//	FS_LIVE_MINIO_KEY=digest16/rootfs.ext4 \
+//	FS_LIVE_MINIO_SHA256=<sha256 of rootfs.bin> \
+//	FS_LIVE_DART_ADDR=http://127.0.0.1:8145 \
+//	go test ./internal/runtime/firecracker/agent/ -run TestLive -count=1 -v
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func liveMinioEnv(t *testing.T) (endpoint, accessKey, secretKey, bucket, key, wantSHA string) {
+	t.Helper()
+	endpoint = os.Getenv("FS_LIVE_MINIO_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("FS_LIVE_MINIO_ENDPOINT not set; live verification is opt-in")
+	}
+	return endpoint,
+		os.Getenv("FS_LIVE_MINIO_AK"),
+		os.Getenv("FS_LIVE_MINIO_SK"),
+		os.Getenv("FS_LIVE_MINIO_BUCKET"),
+		os.Getenv("FS_LIVE_MINIO_KEY"),
+		os.Getenv("FS_LIVE_MINIO_SHA256")
+}
+
+func liveS3Client(endpoint, accessKey, secretKey, bucket string) *s3Client {
+	return &s3Client{
+		endpoint: endpoint, region: "us-east-1", bucket: bucket, prefix: "",
+		accessKey: accessKey, secretKey: secretKey,
+		http:       &http.Client{Timeout: 10 * time.Minute},
+		retryDelay: 100 * time.Millisecond,
+	}
+}
+
+// TestLivePresignedGETAgainstMinIO proves the presigned URL is accepted by a
+// real SigV4 server (MinIO re-derives the query signature) and returns the
+// exact seeded object bytes.
+func TestLivePresignedGETAgainstMinIO(t *testing.T) {
+	endpoint, accessKey, secretKey, bucket, key, wantSHA := liveMinioEnv(t)
+	client := liveS3Client(endpoint, accessKey, secretKey, bucket)
+
+	presigned, err := client.presignGET(key, time.Hour)
+	require.NoError(t, err)
+	response, err := http.Get(presigned)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, response.StatusCode, "MinIO rejected the presigned signature")
+	defer response.Body.Close()
+	payload, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	if wantSHA != "" {
+		require.Equal(t, wantSHA, sha256Hex(payload))
+	}
+}
+
+// TestLivePullThroughDART exercises the exact stage-2 agent path against a
+// real DART instance: presign -> GET <dart>/dart/<presigned-url> -> origin
+// fetch -> whole-object digest. A second read proves the DART block cache
+// serves it (the origin counter stops moving; asserted via the admin
+// metrics the operator can curl).
+func TestLivePullThroughDART(t *testing.T) {
+	endpoint, accessKey, secretKey, bucket, key, wantSHA := liveMinioEnv(t)
+	dartBase := os.Getenv("FS_LIVE_DART_ADDR")
+	if dartBase == "" {
+		t.Skip("FS_LIVE_DART_ADDR not set; the DART-leg of the live check is opt-in")
+	}
+	client := &Client{s3: liveS3Client(endpoint, accessKey, secretKey, bucket), dart: &dartGateway{
+		base: dartBase, ttl: time.Hour, http: &http.Client{Timeout: 10 * time.Minute},
+	}}
+
+	for read := 1; read <= 2; read++ {
+		body, err := client.getArtifact(context.Background(), key)
+		require.NoError(t, err)
+		digest := sha256.New()
+		written, err := io.Copy(digest, body)
+		require.NoError(t, err)
+		require.NoError(t, body.Close())
+		if wantSHA != "" {
+			require.Equal(t, wantSHA, hex.EncodeToString(digest.Sum(nil)), "read %d digest mismatch", read)
+		}
+		t.Logf("read %d: %d bytes via DART (%s)", read, written, dartBase)
+	}
+}

--- a/internal/runtime/firecracker/agent/protocol/types.go
+++ b/internal/runtime/firecracker/agent/protocol/types.go
@@ -126,4 +126,9 @@ type HealthResponse struct {
 	LeaseCount int   `json:"leaseCount"`
 	PinCount   int   `json:"pinCount"`
 	ImageCount int   `json:"imageCount"`
+	// DartUp reports whether the node-local DART P2P daemon answered its
+	// last admin-plane probe. It is informational: the agent's own health
+	// never depends on DART (a broken gateway keeps artifact pulls on the
+	// direct S3 fallback path).
+	DartUp bool `json:"dartUp"`
 }

--- a/internal/runtime/firecracker/agent/pull.go
+++ b/internal/runtime/firecracker/agent/pull.go
@@ -10,20 +10,35 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"fast-sandbox/internal/registryconfig"
 	runtimecontract "fast-sandbox/internal/runtime/contract"
 )
 
 // Client pulls published Firecracker artifacts for an image reference into
-// the node-local cache. Stage 1 carries only the pure pull layer: the UDS
-// server, device leasing, and driver wiring arrive with the runtime-agent
-// work.
+// the node-local cache. The pull chain is stage-1 pure (UDS server, device
+// leasing, and driver wiring arrive with the runtime-agent work); stage 2
+// adds the DART P2P data plane for the artifact bytes.
 type Client struct {
 	s3 *s3Client
+	// dart is the DART P2P gateway configuration; nil keeps the pull on the
+	// direct header-signed S3 path (local mode / stage-1 behavior).
+	dart *dartGateway
+}
+
+// dartGateway routes artifact GETs through a node-local DART instance
+// (stage-2 P2P). The agent signs presigned origin URLs; DART fetches,
+// caches and P2P-distributes the blocks, and the agent still verifies the
+// whole-object digest against the manifest.
+type dartGateway struct {
+	base string // e.g. http://127.0.0.1:8145 (prefix route /dart/<upstream-url>)
+	ttl  time.Duration
+	http *http.Client
 }
 
 // NewClient builds a pull client for a store root (s3://bucket/prefix) with
@@ -38,7 +53,21 @@ func NewClient(storeRoot string, credential registryconfig.Credential, options .
 	if err != nil {
 		return nil, err
 	}
-	return &Client{s3: s3}, nil
+	client := &Client{s3: s3}
+	if config.dartBase != "" {
+		client.dart = &dartGateway{
+			base: strings.TrimRight(config.dartBase, "/"),
+			ttl:  config.presignTTL,
+			http: config.httpClient,
+		}
+		if client.dart.ttl <= 0 {
+			client.dart.ttl = time.Hour
+		}
+		if client.dart.http == nil {
+			client.dart.http = &http.Client{Timeout: defaultS3RequestTimeout}
+		}
+	}
+	return client, nil
 }
 
 // Option configures the pull client.
@@ -48,6 +77,8 @@ type optionsConfig struct {
 	region     string
 	endpoint   string
 	httpClient *http.Client
+	dartBase   string
+	presignTTL time.Duration
 }
 
 // WithRegion overrides the SigV4 signing region (default us-east-1).
@@ -65,6 +96,22 @@ func WithEndpoint(endpoint string) Option {
 // timeout), e.g. to tune timeouts or the transport.
 func WithHTTPClient(client *http.Client) Option {
 	return func(config *optionsConfig) { config.httpClient = client }
+}
+
+// WithDART routes artifact downloads through the node-local DART P2P gateway
+// at base (e.g. http://127.0.0.1:8145). Metadata (image index and manifest)
+// stays on the direct header-signed path: their 404 semantics must survive
+// exactly, and DART collapses origin errors into 502. Empty base = direct
+// mode (the stage-1 behavior).
+func WithDART(base string) Option {
+	return func(config *optionsConfig) { config.dartBase = base }
+}
+
+// WithPresignTTL bounds the lifetime of the presigned URLs handed to DART.
+// The default is one hour; the TTL only needs to cover one artifact fetch
+// (DART reuses the URL for cache misses back to the origin).
+func WithPresignTTL(ttl time.Duration) Option {
+	return func(config *optionsConfig) { config.presignTTL = ttl }
 }
 
 // PullImage resolves the addressing chain for image and materializes the
@@ -136,11 +183,73 @@ func (c *Client) PullImage(ctx context.Context, stateRoot, image string) error {
 	// manifest, so their store keys derive from the manifest reference.
 	buildDir := path.Dir(manifestKey)
 	for _, file := range files {
-		if err := stageFile(ctx, c.s3, dir, path.Join(buildDir, file.publish), file); err != nil {
+		if err := stageFile(ctx, c, dir, path.Join(buildDir, file.publish), file); err != nil {
 			return err
 		}
 	}
 	return commitManifest(dir, payload)
+}
+
+// getArtifact streams one native artifact object. In DART mode the download
+// goes through the P2P gateway as presign -> GET <dart>/dart/<url>; a DART
+// transport failure or a gateway error (502 origin error / 400 prefix
+// drift) falls back to the direct header-signed S3 path, so a broken or
+// missing DART degrades to stage-1 behavior without failing the pull.
+// Without a DART gateway the call is the plain direct GET.
+func (c *Client) getArtifact(ctx context.Context, storeKey string) (io.ReadCloser, error) {
+	if c.dart == nil {
+		return c.s3.get(ctx, storeKey)
+	}
+	body, err := c.getArtifactViaDART(ctx, storeKey)
+	if err == nil {
+		return body, nil
+	}
+	if errors.Is(err, ErrObjectNotFound) {
+		return nil, err
+	}
+	var status *httpError
+	if errors.As(err, &status) && status.StatusCode >= 200 && status.StatusCode < 500 && status.StatusCode != http.StatusBadRequest {
+		// A definitive client-class answer from the origin through DART
+		// (excluding 400, which is a DART routing/prefix problem): do not
+		// fall back, the origin would answer the same.
+		return nil, err
+	}
+	// Transport error, gateway error (502/503) or prefix drift (400): the
+	// DART instance cannot serve this object; fall back to the direct
+	// header-signed path (which carries its own retry loop).
+	return c.s3.get(ctx, storeKey)
+}
+
+// getArtifactViaDART performs one presigned GET through the DART prefix
+// route. DART surfaces origin failures as 502 "origin error" and routing
+// problems as 400, so a non-200 answer here is an httpError for the caller
+// to classify.
+func (c *Client) getArtifactViaDART(ctx context.Context, storeKey string) (io.ReadCloser, error) {
+	presigned, err := c.s3.presignGET(storeKey, c.dart.ttl)
+	if err != nil {
+		return nil, err
+	}
+	target := c.dart.base + "/dart/" + presigned
+	if _, err := url.Parse(target); err != nil {
+		return nil, fmt.Errorf("build DART request URL: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := c.dart.http.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 4096))
+		_ = response.Body.Close()
+		if response.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("%w: %s", ErrObjectNotFound, storeKey)
+		}
+		return nil, &httpError{StatusCode: response.StatusCode, Body: string(body)}
+	}
+	return response.Body, nil
 }
 
 // maxManifestBytes caps the downloaded manifest document. Manifests are

--- a/internal/runtime/firecracker/agent/s3client.go
+++ b/internal/runtime/firecracker/agent/s3client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -222,6 +223,83 @@ func (c *s3Client) objectURL(key string) (string, error) {
 // emptyPayloadHash is the SHA-256 of an empty payload, the fixed
 // X-Amz-Content-Sha256 of a bodyless GET.
 var emptyPayloadHash = sha256Hex(nil)
+
+// unsignedPayload is the presigned-URL payload hash. A presigned GET cannot
+// promise the caller will set a content hash header, so the signature covers
+// the constant "UNSIGNED-PAYLOAD" instead (S3/MinIO convention for query
+// signing; the request still carries no body).
+const unsignedPayload = "UNSIGNED-PAYLOAD"
+
+// presignGET returns a SigV4 query-signed GET URL for a store object, valid
+// for ttl. The signature is derived from the same canonical request as the
+// header signing in sign (identical path, host, region scope and signing
+// key); only the carrier differs — the X-Amz-* parameters travel in the
+// query string and the only signed header is host. Presigned URLs are handed
+// to DART so the P2P layer can fetch from the origin without ever seeing the
+// access key pair.
+func (c *s3Client) presignGET(storeKey string, ttl time.Duration) (string, error) {
+	if ttl <= 0 {
+		ttl = time.Hour
+	}
+	key := storeKey
+	if c.prefix != "" {
+		key = c.prefix + "/" + storeKey
+	}
+	urlString, err := c.objectURL(key)
+	if err != nil {
+		return "", err
+	}
+	target, err := url.Parse(urlString)
+	if err != nil {
+		return "", fmt.Errorf("build object URL: %w", err)
+	}
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	date := now.Format("20060102")
+	scope := date + "/" + c.region + "/s3/aws4_request"
+
+	// The five X-Amz-* parameters sort alphabetically in this order.
+	parameters := [][2]string{
+		{"X-Amz-Algorithm", "AWS4-HMAC-SHA256"},
+		{"X-Amz-Credential", c.accessKey + "/" + scope},
+		{"X-Amz-Date", amzDate},
+		{"X-Amz-Expires", strconv.FormatInt(int64(ttl/time.Second), 10)},
+		{"X-Amz-SignedHeaders", "host"},
+	}
+	canonicalQuery := canonicalQueryString(parameters)
+	canonicalHeaders := "host:" + target.Host + "\n"
+	canonicalRequest := strings.Join([]string{
+		http.MethodGet,
+		target.EscapedPath(),
+		canonicalQuery,
+		canonicalHeaders,
+		"host",
+		unsignedPayload,
+	}, "\n")
+	stringToSign := "AWS4-HMAC-SHA256\n" + amzDate + "\n" + scope + "\n" + sha256Hex([]byte(canonicalRequest))
+	signingKey := deriveSigningKey(c.secretKey, date, c.region)
+	signature := hmacHex(signingKey, stringToSign)
+	target.RawQuery = canonicalQuery + "&X-Amz-Signature=" + signature
+	return target.String(), nil
+}
+
+// canonicalQueryString renders an already-sorted parameter list as the SigV4
+// canonical query string: every name and value is RFC 3986 encoded (spaces as
+// %20, never '+') and pairs join with '&'.
+func canonicalQueryString(parameters [][2]string) string {
+	parts := make([]string, 0, len(parameters))
+	for _, pair := range parameters {
+		parts = append(parts, awsQueryEscape(pair[0])+"="+awsQueryEscape(pair[1]))
+	}
+	return strings.Join(parts, "&")
+}
+
+// awsQueryEscape encodes a SigV4 query component. url.QueryEscape uses '+' for
+// spaces, which SigV4 canonicalization forbids; the '+'-to-%20 replacement
+// yields the RFC 3986 form both sides of the signature agree on.
+func awsQueryEscape(value string) string {
+	return strings.ReplaceAll(url.QueryEscape(value), "+", "%20")
+}
 
 // sign applies AWS Signature Version 4 to the request (service s3,
 // path-style). The payload hash is the empty-string digest: GETs carry no

--- a/internal/runtime/firecracker/agent/server/dart_health_test.go
+++ b/internal/runtime/firecracker/agent/server/dart_health_test.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	agentstate "fast-sandbox/internal/runtime/firecracker/agent/state"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestServiceHealthDartProbe wires the node-local DART state into Health:
+// DartUp follows the probe, and the agent's own OK stays independent of the
+// DART daemon (a broken gateway keeps pulls on the direct-S3 fallback).
+func TestServiceHealthDartProbe(t *testing.T) {
+	stateRoot := t.TempDir()
+	state, err := agentstate.New(stateRoot)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = state.Close() })
+
+	probed := true
+	service := NewService(newFakePuller(), state, stateRoot, WithDARTProbe(func() bool { return probed }))
+	health, err := service.Health(context.Background())
+	require.NoError(t, err)
+	require.True(t, health.OK)
+	require.True(t, health.DartUp, "Health must reflect the DART probe")
+
+	probed = false
+	health, err = service.Health(context.Background())
+	require.NoError(t, err)
+	require.True(t, health.OK, "agent health stays green when DART is down")
+	require.False(t, health.DartUp)
+}
+
+func TestServiceHealthWithoutDARTProbe(t *testing.T) {
+	stateRoot := t.TempDir()
+	state, err := agentstate.New(stateRoot)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = state.Close() })
+
+	service := NewService(newFakePuller(), state, stateRoot)
+	health, err := service.Health(context.Background())
+	require.NoError(t, err)
+	require.False(t, health.DartUp, "no DART probe configured = stage-1 local mode")
+}

--- a/internal/runtime/firecracker/agent/server/service.go
+++ b/internal/runtime/firecracker/agent/server/service.go
@@ -36,6 +36,9 @@ type Service struct {
 	state     *agentstate.State
 	stateRoot string
 	now       func() time.Time
+	// dartUp reports the node-local DART daemon state; nil when DART is not
+	// configured (stage-1 local mode).
+	dartUp func() bool
 }
 
 // NewService assembles the stage-1 backend.
@@ -53,6 +56,14 @@ type ServiceOption func(*Service)
 // WithServiceClock overrides the clock.
 func WithServiceClock(now func() time.Time) ServiceOption {
 	return func(service *Service) { service.now = now }
+}
+
+// WithDARTProbe wires the node-local DART daemon state into Health: dartUp
+// reports whether the DART admin plane answered its last probe. The agent's
+// own health stays independent of DART (a broken gateway keeps pulls on the
+// direct S3 fallback path).
+func WithDARTProbe(dartUp func() bool) ServiceOption {
+	return func(service *Service) { service.dartUp = dartUp }
 }
 
 // PinImage pulls the image (if not already cached) and records one pin.
@@ -134,13 +145,17 @@ func (s *Service) Compatibility(_ context.Context) (string, error) {
 // Health reports the agent state and the cache footprint.
 func (s *Service) Health(_ context.Context) (agentprotocol.HealthResponse, error) {
 	snapshot := s.state.Snapshot()
-	return agentprotocol.HealthResponse{
+	response := agentprotocol.HealthResponse{
 		OK:         true,
 		CacheBytes: cacheBytes(s.stateRoot),
 		LeaseCount: snapshot.LeaseCount,
 		PinCount:   snapshot.PinCount,
 		ImageCount: snapshot.ImageCount,
-	}, nil
+	}
+	if s.dartUp != nil {
+		response.DartUp = s.dartUp()
+	}
+	return response, nil
 }
 
 // manifestDigestFor re-reads the committed manifest digest of an image.

--- a/internal/runtime/firecracker/agent_wiring_test.go
+++ b/internal/runtime/firecracker/agent_wiring_test.go
@@ -188,3 +188,30 @@ func TestSetAgentSocketEmptySwitchesToLocalMode(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, client)
 }
+
+func TestEnsureSandboxColdCreatePullsMissingImage(t *testing.T) {
+	fixture := newDriverFixture(t)
+	agent := &fakeAgentClient{}
+	fixture.installAgent(agent)
+
+	// The image is NOT cached and the agent cannot materialize it (fake):
+	// the create must ask the agent for the pull (on-demand loading) and
+	// then fail with ErrImageNotReady — not reject without ever trying.
+	_, err := fixture.driver.EnsureSandbox(context.Background(), ensureInput(&fixture.sandboxSpec))
+	require.ErrorIs(t, err, ErrImageNotReady)
+	pins, _, _ := agent.snapshot()
+	require.Equal(t, []string{fixture.sandboxSpec.Spec.Image}, pins)
+	require.Equal(t, "warm-pull-pod-1-"+imageKey(fixture.sandboxSpec.Spec.Image), agent.pinReqs[0])
+}
+
+func TestEnsureSandboxCachedImageNeverPins(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Spec.Image)
+	agent := &fakeAgentClient{}
+	fixture.installAgent(agent)
+
+	_, err := fixture.driver.EnsureSandbox(context.Background(), ensureInput(&fixture.sandboxSpec))
+	require.NoError(t, err)
+	pins, _, _ := agent.snapshot()
+	require.Empty(t, pins, "a cached image must not pin on create (warm pull pins once, delete unpins once)")
+}

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -376,6 +376,35 @@ func (d *Driver) EnsureSandbox(ctx context.Context, input *fastletapi.EnsureSand
 		return nil, fmt.Errorf("%w: firecracker requires the Fastlet network manager", ErrNetworkUnavailable)
 	}
 
+	// On-demand image loading: a create whose image is not yet cached asks
+	// the node runtime-agent to pull it (PinImage proxy, artifact bytes via
+	// the DART data plane) instead of failing admission with
+	// ErrImageNotReady. A cached image never touches the agent (sandbox
+	// creates do not pin: only the pod-level warm pull pins once, and every
+	// DeleteSandbox unpins once). Local mode (no agent socket) and
+	// unreachable-agent fallbacks keep the pre-warmed behavior unchanged:
+	// a still-missing image reports ErrImageNotReady exactly as before.
+	if _, err := resolveRootfsImage(stateRoot, spec.Image); err != nil {
+		if !errors.Is(err, ErrImageNotReady) {
+			return nil, err
+		}
+		client, clientErr := d.agentClientOrNil()
+		if clientErr != nil {
+			return nil, clientErr
+		}
+		if client != nil {
+			if _, err := client.PinImage(ctx, d.warmPullRequestID(spec.Image), spec.Image); err != nil {
+				if !errors.Is(err, errAgentUnreachable) {
+					return nil, err
+				}
+				// The agent is absent mid-flight: fall through, the local
+				// check below reports the missing image as before.
+			} else if _, err := resolveRootfsImage(stateRoot, spec.Image); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	directory, err := ensureSandboxDir(stateRoot, identity.SandboxUID)
 	if err != nil {
 		return nil, err

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -21,7 +21,8 @@
 #
 # Environment overrides (all optional):
 #   WORK, KIND_CLUSTER, MINIO_PORT, MINIO_AK, MINIO_SK, MINIO_IMAGE,
-#   MINIO_ENDPOINT, IMAGE_<NAME> (image tags), FC_VERSION, SBX_IMAGE
+#   MINIO_ENDPOINT, IMAGE_<NAME> (image tags), FC_VERSION, SBX_IMAGE,
+#   WARM_IMAGES (=0: skip the pool preheat; the first sandbox pulls cold)
 #
 # Every task logs to $WORK/logs/; failures dump component logs to
 # logs/failure-<task>-<ts>.txt before exiting (never silently).
@@ -61,6 +62,12 @@ ROOTFS_SIZE="${ROOTFS_SIZE:-2Gi}"
 SBX_TEMPLATE="ai-office-sandbox"
 SBX_POOL="firecracker-pool"
 SBX_SANDBOX="sandbox-firecracker"
+
+# WARM_IMAGES=0 skips the pool warmImages preheat: the agent cache starts
+# empty and the FIRST sandbox create triggers the on-demand PinImage pull
+# through DART (the stage-2 cold-start scenario verify measures). Default 1
+# keeps the preheat and the fast delivery-baseline numbers.
+WARM_IMAGES="${WARM_IMAGES:-1}"
 
 # Node labels. The KVM label key is hardcoded by the SandboxTemplate
 # reconciler (sandbox.fast.io/kvm); the firecracker label selects installer/
@@ -876,10 +883,21 @@ assert_publish_layout() {
 
 # --- task 8: SandboxPool -----------------------------------------------------------------------
 pool_up() {
-	kubectl apply -f "$REPO_ROOT/config/samples/pool-firecracker.yaml" >/dev/null
-	wait_for "fastlet pod running" 150 fastlet_pod_ready
-	wait_for "pool warmImages Ready" 300 warm_images_ready
-	pass "fastlet Running + warmImages Ready (agent PinImage closed loop)"
+	if [[ "$WARM_IMAGES" == "1" ]]; then
+		kubectl apply -f "$REPO_ROOT/config/samples/pool-firecracker.yaml" >/dev/null
+		wait_for "fastlet pod running" 150 fastlet_pod_ready
+		wait_for "pool warmImages Ready" 300 warm_images_ready
+		pass "fastlet Running + warmImages Ready (agent PinImage closed loop)"
+	else
+		# Cold-start mode: apply the pool spec WITHOUT the warmImages entry
+		# (it is the last section of the manifest). No preheat: the first
+		# sandbox create pulls the artifact set on demand through DART.
+		local cold_spec="$WORK/pool-firecracker-cold.yaml"
+		sed '/^  warmImages:/,$d' "$REPO_ROOT/config/samples/pool-firecracker.yaml" > "$cold_spec"
+		kubectl apply -f "$cold_spec" >/dev/null
+		wait_for "fastlet pod running" 150 fastlet_pod_ready
+		pass "fastlet Running, NO warmImages (WARM_IMAGES=0: first sandbox pulls cold through DART)"
+	fi
 }
 
 # --- task 9: sandbox + delivery ------------------------------------------------------------------
@@ -2700,7 +2718,7 @@ case "$ACTION" in
 			go version
 			docker --version
 			echo "minio=$MINIO_IMAGE minioPort=$MINIO_PORT bucket=$MINIO_BUCKET"
-			echo "fcVersion=$FC_VERSION sbxImage=$SBX_IMAGE execd=$EXECD"
+			echo "fcVersion=$FC_VERSION sbxImage=$SBX_IMAGE execd=$EXECD warmImages=$WARM_IMAGES"
 			echo "images: controller=$IMG_CONTROLLER agent=$IMG_AGENT builder=$IMG_BUILDER"
 		} > "$LOGS_DIR/environment.txt" 2>&1 || true
 		if [[ -n "$(kind get clusters 2>/dev/null | grep -x "$KIND_CLUSTER" || true)" ]] \

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -22,7 +22,7 @@
 # Environment overrides (all optional):
 #   WORK, KIND_CLUSTER, MINIO_PORT, MINIO_AK, MINIO_SK, MINIO_IMAGE,
 #   MINIO_ENDPOINT, IMAGE_<NAME> (image tags), FC_VERSION, SBX_IMAGE,
-#   WARM_IMAGES (=0: skip the pool preheat; the first sandbox pulls cold)
+#   WARM_IMAGES (=1: restore the preheat; default 0 = on-demand pulls)
 #
 # Every task logs to $WORK/logs/; failures dump component logs to
 # logs/failure-<task>-<ts>.txt before exiting (never silently).
@@ -41,6 +41,10 @@ GEN_DIR="$REPO_ROOT/.integration-env-gen"
 
 KIND_CLUSTER="${KIND_CLUSTER:-firecracker}"
 KIND_CONFIG="$REPO_ROOT/config/dev/kind-firecracker.yaml"
+# P2P is the standard topology: the kind config carries TWO nodes (one
+# fastlet per node, the second warm pull is a peer hit). KIND_SINGLE=1
+# strips the worker for resource-constrained hosts (cache-only, no peer).
+KIND_SINGLE="${KIND_SINGLE:-0}"
 NS="fast-sandbox-system"
 
 MINIO_IMAGE="${MINIO_IMAGE:-minio/minio:latest}"
@@ -63,11 +67,11 @@ SBX_TEMPLATE="ai-office-sandbox"
 SBX_POOL="firecracker-pool"
 SBX_SANDBOX="sandbox-firecracker"
 
-# WARM_IMAGES=0 skips the pool warmImages preheat: the agent cache starts
-# empty and the FIRST sandbox create triggers the on-demand PinImage pull
-# through DART (the stage-2 cold-start scenario verify measures). Default 1
-# keeps the preheat and the fast delivery-baseline numbers.
-WARM_IMAGES="${WARM_IMAGES:-1}"
+# WARM_IMAGES=1 restores the pool warmImages preheat (optional). Default 0:
+# on-demand is the standard stage-2 flow — the agent cache starts empty and
+# the FIRST sandbox create on each node triggers the PinImage pull through
+# DART (peer distribution across the two nodes), which `verify` measures.
+WARM_IMAGES="${WARM_IMAGES:-0}"
 
 # Node labels. The KVM label key is hardcoded by the SandboxTemplate
 # reconciler (sandbox.fast.io/kvm); the firecracker label selects installer/
@@ -207,6 +211,17 @@ agent_leases_drained() {
 	kubectl exec -n "$NS" "$pod" -- sh -c \
 		"curl -fsS --unix-socket /run/fast-sandbox/firecracker/runtime.sock -H 'Content-Type: application/json' -d '{\"podUid\":\"$uid\",\"namespace\":\"$NS\"}' http://firecracker-agent/v1/list-leases" \
 		| grep -q '"leases":\[\]'
+}
+
+# dart_roster_ready reports whether the node-local DART daemon has joined the
+# cluster: its admin /admin/members must list all agent pods (each hostNetwork
+# pod IP == a node, so every member is a peer).
+dart_roster_ready() { # pod expected-members
+	local pod="$1" expected="$2"
+	local members
+	members="$(kubectl exec -n "$NS" "$pod" -- sh -c \
+		'curl -fsS --noproxy "*" http://127.0.0.1:8147/admin/members' 2>/dev/null || true)"
+	[[ "$(printf '%s' "$members" | grep -o '"id":' | wc -l | tr -d ' ')" == "$expected" ]]
 }
 
 jails_cleaned() {
@@ -421,7 +436,7 @@ sysctl_restore() {
 # Disable with XFS_STATEROOT=0; the plain directory then works as before.
 XFS_STATEROOT="${XFS_STATEROOT:-1}"
 XFS_LOOP_FILE="${XFS_LOOP_FILE:-$WORK/fast-sandbox.img}"
-XFS_SIZE="${XFS_SIZE:-16G}"
+XFS_SIZE="${XFS_SIZE:-24G}"
 XFS_MOUNT_POINT="${XFS_MOUNT_POINT:-/var/lib/fast-sandbox}"
 
 ensure_xfsprogs() {
@@ -640,9 +655,20 @@ EOF
 # slow/blocked pull fails loudly instead of inside kind create.
 # KIND_RETAIN=1 keeps the failed node container for diagnosis (kind --retain).
 kind_up() {
-	local create_args=()
+	local create_args=() kind_config="$KIND_CONFIG"
 	[[ "$KIND_RETAIN" == 1 ]] && create_args+=(--retain)
+	if [[ "$KIND_SINGLE" == "1" ]]; then
+		# KIND_SINGLE=1 strips the worker node (P2P becomes cache-only).
+		kind_config="$WORK/kind-firecracker-single.yaml"
+		sed '/^- role: worker/,$d' "$KIND_CONFIG" > "$kind_config"
+		log "single-node topology (KIND_SINGLE=1: no worker, no peer traffic)"
+	fi
 	if [[ -n "$(kind get clusters 2>/dev/null | grep -x "$KIND_CLUSTER" || true)" ]]; then
+		local node_count
+		node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+		if [[ "$KIND_SINGLE" != "1" && "$node_count" -lt 2 ]]; then
+			log "WARNING: existing $node_count-node cluster cannot grow a worker; run 'integration-env.sh down' first for the two-node P2P topology"
+		fi
 		log "cluster $KIND_CLUSTER already exists; reusing (run down first for a clean rebuild)"
 	else
 		if [[ -n "${KIND_NODE_IMAGE:-}" ]]; then
@@ -650,22 +676,24 @@ kind_up() {
 			docker pull -q "$KIND_NODE_IMAGE" || die "kind node image pull failed (KIND_NODE_IMAGE=$KIND_NODE_IMAGE)"
 			log "creating cluster with node image $KIND_NODE_IMAGE"
 			kind create cluster --name "$KIND_CLUSTER" --image "$KIND_NODE_IMAGE" \
-				"${create_args[@]}" --config "$KIND_CONFIG" > "$LOGS_DIR/kind-create.log" 2>&1 \
+				"${create_args[@]}" --config "$kind_config" > "$LOGS_DIR/kind-create.log" 2>&1 \
 				|| fail "kind create failed (full log: $LOGS_DIR/kind-create.log)"
 		else
 			log "creating cluster (pulling kindest/node may take minutes; set KIND_NODE_IMAGE to a mirror if it fails)"
-			kind create cluster --name "$KIND_CLUSTER" --config "$KIND_CONFIG" \
+			kind create cluster --name "$KIND_CLUSTER" --config "$kind_config" \
 				"${create_args[@]}" > "$LOGS_DIR/kind-create.log" 2>&1 \
 				|| fail "kind create failed (full log: $LOGS_DIR/kind-create.log)"
 		fi
 		pass "kind cluster created"
 	fi
 	local node
-	node="$(kind_node)"
-	docker exec "$node" sh -c 'test -e /dev/kvm' || die "KVM not visible inside the kind node container"
-	kubectl label node "$node" "$KVM_NODE_LABEL=true" --overwrite >/dev/null
-	kubectl label node "$node" "$FC_NODE_LABEL=true" --overwrite >/dev/null
-	pass "kind cluster ready (kvm passthrough + labels)"
+	for node in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
+		docker exec "$node" sh -c 'test -e /dev/kvm' || die "KVM not visible inside the kind node container $node"
+		kubectl label node "$node" "$KVM_NODE_LABEL=true" --overwrite >/dev/null
+		kubectl label node "$node" "$FC_NODE_LABEL=true" --overwrite >/dev/null
+		log "node $node: KVM + firecracker labels applied"
+	done
+	pass "kind cluster ready (kvm passthrough + labels on every node)"
 }
 
 # --- task 3: MinIO + credentials -------------------------------------------------------
@@ -808,7 +836,17 @@ agent_up() {
 				"curl -fsS --noproxy '*' --unix-socket /run/fast-sandbox/firecracker/runtime.sock -H 'Content-Type: application/json' -d '{\"podUid\":\"$uid\",\"namespace\":\"$NS\"}' http://firecracker-agent/v1/health | grep -q '\"dartUp\":true'"
 		log "dart: $node dart pid=$(kubectl exec -n "$NS" "$pod" -- sh -c 'pgrep -x dart')"
 	done
-	pass "runtime-agent healthy (UDS /v1/health) + DART daemon up on every node"
+	# P2P roster: every daemon must see every other agent pod as a peer
+	# before any warm pull, so the second node's pull can be served by the
+	# first node's dart instead of the origin.
+	local expected_members
+	expected_members="$(printf '%s' "$pods" | wc -w | tr -d ' ')"
+	for pod in $pods; do
+		node="$(kubectl -n "$NS" get pod "$pod" -o jsonpath='{.spec.nodeName}')"
+		wait_for "dart roster full on $node ($expected_members members)" 90 \
+			dart_roster_ready "$pod" "$expected_members"
+	done
+	pass "runtime-agent healthy (UDS /v1/health) + DART daemons up, roster=$expected_members"
 }
 
 # --- task 7: SandboxTemplate build -----------------------------------------------------------
@@ -884,19 +922,67 @@ assert_publish_layout() {
 # --- task 8: SandboxPool -----------------------------------------------------------------------
 pool_up() {
 	if [[ "$WARM_IMAGES" == "1" ]]; then
+		# Optional preheat mode: warmImages pull the artifact set on every
+		# fastlet node during up (fast delivery baselines; the second node
+		# is still served by the first node's DART peer).
 		kubectl apply -f "$REPO_ROOT/config/samples/pool-firecracker.yaml" >/dev/null
 		wait_for "fastlet pod running" 150 fastlet_pod_ready
 		wait_for "pool warmImages Ready" 300 warm_images_ready
-		pass "fastlet Running + warmImages Ready (agent PinImage closed loop)"
+		p2p_evidence "warm preheat"
+		pass "fastlet Running + warmImages Ready (agent PinImage closed loop, P2P evidence captured)"
 	else
-		# Cold-start mode: apply the pool spec WITHOUT the warmImages entry
-		# (it is the last section of the manifest). No preheat: the first
-		# sandbox create pulls the artifact set on demand through DART.
+		# On-demand is the standard stage-2 flow: apply the pool spec
+		# WITHOUT the warmImages entry (it is the last section of the
+		# manifest). No preheat — the first sandbox create on each node
+		# pulls the artifact set through DART; the evidence lands in the
+		# verify stage (verify 5: P2P evidence).
 		local cold_spec="$WORK/pool-firecracker-cold.yaml"
 		sed '/^  warmImages:/,$d' "$REPO_ROOT/config/samples/pool-firecracker.yaml" > "$cold_spec"
 		kubectl apply -f "$cold_spec" >/dev/null
 		wait_for "fastlet pod running" 150 fastlet_pod_ready
-		pass "fastlet Running, NO warmImages (WARM_IMAGES=0: first sandbox pulls cold through DART)"
+		pass "fastlet Running, on-demand pull (default: first sandbox pulls through DART)"
+	fi
+}
+
+# p2p_evidence asserts the stage-2 outcome from the DART block counters: the
+# published artifact set (rootfs/vmstate/memory) is pulled once per 4MiB
+# block from the origin cluster-wide, and when more than one node served
+# traffic the second node must have been fed by the first node's peer
+# (block_source{peer} > 0). P2P is the standard data plane, so this runs as
+# part of the environment flow, not as a separate experiment.
+p2p_evidence() { # description
+	local description="$1"
+	local pods pod manifest_ref manifest_key build_dir expected_blocks=0
+	local origin_total=0 peer_total=0 cache_total=0 size value source active_nodes=0 node_total
+	manifest_ref="$(kubectl_get "sandboxtemplate/$SBX_TEMPLATE" '{.status.manifestRef}')"
+	manifest_key="${manifest_ref#s3://$MINIO_BUCKET/}"
+	build_dir="$(dirname "$manifest_key")"
+	for object in rootfs.ext4 vmstate.snap memory.snap; do
+		size="$(mc stat --json "chain/$MINIO_BUCKET/$build_dir/$object" 2>/dev/null | jq -r .size)"
+		[[ "$size" =~ ^[0-9]+$ ]] || die "cannot stat published $object (publish incomplete?)"
+		expected_blocks=$((expected_blocks + (size + 4194303) / 4194304))
+	done
+	pods="$(kubectl -n "$NS" get pods -l component=firecracker-runtime-agent -o jsonpath='{.items[*].metadata.name}')"
+	for pod in $pods; do
+		node_total=0
+		while read -r source value; do
+			case "$source" in
+				origin) origin_total=$((origin_total + value)); node_total=$((node_total + value)) ;;
+				peer) peer_total=$((peer_total + value)); node_total=$((node_total + value)) ;;
+				cache) cache_total=$((cache_total + value)); node_total=$((node_total + value)) ;;
+			esac
+		done < <(dart_source_counters "$pod")
+		[[ "$node_total" -gt 0 ]] && active_nodes=$((active_nodes + 1))
+	done
+	log "p2p evidence ($description): expected origin=$expected_blocks blocks; cluster origin=$origin_total peer=$peer_total cache=$cache_total active-nodes=$active_nodes"
+	[[ "$origin_total" -ge "$expected_blocks" ]] || fail "cluster origin $origin_total < expected $expected_blocks blocks"
+	[[ "$origin_total" -le $((expected_blocks + 4)) ]] \
+		|| fail "origin amplified: $origin_total > $((expected_blocks + 4)): pulls were not deduplicated by DART"
+	if [[ "$active_nodes" -ge 2 ]]; then
+		[[ "$peer_total" -gt 0 ]] || fail "no peer traffic across $active_nodes nodes: the second node was not served by the peer"
+		pass "P2P evidence ($description): origin ~1 fetch per block (cluster=$origin_total/$expected_blocks), peer=$peer_total, nodes=$active_nodes"
+	else
+		pass "P2P evidence ($description): origin ~1 fetch per block (cluster=$origin_total/$expected_blocks) on $active_nodes node (no peer needed)"
 	fi
 }
 
@@ -1430,7 +1516,8 @@ verify() {
 	run_stage "verify 1: sandbox create + execd /ping (fastctl)" verify_sandbox "$SBX_SANDBOX"
 	run_stage "verify 2: clone sandbox (shared snapshot, per-clone netns)" verify_sandbox "$second"
 	run_stage "verify 3: max concurrency (2 fastlets, 10 slots)" verify_concurrent
-	run_stage "verify 4: delete all ($((CONCURRENCY + 2))) + cleanup" verify_delete_all
+	run_stage "verify 4: P2P evidence (origin ~1 fetch/block via DART)" p2p_evidence "verify delivery"
+	run_stage "verify 5: delete all ($((CONCURRENCY + 2))) + cleanup" verify_delete_all
 	trap - EXIT
 	resolve_daemon_down
 	port_forward_down
@@ -2642,7 +2729,8 @@ down() {
 		log "down: purging node runtime cache under $XFS_MOUNT_POINT/firecracker"
 		sudo_ rm -rf "$XFS_MOUNT_POINT/firecracker/images" \
 			"$XFS_MOUNT_POINT/firecracker/agent" \
-			"$XFS_MOUNT_POINT/firecracker/jails" 2>/dev/null || true
+			"$XFS_MOUNT_POINT/firecracker/jails" \
+			"$XFS_MOUNT_POINT/firecracker/cache" 2>/dev/null || true
 	fi
 	if docker network ls --format '{{.Name}}' | grep -qx 'kind'; then
 		log "note: docker network 'kind' remains (kind-wide, reused on next up)"

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -14,6 +14,7 @@
 #   ./scripts/integration-env.sh up            # full environment + chain
 #   ./scripts/integration-env.sh status        # component/template/pool health
 #   ./scripts/integration-env.sh verify        # sandbox create + execd /ping
+#   ./scripts/integration-env.sh verify-p2p    # DART data-plane evidence (stage 2)
 #   ./scripts/integration-env.sh down          # teardown, host left clean
 #   ./scripts/integration-env.sh --cleanup     # down after an interrupted run
 #   ./scripts/integration-env.sh up --auto-clean   # down automatically on failure
@@ -778,10 +779,29 @@ installer_up() {
 
 # --- task 6: agent DaemonSet ----------------------------------------------------------------
 agent_up() {
+	kubectl apply -f "$REPO_ROOT/config/dev/dart-service.yaml" >/dev/null
 	kubectl apply -f "$REPO_ROOT/config/dev/agent-daemonset.yaml" >/dev/null
 	wait_for "runtime-agent DaemonSet ready" 120 \
 		kubectl -n "$NS" rollout status daemonset/firecracker-runtime-agent --timeout=10s
-	pass "runtime-agent healthy (UDS /v1/health)"
+
+	# DART P2P daemon (stage 2): every agent pod must have its node-local
+	# dart child answering on the admin plane, and agent /v1/health must
+	# report dartUp=true (a missing dart only degrades pulls to direct S3,
+	# so this is a positive wiring assertion, not a readiness gate).
+	local pod uid node pods
+	pods="$(kubectl -n "$NS" get pods -l component=firecracker-runtime-agent -o jsonpath='{.items[*].metadata.name}')"
+	for pod in $pods; do
+		uid="$(kubectl -n "$NS" get pod "$pod" -o jsonpath='{.metadata.uid}')"
+		node="$(kubectl -n "$NS" get pod "$pod" -o jsonpath='{.spec.nodeName}')"
+		wait_for "dart admin /healthz on $node" 30 \
+			kubectl exec -n "$NS" "$pod" -- sh -c \
+				"curl -fsS --noproxy '*' http://127.0.0.1:8147/healthz | grep -q ok"
+		wait_for "agent health dartUp on $node" 30 \
+			kubectl exec -n "$NS" "$pod" -- sh -c \
+				"curl -fsS --noproxy '*' --unix-socket /run/fast-sandbox/firecracker/runtime.sock -H 'Content-Type: application/json' -d '{\"podUid\":\"$uid\",\"namespace\":\"$NS\"}' http://firecracker-agent/v1/health | grep -q '\"dartUp\":true'"
+		log "dart: $node dart pid=$(kubectl exec -n "$NS" "$pod" -- sh -c 'pgrep -x dart')"
+	done
+	pass "runtime-agent healthy (UDS /v1/health) + DART daemon up on every node"
 }
 
 # --- task 7: SandboxTemplate build -----------------------------------------------------------
@@ -1778,6 +1798,86 @@ verify_execd_api_cleanup() { # sandbox-name
 	pass "sandbox $name deleted; workspace clean"
 }
 
+# --- verify-p2p: DART data-plane evidence (stage 2) ---------------------------
+# Proves the wiring end to end on the real store: agent-signed presigned URL
+# -> node-local DART prefix route -> origin fetch (first read) -> DART block
+# cache (second read, zero new origin blocks). Cross-node peer hits need a
+# second worker; on the single-node topology the cache-hit half is asserted
+# and the origin counter is recorded as the baseline.
+dart_source_counters() { # pod  (stdout: "cache <n>"; "peer <n>"; "origin <n>")
+	local pod="$1" metrics
+	metrics="$(kubectl exec -n "$NS" "$pod" -- sh -c 'curl -fsS --noproxy "*" http://127.0.0.1:8147/metrics' 2>/dev/null || true)"
+	printf '%s\n' "$metrics" | grep -E '^dart_block_source_total' \
+		| sed -E 's/^dart_block_source_total\{source="([a-z]+)"\} ([0-9]+)$/\1 \2/' || true
+}
+
+dart_source_delta() { # before-file after-file -> "cache <n> peer <n> origin <n>"
+	local source delta line_before line_after value_before value_after
+	for source in cache peer origin; do
+		line_before="$(grep "^$source " "$1" || true)"
+		line_after="$(grep "^$source " "$2" || true)"
+		value_before="${line_before##* }"; value_after="${line_after##* }"
+		delta=$(( ${value_after:-0} - ${value_before:-0} ))
+		printf '%s %d\n' "$source" "$delta"
+	done
+}
+
+verify_p2p() {
+	local manifest_ref manifest_key build_key probe_key presigned probe_url
+	local pods pod node before after cache_delta origin_delta peer_delta
+	manifest_ref="$(kubectl_get "sandboxtemplate/$SBX_TEMPLATE" '{.status.manifestRef}')"
+	[[ "$manifest_ref" == s3://* ]] || die "manifestRef is not an s3 URL: $manifest_ref"
+	manifest_key="${manifest_ref#s3://$MINIO_BUCKET/}"
+	build_key="$(dirname "$manifest_key")"
+	probe_key="$build_key/rootfs.ext4"
+
+	# The presigned URL must name the MinIO container IP on the kind network
+	# (the node containers' view of the store), not the host loopback the
+	# dev alias signs for.
+	local endpoint_host
+	endpoint_host="${MINIO_ENDPOINT#http://}"
+	[[ -n "$endpoint_host" ]] || die "MINIO_ENDPOINT is empty (up must run first)"
+	mc alias set chain-net "$MINIO_ENDPOINT" "$MINIO_AK" "$MINIO_SK" >/dev/null 2>&1 || true
+	presigned="$(mc presign --expiry 1h "chain-net/$MINIO_BUCKET/$probe_key")" \
+		|| die "mc presign failed for $probe_key"
+	log "verify-p2p probe object: $probe_key ($(mc stat --json "chain-net/$MINIO_BUCKET/$probe_key" 2>/dev/null | jq -r '.size' 2>/dev/null || echo '?' ) bytes)"
+
+	pods="$(kubectl -n "$NS" get pods -l component=firecracker-runtime-agent -o jsonpath='{.items[*].metadata.name}')"
+	[[ -n "$pods" ]] || die "no agent pods"
+	for pod in $pods; do
+		node="$(kubectl -n "$NS" get pod "$pod" -o jsonpath='{.spec.nodeName}')"
+		before="$(mktemp)"; after="$(mktemp)"
+		dart_source_counters "$pod" > "$before"
+		# First read: cold blocks must come from the origin.
+		log "p2p $node: first read (cold, origin expected)"
+		kubectl exec -n "$NS" "$pod" -- sh -c \
+			"curl -fsS --noproxy '*' -o /dev/null 'http://127.0.0.1:8145/dart/$presigned'" \
+			|| die "first DART read failed on $node"
+		# Second read: served from the DART block cache, origin delta = 0.
+		log "p2p $node: second read (warm, cache expected)"
+		kubectl exec -n "$NS" "$pod" -- sh -c \
+			"curl -fsS --noproxy '*' -o /dev/null 'http://127.0.0.1:8145/dart/$presigned'" \
+			|| die "second DART read failed on $node"
+		dart_source_counters "$pod" > "$after"
+		while read -r source delta; do
+			case "$source" in
+				cache) cache_delta="$delta" ;;
+				peer) peer_delta="$delta" ;;
+				origin) origin_delta="$delta" ;;
+			esac
+		done < <(dart_source_delta "$before" "$after")
+		log "p2p $node: block_source deltas cache=+$cache_delta peer=+$peer_delta origin=+$origin_delta"
+		if [[ "$cache_delta" -gt 0 && "$origin_delta" -eq 0 ]]; then
+			pass "p2p $node: warm read served by the DART block cache (origin delta = 0)"
+		else
+			fail "p2p $node: warm read did not hit the cache (cache=+$cache_delta origin=+$origin_delta)"
+		fi
+		rm -f "$before" "$after"
+	done
+	highlight "== verify-p2p complete: presign -> DART -> origin (cold) -> block cache (warm) =="
+	highlight "   cross-node peer hits require a 2-worker cluster (see docs/guides/firecracker-integration-env.md §8)"
+}
+
 verify_execd_api() {
 	local name="$EXECD_API_SBX" row verdict
 	local api_hang=0 api_pass=0 api_other=0 api_skip=0 api_total=0
@@ -2467,6 +2567,9 @@ status() {
 	log "status: Sandboxes"
 	kubectl -n "$NS" get sandbox -o wide 2>/dev/null || true
 	echo
+	log "status: DART P2P (block_source/cache/peer/origin per node)"
+	dart_metrics_summary || true
+	echo
 	log "status: MinIO"
 	docker ps --filter "name=$MINIO_CONTAINER" --format '{{.Names}} {{.Status}}' 2>/dev/null || true
 	if kind get clusters 2>/dev/null | grep -x "$KIND_CLUSTER" >/dev/null; then
@@ -2474,6 +2577,27 @@ status() {
 	else
 		log "kind cluster: down"
 	fi
+}
+
+# dart_metrics_summary prints the DART block-source counters and member count
+# per agent node — the stage-2 acceptance evidence (origin amplification:
+# N nodes pulling the same image should show origin fetches ~once, peers
+# serving the rest).
+dart_metrics_summary() {
+	local pods pod node metrics
+	pods="$(kubectl -n "$NS" get pods -l component=firecracker-runtime-agent -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)"
+	[[ -n "$pods" ]] || { echo "  (no agent pods)"; return 0; }
+	for pod in $pods; do
+		node="$(kubectl -n "$NS" get pod "$pod" -o jsonpath='{.spec.nodeName}' 2>/dev/null)"
+		metrics="$(kubectl exec -n "$NS" "$pod" -- sh -c 'curl -fsS --noproxy "*" http://127.0.0.1:8147/metrics' 2>/dev/null || true)"
+		echo "  $node:"
+		if [[ -z "$metrics" ]]; then
+			echo "    (DART metrics unreachable)"
+			continue
+		fi
+		printf '%s\n' "$metrics" | grep -E '^dart_block_source_total\{source="(cache|peer|origin)"\}' \
+			| sed 's/^/    /' || true
+	done
 }
 
 # --- down ---------------------------------------------------------------------------------------
@@ -2531,6 +2655,10 @@ usage: integration-env.sh [--cleanup|--auto-clean] {up|down|status|verify}
   status   component / template / pool / sandbox health
   verify   create 2 sandboxes, probe execd /ping, then a max-concurrency
            batch (CONCURRENCY=5 at pool capacity), delete all, assert cleanup
+  verify-p2p
+           DART data-plane evidence (stage 2): presigned URL -> node-local
+           DART -> origin (cold) -> block cache (warm, origin delta 0);
+           cross-node peer hits need a 2-worker cluster (guide §8)
   verify-execd-api
            execd HTTP API usability battery in the Firecracker guest
            (OpenSandbox #1695): /ping, POST /command SSE (echo/pipe/sleep/
@@ -2553,7 +2681,7 @@ for arg in "$@"; do
 	case "$arg" in
 		--cleanup) ACTION="down" ;;
 		--auto-clean) AUTO_CLEAN=1 ;;
-		up|down|status|verify|verify-execd-api|verify-egress) ACTION="$arg" ;;
+		up|down|status|verify|verify-p2p|verify-execd-api|verify-egress) ACTION="$arg" ;;
 		*) usage ;;
 	esac
 done
@@ -2606,6 +2734,11 @@ case "$ACTION" in
 	verify)
 		trap 'on_error verify' ERR
 		verify
+		trap - ERR
+		;;
+	verify-p2p)
+		trap 'on_error verify-p2p' ERR
+		verify_p2p
 		trap - ERR
 		;;
 	verify-execd-api)

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -693,6 +693,14 @@ kind_up() {
 		kubectl label node "$node" "$FC_NODE_LABEL=true" --overwrite >/dev/null
 		log "node $node: KVM + firecracker labels applied"
 	done
+	if [[ "$KIND_SINGLE" != "1" ]]; then
+		# Multi-node kind keeps the control-plane tainted (NoSchedule),
+		# which would strand half the topology: every firecracker workload
+		# (agent DaemonSet, fastlet pool, builder) must be schedulable on
+		# BOTH nodes for the P2P assertions to see two peers.
+		kubectl taint nodes --all node-role.kubernetes.io/control-plane- >/dev/null 2>&1 || true
+		log "control-plane taint removed (both nodes schedulable for the P2P topology)"
+	fi
 	pass "kind cluster ready (kvm passthrough + labels on every node)"
 }
 


### PR DESCRIPTION
## 变更

实现 stage-2（`firecracker-native-p2p-plan.md`）：native artifact 拉取接入节点级 **DART**（P2P 缓存 + HRW 分发树）。**index/manifest 保持直连**——DART 会把上游 404 收敛为 502，破坏 `ErrImageNotReady` 精确语义；P2P 收益主体本就是多 GiB artifact。

### 分层实现

| 层 | 内容 |
|---|---|
| `s3client` | `presignGET`：SigV4 query 签名（与 header 签名共享 signing key/canonical 派生）；单测含**服务端重算签名**校验 |
| `agent.Client` | `WithDART`/`WithPresignTTL`：artifact → `presign → GET <dart>/dart/<url>`；DART 不可达 / 502 / 400 → **fallback 直连 S3**；幂等/整对象 sha256 语义不变 |
| `agent/dart` | 子进程管理器：admin `/healthz` 探活、崩溃重启退避、SIGTERM 优雅关闭、日志锁 |
| 协议 | `HealthResponse.dartUp`（informational，agent 健康不依赖 DART）；`WithDARTProbe` |
| agent 入口 | 编排 dart 子进程（`FAST_SANDBOX_DART_*` env；`DART_ADDR` 空 = stage-1 直连模式）；`run()` 重构保证退出清理 |
| 镜像 | Dockerfile dart 构建阶段 pin `a85f39f`（label + `/usr/local/share/dart-rev`） |
| 清单 | daemonset DART env + 新 headless Service（DNS 发现）；hostNetwork podIP=节点 IP、hostname=节点名（HRW 稳定身份） |
| 集成环境 | `agent_up` 逐节点断言 dart `/healthz` + `dartUp:true`；`status` 打印 `block_source{cache,peer,origin}`；新 `verify-p2p` ACTION（冷读 origin → 热读 cache，origin delta=0） |
| 真机验证 | `live_minio_test.go`（env 门控）：真实 MinIO 服务端验签 + 真实 DART 前缀链路，收口"presign 对 MinIO 签名正确性"风险项 |

### 验证

- `go build ./...` / `go vet ./...` / `go test ./internal/runtime/firecracker/... -count=1` 全绿（新增单测含 `-race`）
- Linux 侧待跑：agent 镜像构建（DART pin）、`integration-env.sh up` 后 `verify-p2p`、双节点 kind 的跨节点 peer 命中（G 节，未实现——单节点验证 cache 段）

### 设计取舍（相对 plan 的两处）

1. **metadata 直连**：plan 原文"index/manifest 小对象也走 DART"，改为保持直连保 404 语义（DART 502 收敛），注释与 commit 已记录
2. **fallback 粒度**：DART 失败按"单次 gateway 尝试 → 直连（自带重试）"实现，无逐块 flap