### PR TITLE
fix(reconciler): fastlet pods never mount the service-account token

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -72,7 +72,7 @@ at `/etc/fast-sandbox/registry/registry.json`. See
 - `FAST_SANDBOX_NETWORK_HOST_NETNS_ROOT`;
 - `FAST_SANDBOX_NETWORK_MTU`.
 
-Pool templates cannot override these variables or other platform-owned containers, mounts, runtime handlers, and security settings.
+Pool templates cannot override these variables or other platform-owned containers, mounts, runtime handlers, and security settings. Fastlet Pods never mount the service-account token (`automountServiceAccountToken: false` is forced), so they have no Kubernetes API access; control-plane components reach Fastlet over the Pod network.
 
 ## Proxy configuration
 

--- a/internal/controlplane/reconciler/sandboxpool_controller.go
+++ b/internal/controlplane/reconciler/sandboxpool_controller.go
@@ -644,6 +644,7 @@ func (r *SandboxPoolReconciler) constructPodWithRuntimePlan(pool *apiv1alpha2.Sa
 	podSpec.HostNetwork = false
 	podSpec.HostPID = false
 	podSpec.RuntimeClassName = nil
+	podSpec.AutomountServiceAccountToken = boolPtr(false)
 	if len(podSpec.Containers) == 0 {
 		return nil, errors.New("fastletTemplate.spec.containers must contain the fastlet container")
 	}

--- a/internal/controlplane/reconciler/sandboxpool_controller_test.go
+++ b/internal/controlplane/reconciler/sandboxpool_controller_test.go
@@ -211,6 +211,7 @@ func TestConstructPodUsesRuntimeProfileAndFixedResources(t *testing.T) {
 		FastletProxyImage: "fastlet-proxy:test", RouteVerifyPublicKey: "test-public-key",
 	}
 	runtimeClass := "must-not-leak"
+	automount := true
 	pool := &apiv1alpha2.SandboxPool{
 		TypeMeta:   metav1.TypeMeta{APIVersion: apiv1alpha2.GroupVersion.String(), Kind: "SandboxPool"},
 		ObjectMeta: metav1.ObjectMeta{Name: "pool-a", Namespace: "default", UID: types.UID("pool-uid")},
@@ -223,7 +224,8 @@ func TestConstructPodUsesRuntimeProfileAndFixedResources(t *testing.T) {
 				CPU: resource.MustParse("1"), Memory: resource.MustParse("1Gi"), PIDs: 256,
 			},
 			FastletTemplate: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
-				RuntimeClassName: &runtimeClass,
+				RuntimeClassName:             &runtimeClass,
+				AutomountServiceAccountToken: &automount,
 				Containers: []corev1.Container{{
 					Name: "fastlet", Image: "fastlet:test",
 					Env: []corev1.EnvVar{
@@ -242,6 +244,8 @@ func TestConstructPodUsesRuntimeProfileAndFixedResources(t *testing.T) {
 	pod, err := reconciler.constructPodWithRuntimePlan(pool, runtimePlan)
 	require.NoError(t, err)
 	require.Nil(t, pod.Spec.RuntimeClassName)
+	require.NotNil(t, pod.Spec.AutomountServiceAccountToken)
+	require.False(t, *pod.Spec.AutomountServiceAccountToken)
 	require.Equal(t, "container", envValue(pod.Spec.Containers[0].Env, "FAST_SANDBOX_RUNTIME"))
 	require.Equal(t, profile.ProfileHash, envValue(pod.Spec.Containers[0].Env, "FAST_SANDBOX_RUNTIME_PROFILE_HASH"))
 	require.Equal(t, profile.ProfileHash, pod.Annotations["fast-sandbox.io/runtime-profile-hash"])


### PR DESCRIPTION
Fastlet and its fastlet-proxy sidecar are inbound-only HTTP servers: the control plane (controller/sandbox-proxy) dials them directly over the Pod network and never goes through the Kubernetes API (heartbeats are pulled by the control plane too, see fastletcontrol/loop.go dialing `http://podIP:5758`). Fastlet therefore never needs API server access.

Force `automountServiceAccountToken: false` when constructing Fastlet Pods so kubelet does not inject a `kube-api-access-*` ServiceAccount token volume.

Changes:
- `constructPodWithRuntimePlan` now forces `podSpec.AutomountServiceAccountToken = false` in the platform-owned reset block (alongside HostNetwork/HostPID/RuntimeClassName); a Pool's `fastletTemplate` cannot override it.
- Unit test: template explicitly sets `automountServiceAccountToken: true`, the constructed Pod still has it false.
- `docs/reference/configuration.md`: note that Fastlet Pods never mount the SA token and have no API server access.

Note: the Pod template hash changes with the spec, so existing Pools will automatically roll their Fastlet Pods to the new template.