### PR TITLE
fix(firecracker): report failed network slot release on delete so retry converges

### DIFF
--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -699,10 +699,15 @@ func (d *Driver) DeleteSandbox(ctx context.Context, sandboxID string) (resultErr
 		return err
 	}
 	d.killAndForget(sandboxID, state.PID)
-	stateIdentity := state.Config.Identity
-	if manager != nil && stateIdentity.SandboxUID != "" {
-		if _, exists := manager.Lookup(sandboxID); exists {
-			_ = manager.Release(ctx, d.networkOwner(&state.Config))
+	if manager != nil && state.Config.Identity.SandboxUID != "" {
+		// Release is reached unconditionally: a slot stuck in Destroying by an
+		// earlier failed release must be retried here, and Release matches
+		// Destroying leftovers itself (the old Lookup-only-Bound guard made
+		// such slots unreachable until a Fastlet restart).
+		if err := manager.Release(ctx, d.networkOwner(&state.Config)); err != nil {
+			klog.ErrorS(err, "DeleteSandbox: network slot release failed; sandbox state retained for delete retry",
+				"sandboxId", sandboxID, "stateDirectory", directory)
+			return fmt.Errorf("release network slot of sandbox %s: %w", sandboxID, err)
 		}
 	}
 	d.mu.RLock()

--- a/internal/runtime/firecracker/driver_test.go
+++ b/internal/runtime/firecracker/driver_test.go
@@ -49,6 +49,23 @@ func (fakeNetworkDriver) Validate(_ context.Context, slot *fastletnetwork.Slot) 
 }
 func (fakeNetworkDriver) Destroy(context.Context, *fastletnetwork.Slot) error { return nil }
 
+// flakyDestroyDriver fails the first slot destroys so DeleteSandbox must
+// surface the release failure and converge on a later retry.
+type flakyDestroyDriver struct {
+	fakeNetworkDriver
+	failuresRemaining int
+	destroyCalls      int
+}
+
+func (f *flakyDestroyDriver) Destroy(ctx context.Context, slot *fastletnetwork.Slot) error {
+	f.destroyCalls++
+	if f.failuresRemaining > 0 {
+		f.failuresRemaining--
+		return errors.New("netns delete failed: EBUSY")
+	}
+	return nil
+}
+
 // memoryStateStore keeps slots in memory for the manager fixture.
 type memoryStateStore struct {
 	mu    sync.Mutex
@@ -89,6 +106,10 @@ func cloneSlotForTest(slot *fastletnetwork.Slot) *fastletnetwork.Slot {
 }
 
 func newNetworkManagerForTest(t *testing.T) *fastletnetwork.Manager {
+	return newNetworkManagerWithDriverForTest(t, fakeNetworkDriver{})
+}
+
+func newNetworkManagerWithDriverForTest(t *testing.T, driver fastletnetwork.Driver) *fastletnetwork.Manager {
 	t.Helper()
 	root := t.TempDir()
 	manager, err := fastletnetwork.NewManager(fastletnetwork.Config{
@@ -96,7 +117,7 @@ func newNetworkManagerForTest(t *testing.T) *fastletnetwork.Manager {
 		StateRoot: root, NetNSRoot: filepath.Join(root, "netns"), HostNetNSRoot: filepath.Join(root, "host-netns"),
 		IDGenerator: func() (string, error) { return "slot-1", nil },
 		Now:         func() time.Time { return time.Unix(1720000000, 0) },
-	}, fakeNetworkDriver{}, newMemoryStateStore())
+	}, driver, newMemoryStateStore())
 	require.NoError(t, err)
 	require.NoError(t, manager.Initialize(context.Background()))
 	return manager
@@ -621,6 +642,40 @@ func TestDeleteSandboxIsIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	_, err = os.Stat(directory)
 	require.True(t, os.IsNotExist(err))
+}
+
+func TestDeleteSandboxRetriesFailedSlotRelease(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Spec.Image)
+	require.NoError(t, fixture.driver.Initialize(context.Background(), ""))
+
+	flaky := &flakyDestroyDriver{failuresRemaining: 1}
+	manager := newNetworkManagerWithDriverForTest(t, flaky)
+	fixture.driver.SetNetworkManager(manager)
+
+	_, err := fixture.driver.EnsureSandbox(context.Background(), ensureInput(&fixture.sandboxSpec))
+	require.NoError(t, err)
+	require.Equal(t, 1, manager.Snapshot().Bound)
+
+	directory, err := sandboxDir(fixture.stateRoot, "sandbox-1")
+	require.NoError(t, err)
+
+	// The slot destroy fails (netns EBUSY): the delete must NOT report
+	// success, and the durable state directory must stay so a delete-failed
+	// retry can re-release the slot once the dying VMM drains.
+	err = fixture.driver.DeleteSandbox(context.Background(), "sandbox-1")
+	require.ErrorContains(t, err, "release network slot")
+	require.DirExists(t, directory)
+	require.Equal(t, 1, flaky.destroyCalls)
+	require.Equal(t, 1, manager.Snapshot().Destroying)
+	require.Zero(t, manager.Snapshot().Bound)
+
+	// The retry reaches the Destroying leftover and converges.
+	require.NoError(t, fixture.driver.DeleteSandbox(context.Background(), "sandbox-1"))
+	require.NoDirExists(t, directory)
+	require.Equal(t, 2, flaky.destroyCalls)
+	require.Zero(t, manager.Snapshot().Destroying)
+	require.Zero(t, manager.Snapshot().Bound)
 }
 
 func TestListManagedSandboxesFiltersNamespace(t *testing.T) {


### PR DESCRIPTION
## Problem

`DeleteSandbox` in the firecracker driver swallowed the network slot `Release` error (`_ = manager.Release(...)`), so:

- a slot whose host netns destroy failed (EBUSY while the dying VMM still holds references) stayed stuck in the **Destroying** phase, in memory and on disk;
- because the release was guarded by `manager.Lookup` (which only matches **Bound** slots), no later delete attempt could reach the stuck slot again — it leaked until a Fastlet restart (Initialize retries Destroying leftovers) or the node janitor (only after the Fastlet Pod dies) reaped it.

The `DeleteSandbox` RPC meanwhile returned success, so the Sandbox Manager recorded the delete as complete and nothing retried.

## Fix

- **Do not swallow the Release error** (internal/runtime/firecracker/driver.go): a failed release now returns an error, which makes the Sandbox Manager record `delete-failed` and lets the control plane retry deletion.
- **Drop the Bound-only `Lookup` guard**: `Release` is now called directly with the owner rebuilt from the durable state. `Release` is idempotent, matches Bound and Destroying leftovers itself, and is a no-op when no slot exists — so a retry converges on the stuck slot once the VMM's references drain.
- **Keep the sandbox state directory on release failure**: it is what lets a delete-failed retry rebuild the owner. It is removed only after the slot release converges.
- Logs the failure with `klog.ErrorS` (sandbox ID + state directory).

## Test

New regression test `TestDeleteSandboxRetriesFailedSlotRelease`: a flaky network driver fails the first destroy (EBUSY). Asserts the first delete returns an error, keeps the state dir, and leaves the slot in Destroying; the second delete retries, converges, removes the state dir, and zeroes Bound/Destroying slots.

Related prior analysis: PR #41 (separate reconciler fix, kept out of this branch).