### PR TITLE
refactor(firecracker): drop dead code, debug-only stage logs, stale comments

### DIFF
--- a/cmd/firecracker-runtime-agent/main.go
+++ b/cmd/firecracker-runtime-agent/main.go
@@ -1,10 +1,5 @@
 package main
 
-// firecracker-runtime-agent serves the node-level UDS management API of
-// the Firecracker on-demand loading design (implementation plan §8): the
-// pull chain (agent.Client) plus the durable lease/journal state, exposed
-// to fastlet drivers as JSON over a Unix socket.
-
 import (
 	"context"
 	"errors"

--- a/internal/runtime/firecracker/agent/cache.go
+++ b/internal/runtime/firecracker/agent/cache.go
@@ -83,12 +83,8 @@ func CachedManifestDigest(stateRoot, image string) (string, bool, error) {
 
 // cacheComplete reports whether the image directory holds a committed pull:
 // the local manifest plus a native file set whose digests match. It is the
-// idempotency check: a complete cache is never touched again.
-//
-// Deliberate trade-off: a committed cache is never refreshed for the same
-// image reference, even when the publisher rebuilds it. Picking up a new
-// build requires clearing the cache directory or using a new tag. Warm-image
-// preheating relies on this "pull once per reference" behavior.
+// idempotency check: a complete cache is never touched again (the trade-off
+// is documented on Client.PullImage).
 func cacheComplete(dir string) (bool, error) {
 	payload, err := os.ReadFile(filepath.Join(dir, manifestName))
 	if err != nil {

--- a/internal/runtime/firecracker/agent/dart/manager.go
+++ b/internal/runtime/firecracker/agent/dart/manager.go
@@ -82,7 +82,6 @@ type Manager struct {
 	logMu  sync.Mutex // serializes manager logs and child output
 
 	mu         sync.Mutex
-	cmd        *exec.Cmd
 	startCount int
 	healthy    atomic.Bool
 	backoff    time.Duration
@@ -133,8 +132,7 @@ func (m *Manager) Args() []string {
 }
 
 // StartCount reports how many times the child has been started (including
-// crash restarts). It is diagnostic: a climbing count means the child is
-// crash-looping, visible next to the agent's DartUp health.
+// crash restarts); tests assert the crash-restart discipline on it.
 func (m *Manager) StartCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -208,7 +206,6 @@ func (m *Manager) start(ctx context.Context) (*exec.Cmd, <-chan error, error) {
 		return nil, nil, err
 	}
 	m.mu.Lock()
-	m.cmd = command
 	m.startCount++
 	m.mu.Unlock()
 	m.healthy.Store(false) // not probed yet
@@ -269,9 +266,7 @@ func (m *Manager) backoffDelay(ctx context.Context) bool {
 		m.backoff = restartBackoffMax
 	}
 	m.mu.Unlock()
-	if delay > 0 {
-		m.logf("dart: restarting in %s\n", delay)
-	}
+	m.logf("dart: restarting in %s\n", delay)
 	timer := time.NewTimer(delay)
 	defer timer.Stop()
 	select {

--- a/internal/runtime/firecracker/agent/dart_test.go
+++ b/internal/runtime/firecracker/agent/dart_test.go
@@ -82,15 +82,6 @@ func (d *fakeDART) hitCount() int {
 	return len(d.hits)
 }
 
-func (d *fakeDART) latestUpstream() string {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if len(d.hits) == 0 {
-		return ""
-	}
-	return d.hits[len(d.hits)-1]
-}
-
 // --- B: presigned URL construction and SigV4 query signature ---------------
 
 func TestPresignGETParametersAndSignature(t *testing.T) {
@@ -105,7 +96,7 @@ func TestPresignGETParametersAndSignature(t *testing.T) {
 		accessKey: "test-access-key", secretKey: "test-secret-key",
 		http: &http.Client{Timeout: time.Second},
 	}
-	presigned, err := client.presignGET("index/abc.json", time.Minute)
+	presigned, err := client.presignGET("index/abc.json")
 	require.NoError(t, err)
 
 	parsed, err := url.Parse(presigned)
@@ -129,7 +120,7 @@ func TestPresignGETParametersAndSignature(t *testing.T) {
 	require.True(t, strings.HasPrefix(query.Get("X-Amz-Credential"), "test-access-key/"))
 	require.Contains(t, query.Get("X-Amz-Credential"), "/us-east-1/s3/aws4_request")
 	require.Equal(t, "host", query.Get("X-Amz-SignedHeaders"))
-	require.Equal(t, "60", query.Get("X-Amz-Expires"))
+	require.Equal(t, "3600", query.Get("X-Amz-Expires"))
 	require.NotEmpty(t, query.Get("X-Amz-Date"))
 	require.Len(t, query.Get("X-Amz-Signature"), 64)
 }
@@ -152,7 +143,7 @@ func TestPresignGETSignatureValidatesServerSide(t *testing.T) {
 		accessKey: accessKey, secretKey: secret,
 		http: &http.Client{Timeout: time.Second},
 	}
-	presigned, err := client.presignGET("digest16/rootfs.ext4", time.Hour)
+	presigned, err := client.presignGET("digest16/rootfs.ext4")
 	require.NoError(t, err)
 	response, err := http.Get(presigned)
 	require.NoError(t, err)
@@ -211,7 +202,7 @@ func TestPullImageArtifactsViaDART(t *testing.T) {
 	store, client, _, artifacts := publishFixture(t)
 	gateway := newFakeDART(t)
 	dartClient := &Client{s3: client, dart: &dartGateway{
-		base: gateway.url(), ttl: time.Hour, http: &http.Client{Timeout: time.Minute},
+		base: gateway.url(), http: &http.Client{Timeout: time.Minute},
 	}}
 	root := t.TempDir()
 
@@ -259,7 +250,7 @@ func TestPullImageDARTUnreachableFallsBackToDirect(t *testing.T) {
 	gateway.server.Close() // simulate a dead DART process
 
 	dartClient := &Client{s3: client, dart: &dartGateway{
-		base: dartBase, ttl: time.Hour, http: &http.Client{Timeout: time.Second},
+		base: dartBase, http: &http.Client{Timeout: time.Second},
 	}}
 	require.NoError(t, dartClient.PullImage(context.Background(), t.TempDir(), testImage))
 
@@ -277,7 +268,7 @@ func TestPullImageDARTGatewayErrorFallsBackToDirect(t *testing.T) {
 	gateway.mu.Unlock()
 
 	dartClient := &Client{s3: client, dart: &dartGateway{
-		base: gateway.url(), ttl: time.Hour, http: &http.Client{Timeout: time.Second},
+		base: gateway.url(), http: &http.Client{Timeout: time.Second},
 	}}
 	require.NoError(t, dartClient.PullImage(context.Background(), t.TempDir(), testImage))
 
@@ -295,7 +286,7 @@ func TestPullImageDARTKeepsImageNotReadySemantics(t *testing.T) {
 	gateway := newFakeDART(t)
 
 	dartClient := &Client{s3: client, dart: &dartGateway{
-		base: gateway.url(), ttl: time.Hour, http: &http.Client{Timeout: time.Second},
+		base: gateway.url(), http: &http.Client{Timeout: time.Second},
 	}}
 	err := dartClient.PullImage(context.Background(), t.TempDir(), testImage)
 	require.ErrorIs(t, err, runtimecontract.ErrImageNotReady)

--- a/internal/runtime/firecracker/agent/doc.go
+++ b/internal/runtime/firecracker/agent/doc.go
@@ -1,9 +1,6 @@
 // Package agent implements the node-level firecracker-runtime-agent pull
-// layer (stage 1 of the Firecracker on-demand loading design): the consumer
-// side of the addressing chain SandboxSpec.Image -> index -> manifest ->
+// layer of the Firecracker on-demand loading design: the consumer side of
+// the addressing chain SandboxSpec.Image -> index -> manifest ->
 // content-addressed native artifacts, materialized in the cache shared with
 // the driver (<StateRoot>/images/<sha256(image)>/).
-//
-// Stage 1 scope: no UDS server, no P2P, no overlaybd, and the driver keeps
-// its local PullImage until the agent wiring lands.
 package agent

--- a/internal/runtime/firecracker/agent/index_test.go
+++ b/internal/runtime/firecracker/agent/index_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -65,16 +64,6 @@ func TestIndexKeyMatchesCacheKey(t *testing.T) {
 	// addressing chain works without control-plane coordination.
 	require.Equal(t, indexKey(testImage), "index/"+imageKey(testImage)+".json")
 	require.Len(t, imageKey(testImage), 64)
-}
-
-// s3NotFoundServer returns 404 for every path.
-func s3NotFoundServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.NotFound(w, nil)
-	}))
-	t.Cleanup(server.Close)
-	return server
 }
 
 // clientForEndpoint builds a client without the fake store (used for

--- a/internal/runtime/firecracker/agent/live_minio_test.go
+++ b/internal/runtime/firecracker/agent/live_minio_test.go
@@ -67,7 +67,7 @@ func TestLivePresignedGETAgainstMinIO(t *testing.T) {
 	endpoint, accessKey, secretKey, bucket, key, wantSHA := liveMinioEnv(t)
 	client := liveS3Client(endpoint, accessKey, secretKey, bucket)
 
-	presigned, err := client.presignGET(key, time.Hour)
+	presigned, err := client.presignGET(key)
 	require.NoError(t, err)
 	response, err := http.Get(presigned)
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestLivePullThroughDART(t *testing.T) {
 		t.Skip("FS_LIVE_DART_ADDR not set; the DART-leg of the live check is opt-in")
 	}
 	client := &Client{s3: liveS3Client(endpoint, accessKey, secretKey, bucket), dart: &dartGateway{
-		base: dartBase, ttl: time.Hour, http: &http.Client{Timeout: 10 * time.Minute},
+		base: dartBase, http: &http.Client{Timeout: 10 * time.Minute},
 	}}
 
 	for read := 1; read <= 2; read++ {
@@ -158,7 +158,7 @@ func TestLivePeerHitThroughTwoDARTNodes(t *testing.T) {
 	origin := func() int { return dartCounter(t, adminA, "origin") + dartCounter(t, adminB, "origin") }
 	readVia := func(name, base string) {
 		client := &Client{s3: liveS3Client(endpoint, accessKey, secretKey, bucket), dart: &dartGateway{
-			base: base, ttl: time.Hour, http: &http.Client{Timeout: 10 * time.Minute},
+			base: base, http: &http.Client{Timeout: 10 * time.Minute},
 		}}
 		body, err := client.getArtifact(context.Background(), key)
 		require.NoError(t, err)

--- a/internal/runtime/firecracker/agent/protocol/types.go
+++ b/internal/runtime/firecracker/agent/protocol/types.go
@@ -38,7 +38,7 @@ type ErrorCode string
 
 const (
 	ErrorInvalidRequest ErrorCode = "InvalidRequest" // 400
-	ErrorUnauthorized   ErrorCode = "Unauthorized"   // 403 (identity header missing)
+	ErrorUnauthorized   ErrorCode = "Unauthorized"   // 403 (identity missing or empty)
 	ErrorConflict       ErrorCode = "Conflict"       // 409 (idempotency key or ownership mismatch)
 	ErrorNotFound       ErrorCode = "NotFound"       // 404 (image not published)
 	ErrorInternal       ErrorCode = "Internal"       // 500

--- a/internal/runtime/firecracker/agent/pull.go
+++ b/internal/runtime/firecracker/agent/pull.go
@@ -14,30 +14,27 @@ import (
 	"os"
 	"path"
 	"strings"
-	"time"
 
 	"fast-sandbox/internal/registryconfig"
 	runtimecontract "fast-sandbox/internal/runtime/contract"
 )
 
 // Client pulls published Firecracker artifacts for an image reference into
-// the node-local cache. The pull chain is stage-1 pure (UDS server, device
-// leasing, and driver wiring arrive with the runtime-agent work); stage 2
-// adds the DART P2P data plane for the artifact bytes.
+// the node-local cache. When a DART P2P gateway is configured (WithDART)
+// artifact bytes route through it with a direct header-signed S3 fallback.
 type Client struct {
 	s3 *s3Client
 	// dart is the DART P2P gateway configuration; nil keeps the pull on the
-	// direct header-signed S3 path (local mode / stage-1 behavior).
+	// direct header-signed S3 path.
 	dart *dartGateway
 }
 
-// dartGateway routes artifact GETs through a node-local DART instance
-// (stage-2 P2P). The agent signs presigned origin URLs; DART fetches,
-// caches and P2P-distributes the blocks, and the agent still verifies the
-// whole-object digest against the manifest.
+// dartGateway routes artifact GETs through a node-local DART instance. The
+// agent signs presigned origin URLs; DART fetches, caches and P2P-distributes
+// the blocks, and the agent still verifies the whole-object digest against
+// the manifest.
 type dartGateway struct {
 	base string // e.g. http://127.0.0.1:8145 (prefix route /dart/<upstream-url>)
-	ttl  time.Duration
 	http *http.Client
 }
 
@@ -55,16 +52,13 @@ func NewClient(storeRoot string, credential registryconfig.Credential, options .
 	}
 	client := &Client{s3: s3}
 	if config.dartBase != "" {
+		httpClient := config.httpClient
+		if httpClient == nil {
+			httpClient = &http.Client{Timeout: defaultS3RequestTimeout}
+		}
 		client.dart = &dartGateway{
 			base: strings.TrimRight(config.dartBase, "/"),
-			ttl:  config.presignTTL,
-			http: config.httpClient,
-		}
-		if client.dart.ttl <= 0 {
-			client.dart.ttl = time.Hour
-		}
-		if client.dart.http == nil {
-			client.dart.http = &http.Client{Timeout: defaultS3RequestTimeout}
+			http: httpClient,
 		}
 	}
 	return client, nil
@@ -78,7 +72,6 @@ type optionsConfig struct {
 	endpoint   string
 	httpClient *http.Client
 	dartBase   string
-	presignTTL time.Duration
 }
 
 // WithRegion overrides the SigV4 signing region (default us-east-1).
@@ -102,16 +95,9 @@ func WithHTTPClient(client *http.Client) Option {
 // at base (e.g. http://127.0.0.1:8145). Metadata (image index and manifest)
 // stays on the direct header-signed path: their 404 semantics must survive
 // exactly, and DART collapses origin errors into 502. Empty base = direct
-// mode (the stage-1 behavior).
+// mode.
 func WithDART(base string) Option {
 	return func(config *optionsConfig) { config.dartBase = base }
-}
-
-// WithPresignTTL bounds the lifetime of the presigned URLs handed to DART.
-// The default is one hour; the TTL only needs to cover one artifact fetch
-// (DART reuses the URL for cache misses back to the origin).
-func WithPresignTTL(ttl time.Duration) Option {
-	return func(config *optionsConfig) { config.presignTTL = ttl }
 }
 
 // PullImage resolves the addressing chain for image and materializes the
@@ -225,7 +211,7 @@ func (c *Client) getArtifact(ctx context.Context, storeKey string) (io.ReadClose
 // problems as 400, so a non-200 answer here is an httpError for the caller
 // to classify.
 func (c *Client) getArtifactViaDART(ctx context.Context, storeKey string) (io.ReadCloser, error) {
-	presigned, err := c.s3.presignGET(storeKey, c.dart.ttl)
+	presigned, err := c.s3.presignGET(storeKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/firecracker/agent/s3client.go
+++ b/internal/runtime/firecracker/agent/s3client.go
@@ -230,17 +230,18 @@ var emptyPayloadHash = sha256Hex(nil)
 // signing; the request still carries no body).
 const unsignedPayload = "UNSIGNED-PAYLOAD"
 
-// presignGET returns a SigV4 query-signed GET URL for a store object, valid
-// for ttl. The signature is derived from the same canonical request as the
-// header signing in sign (identical path, host, region scope and signing
-// key); only the carrier differs — the X-Amz-* parameters travel in the
-// query string and the only signed header is host. Presigned URLs are handed
-// to DART so the P2P layer can fetch from the origin without ever seeing the
-// access key pair.
-func (c *s3Client) presignGET(storeKey string, ttl time.Duration) (string, error) {
-	if ttl <= 0 {
-		ttl = time.Hour
-	}
+// presignGETTTL bounds a presigned URL. The TTL only needs to cover one
+// artifact fetch: DART reuses the URL for cache misses back to the origin.
+const presignGETTTL = time.Hour
+
+// presignGET returns a SigV4 query-signed GET URL for a store object. The
+// signature is derived from the same canonical request as the header signing
+// in sign (identical path, host, region scope and signing key); only the
+// carrier differs — the X-Amz-* parameters travel in the query string and
+// the only signed header is host. Presigned URLs are handed to DART so the
+// P2P layer can fetch from the origin without ever seeing the access key
+// pair.
+func (c *s3Client) presignGET(storeKey string) (string, error) {
 	key := storeKey
 	if c.prefix != "" {
 		key = c.prefix + "/" + storeKey
@@ -263,7 +264,7 @@ func (c *s3Client) presignGET(storeKey string, ttl time.Duration) (string, error
 		{"X-Amz-Algorithm", "AWS4-HMAC-SHA256"},
 		{"X-Amz-Credential", c.accessKey + "/" + scope},
 		{"X-Amz-Date", amzDate},
-		{"X-Amz-Expires", strconv.FormatInt(int64(ttl/time.Second), 10)},
+		{"X-Amz-Expires", strconv.FormatInt(int64(presignGETTTL/time.Second), 10)},
 		{"X-Amz-SignedHeaders", "host"},
 	}
 	canonicalQuery := canonicalQueryString(parameters)

--- a/internal/runtime/firecracker/agent/server/server.go
+++ b/internal/runtime/firecracker/agent/server/server.go
@@ -37,7 +37,7 @@ const (
 	maxRequestBytes = 4 << 20
 )
 
-// Server is the UDS HTTP service. A nil Backend reports Unavailable.
+// Server is the UDS HTTP service. A nil Backend answers 500 ErrorInternal.
 type Server struct {
 	Backend    Backend
 	socketPath string
@@ -321,8 +321,6 @@ func writeError(writer http.ResponseWriter, err error) {
 		classified = typed
 	} else if errors.Is(err, agentstate.ErrConflict) {
 		classified = &Error{Code: agentprotocol.ErrorConflict, Message: err.Error(), Cause: err}
-	} else if errors.Is(err, agentstate.ErrLeaseNotFound) {
-		classified = &Error{Code: agentprotocol.ErrorNotFound, Message: err.Error(), Cause: err}
 	} else if errors.Is(err, runtimecontract.ErrImageNotReady) {
 		classified = &Error{Code: agentprotocol.ErrorNotFound, Message: err.Error(), Cause: err}
 	}

--- a/internal/runtime/firecracker/agent/state/journal.go
+++ b/internal/runtime/firecracker/agent/state/journal.go
@@ -1,12 +1,5 @@
 package state
 
-// The journal is an append-only JSON line log ordering every mutating RPC:
-// an intent line is fsynced before the side effect runs, a result line
-// after it commits. Recovery replays completed pairs in file order and
-// drops intents without results (crashes mid-execution). The only
-// legitimate malformed content is a trailing partial line from a crash
-// mid-append, which is truncated; mid-file corruption fails recovery.
-
 import (
 	"bytes"
 	"encoding/json"

--- a/internal/runtime/firecracker/agent/state/leases.go
+++ b/internal/runtime/firecracker/agent/state/leases.go
@@ -46,9 +46,6 @@ var (
 	// request id was already committed by a different pod, or the op
 	// collides with state owned by another pod.
 	ErrConflict = errors.New("conflict")
-	// ErrLeaseNotFound reports that a release or lookup targeted a lease
-	// the agent does not know.
-	ErrLeaseNotFound = errors.New("lease not found")
 )
 
 // Options configures the state for tests.
@@ -80,7 +77,6 @@ type imageRefs struct {
 type completed struct {
 	op        Op
 	podUID    string
-	namespace string
 	pinDigest string
 	lease     *agentprotocol.Lease
 }
@@ -308,7 +304,7 @@ func (s *State) ReleaseDevices(id agentprotocol.Identity, leaseID string) error 
 	return err
 }
 
-// GetLease returns a lease by id (for ListLeases and ownership checks).
+// GetLease returns a lease by id.
 func (s *State) GetLease(leaseID string) (agentprotocol.Lease, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -370,7 +366,7 @@ func (s *State) run(id agentprotocol.Identity, op Op, args any, do func() (any, 
 		}
 	}()
 	apply(result)
-	entry := completed{op: op, podUID: id.PodUID, namespace: id.Namespace}
+	entry := completed{op: op, podUID: id.PodUID}
 	entry.setResult(result)
 	s.completed[id.RequestID] = entry
 	resultPayload := mustJSON(result)
@@ -413,7 +409,7 @@ func (s *State) rememberCompleted(id agentprotocol.Identity, op Op, lease *agent
 		}
 		return nil
 	}
-	s.completed[id.RequestID] = completed{op: op, podUID: id.PodUID, namespace: id.Namespace, lease: lease}
+	s.completed[id.RequestID] = completed{op: op, podUID: id.PodUID, lease: lease}
 	return nil
 }
 
@@ -452,7 +448,7 @@ func (s *State) recover() error {
 // replayApply rebuilds the effect of one committed journal entry pair.
 func (s *State) replayApply(intent, result journalEntry) error {
 	op := Op(intent.Op)
-	completed := completed{op: op, podUID: intent.PodUID, namespace: intent.Namespace}
+	completed := completed{op: op, podUID: intent.PodUID}
 	switch op {
 	case OpPinImage:
 		var args pinImageArgs

--- a/internal/runtime/firecracker/agent_client_test.go
+++ b/internal/runtime/firecracker/agent_client_test.go
@@ -71,15 +71,6 @@ func (s *fakeAgentServer) recorded() []string {
 	return append([]string(nil), s.requests...)
 }
 
-// wireAgent connects the fake server to the driver fields.
-func (f *driverFixture) wireAgent(t *testing.T, server *fakeAgentServer) {
-	t.Helper()
-	f.driver.newAgentClient = func(string) (AgentClient, error) {
-		return NewAgentClient(server.socket, "tenant-a", "pod-1")
-	}
-	f.driver.agentSocket = server.socket
-}
-
 func TestAgentClientPinImageRequestAndResponse(t *testing.T) {
 	server := newFakeAgentServer(t)
 	server.responses[agentprotocol.RoutePinImage] = func(writer http.ResponseWriter, _ []byte) {

--- a/internal/runtime/firecracker/client.go
+++ b/internal/runtime/firecracker/client.go
@@ -233,18 +233,11 @@ func pathEscape(value string) string {
 	// guard rather than a lookup.
 	var escaped bytes.Buffer
 	for _, character := range value {
-		if isSafePathCharacter(character) {
+		if isSafeIDCharacter(character) {
 			escaped.WriteRune(character)
 			continue
 		}
 		fmt.Fprintf(&escaped, "%%%02X", character)
 	}
 	return escaped.String()
-}
-
-func isSafePathCharacter(character rune) bool {
-	return (character >= 'a' && character <= 'z') ||
-		(character >= 'A' && character <= 'Z') ||
-		(character >= '0' && character <= '9') ||
-		character == '-' || character == '_' || character == '.'
 }

--- a/internal/runtime/firecracker/doc.go
+++ b/internal/runtime/firecracker/doc.go
@@ -1,13 +1,14 @@
 // Package firecracker implements the direct Firecracker runtime driver for
-// Fastlet: one microVM booted on demand per Sandbox create request, launched
-// as a plain child process with an immutable per-Sandbox identity (matching
-// the NodeJanitor residual-process contract: binary "firecracker" + "--id").
+// Fastlet: one microVM restored from a golden snapshot per Sandbox create
+// request, launched as a child process (jailer-chrooted when configured)
+// with an immutable per-Sandbox identity (matching the NodeJanitor
+// residual-process contract: binary "firecracker" + "--id").
 //
 // Networking comes from the pre-provisioned Fastlet slot: the slot carries
 // the pod-side IP and the guest tap prepared by GuestVMNetNSDriver, so a
-// create performs no ip/iptables commands. The guest owns the address after
-// the slot IP (DNATed at the host) and is configured via the kernel ip=
-// boot argument. Rootfs comes from the content-addressed cache (copied per
+// create performs no ip/iptables commands. Restored clones share the static
+// guest address baked into the golden snapshot, DNATed per slot at the
+// host. Rootfs comes from the content-addressed cache (reflink-copied per
 // instance), and durable state in StateRoot/sandboxes/<id>/meta.json anchors
 // idempotent create, delete, and Fastlet-restart recovery.
 //

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -534,7 +534,6 @@ func (d *Driver) EnsureSandbox(ctx context.Context, input *fastletapi.EnsureSand
 		infraDiagnostics = instance.Diagnostics
 		infraPrepared = true
 		infraDur = time.Since(infraStarted)
-		klog.V(4).InfoS("firecracker Infra Components delivered", "sandboxId", identity.SandboxUID, "services", len(instance.Services), "duration", infraDur.String())
 	}
 
 	// Restore-only startup: the golden snapshot carries the guest network
@@ -565,7 +564,6 @@ func (d *Driver) EnsureSandbox(ctx context.Context, input *fastletapi.EnsureSand
 
 	launchCtx, launchSpan := observability.Start(ctx, "fastlet.firecracker.launch")
 	launchStarted := time.Now()
-	spawnStarted := time.Now()
 	process, err := d.launchVM(launchCtx, launchConfig{
 		BinaryPath: d.config.BinaryPath,
 		SandboxID:  identity.SandboxUID,
@@ -573,7 +571,6 @@ func (d *Driver) EnsureSandbox(ctx context.Context, input *fastletapi.EnsureSand
 		WorkingDir: directory,
 		LogPath:    filepath.Join(logDir, processLogName),
 	}, slot)
-	spawnDur := time.Since(spawnStarted)
 	if err == nil {
 		state.PID = process.PID()
 		d.rememberProcess(identity.SandboxUID, process)
@@ -583,9 +580,7 @@ func (d *Driver) EnsureSandbox(ctx context.Context, input *fastletapi.EnsureSand
 			observability.End(launchSpan, saveErr)
 			return nil, saveErr
 		}
-		socketStarted := time.Now()
 		err = d.waitSocket(launchCtx, state.APIAddress, firecrackerSocketWaitTimeout)
-		socketWaitDur := time.Since(socketStarted)
 		if err != nil {
 			detail := readProcessLog(logDir)
 			d.killAndForget(identity.SandboxUID, process.PID())
@@ -593,7 +588,6 @@ func (d *Driver) EnsureSandbox(ctx context.Context, input *fastletapi.EnsureSand
 			observability.End(launchSpan, err)
 			return nil, fmt.Errorf("%w: firecracker API socket did not appear: %v%s", ErrRuntimeNotInitialized, err, detail)
 		}
-		klog.V(4).InfoS("firecracker API socket ready", "sandboxId", identity.SandboxUID, "spawn", spawnDur.String(), "socketWait", socketWaitDur.String())
 	}
 	observability.End(launchSpan, err)
 	if err != nil {
@@ -948,15 +942,6 @@ func readProcessLog(stateDir string) string {
 		tail = tail[len(tail)-4096:]
 	}
 	return "\nfirecracker process log:\n" + string(tail)
-}
-
-// bootVM starts the microVM and waits until the machine state is Running.
-// It is used by the snapshot preparation path (cold boot: InstanceStart).
-func bootVM(ctx context.Context, client *Client, timeoutSeconds int32) (int, error) {
-	if err := client.Start(ctx); err != nil {
-		return 0, fmt.Errorf("start Firecracker instance: %w", err)
-	}
-	return waitVMRunning(ctx, client, timeoutSeconds)
 }
 
 // resumeVM resumes a microVM restored from a snapshot and waits until it is

--- a/internal/runtime/firecracker/e2e_test.go
+++ b/internal/runtime/firecracker/e2e_test.go
@@ -432,6 +432,16 @@ func runE2EOnce(t *testing.T, useInfra bool) {
 // network_overrides expects), so the reuse check must reject it.
 const e2ePrepVersion = 2
 
+// bootVM starts the microVM and waits until the machine state is Running.
+// It serves the golden-snapshot prep path only (cold boot: InstanceStart);
+// the production driver is restore-only and resumes via resumeVM.
+func bootVM(ctx context.Context, client *Client, timeoutSeconds int32) (int, error) {
+	if err := client.Start(ctx); err != nil {
+		return 0, fmt.Errorf("start Firecracker instance: %w", err)
+	}
+	return waitVMRunning(ctx, client, timeoutSeconds)
+}
+
 // prepareE2EGoldenSnapshot produces (or reuses) the golden snapshot set of
 // the E2E image (方式 B self-bootstrap, golden-restore plan §5): a
 // preparation VM cold-boots the kernel once with a NIC and a static guest

--- a/internal/runtime/firecracker/infra_delivery.go
+++ b/internal/runtime/firecracker/infra_delivery.go
@@ -6,12 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"time"
 
 	fastletinfra "fast-sandbox/internal/fastlet/infra"
 	fastletnetwork "fast-sandbox/internal/fastlet/network"
-
-	"k8s.io/klog/v2"
 )
 
 // ensureLoopDevices creates the loop device nodes the rootfs loop mount
@@ -70,15 +67,9 @@ func deliverGuestInfra(ctx context.Context, runner fastletnetwork.CommandRunner,
 		return err
 	}
 
-	// Per-step timing isolates the GuestCopy cost: mounting a multi-GiB
-	// sparse ext4 image read-write can initialize metadata/journal regions
-	// (allocating blocks over the holes), which is where the delivery
-	// latency tends to hide.
-	mountStarted := time.Now()
 	if _, err := runner.Run(ctx, "mount", "-o", "loop", rootfsImage, mountpoint); err != nil {
 		return fmt.Errorf("mount guest rootfs for Infra delivery: %w", err)
 	}
-	klog.V(4).InfoS("infra delivery: rootfs mounted", "rootfs", rootfsImage, "mountMs", time.Since(mountStarted).Milliseconds())
 	mounted := true
 	defer func() {
 		if mounted {
@@ -86,7 +77,6 @@ func deliverGuestInfra(ctx context.Context, runner fastletnetwork.CommandRunner,
 		}
 	}()
 
-	copyStarted := time.Now()
 	for _, mount := range instance.Mounts {
 		if mount.Source == "" || mount.Destination == "" {
 			continue
@@ -107,12 +97,9 @@ func deliverGuestInfra(ctx context.Context, runner fastletnetwork.CommandRunner,
 			return fmt.Errorf("copy Infra artifact to %s: %w", mount.Destination, err)
 		}
 	}
-	klog.V(4).InfoS("infra delivery: artifacts copied", "files", len(instance.Mounts), "copyMs", time.Since(copyStarted).Milliseconds())
-	umountStarted := time.Now()
 	if _, err := runner.Run(ctx, "umount", mountpoint); err != nil {
 		return err
 	}
-	klog.V(4).InfoS("infra delivery: rootfs unmounted", "umountMs", time.Since(umountStarted).Milliseconds())
 	mounted = false
 	return nil
 }

--- a/internal/runtime/firecracker/infra_e2e_test.go
+++ b/internal/runtime/firecracker/infra_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build firecracker
+
 package firecracker
 
 import (

--- a/internal/runtime/firecracker/restore.go
+++ b/internal/runtime/firecracker/restore.go
@@ -110,7 +110,7 @@ func validateRestoreMachineConfig(spec fastletapi.SandboxSpec, config runtimecat
 	if _, err := machineVCPUs(machine.VCPU); err != nil {
 		return err
 	}
-	snapshotMiB, err := machineMemMiB(machine.Memory)
+	snapshotMiB, err := parseMemMiB(machine.Memory)
 	if err != nil {
 		return err
 	}
@@ -137,11 +137,6 @@ func machineVCPUs(value string) (int, error) {
 		return 0, fmt.Errorf("%w: manifest vcpu %q yields no vCPU", ErrInvalidConfig, value)
 	}
 	return vcpus, nil
-}
-
-// machineMemMiB parses the manifest memory quantity into MiB.
-func machineMemMiB(value string) (int, error) {
-	return parseMemMiB(value)
 }
 
 // parseMemMiB parses a resource quantity into whole MiB.


### PR DESCRIPTION
Systematic cleanup of the firecracker runtime (`internal/runtime/firecracker`, `agent/*`, `cmd/firecracker-runtime-agent`) after a full code/comment/log review. **Safe scope**: no behavioral change to the restore driver, the agent UDS RPC/wire surface, or the `firecracker`-tagged e2e flow.

### Dead code
- `machineMemMiB` pass-through wrapper; `isSafePathCharacter` (byte-identical duplicate of `isSafeIDCharacter`)
- `agent` `WithPresignTTL` option (zero references) + `presignTTL`/`dartGateway.ttl` wiring; `presignGET` loses the never-set TTL knob (fixed 1 h presign TTL)
- `dart.Manager.cmd` write-only field; always-true `delay > 0` restart-log guard
- `state.completed.namespace` (written 3×, never read); `ErrLeaseNotFound` sentinel nothing returns + its unreachable, duplicate mapping branch in `server.writeError`
- unused test helpers: `s3NotFoundServer`, `driverFixture.wireAgent`, `fakeDART.latestUpstream`
- `bootVM` moved from `driver.go` into the `firecracker`-tagged `e2e_test.go` (its only caller — it is e2e snapshot-prep code, not production code); `infra_e2e_test.go` gains the missing `firecracker` build tag so the default suite stops compiling an orphan helper file

### Debug-only logs
Per-step timing logs at `V(4)` that duplicate the per-create Info summary (which also persists `StageDurations`):
- infra delivery mount/copy/umount stopwatch logs and timers
- `EnsureSandbox` “Infra Components delivered” and “API socket ready” stage-split logs and their unused timers

### Stale / redundant comments
- stage-1/stage-2 wording that contradicts shipped DART P2P, UDS server and driver wiring
- duplicated idempotency trade-off note (`cache.go` vs `PullImage`), journal recap (`journal.go`), cmd recap (`main.go` vs `doc.go`), boot-args networking claim (`doc.go`, restore-only startup), stale `StartCount`/`GetLease`/`Server` (nil backend answers 500) docs, “identity header” → in-body identity fix

### Validation
- `go build ./...`, `go vet`, unit tests all green (incl. dart manager subprocess tests)
- `staticcheck` clean for the whole scope
- firecracker-tagged e2e compile verified: `go vet -tags firecracker ./internal/runtime/firecracker/`