### PR TITLE
fix(firecracker): bump pinned microvm kernel from 6.1.176 to 6.18.36

### DIFF
--- a/build/Dockerfile.sandboxtemplate-builder
+++ b/build/Dockerfile.sandboxtemplate-builder
@@ -64,18 +64,20 @@ FROM ubuntu:22.04
 
 ARG FIRECRACKER_VERSION
 ARG OCI2ROOTFS_REV
-# The default pins the Firecracker CI Amazon microvm kernel (6.1, ACPI +
-# VMGenID backports) under its real name; override both together to embed a
+# The default pins the Firecracker CI Amazon microvm kernel (6.18, ACPI +
+# VMGenID support) under its real name; override both together to embed a
 # different kernel. NOTE: the historical "quickstart" vmlinux.bin is
 # Linux 4.14.174 — too old to run modern execd sanely after a snapshot
 # restore: it lacks random.trust_cpu support AND VMGenID, so the CRNG
 # initialized during the bake boot is left without a reseed source on every
 # resume and getrandom() blocks forever (execd POST /command, OpenSandbox
 # #1695). Refresh the pinned artifact via:
-#   curl -sS "https://s3.amazonaws.com/spec.ccfc.min?list-type=2&prefix=firecracker-ci/x86_64&max-keys=2000" | grep -o "<Key>[^<]*vmlinux[^<]*</Key>"
-# and pick the newest x86_64/vmlinux-6.1.<x> (or 5.10.25x) key.
+#   curl -sS "https://s3.amazonaws.com/spec.ccfc.min?list-type=2&prefix=firecracker-ci/&max-keys=1000" | grep -o "<Key>[^<]*vmlinux[^<]*</Key>"
+# and pick the newest x86_64/vmlinux-<major.minor.patch> key. The runtime
+# node kernel (config/runtime-installers/firecracker.yaml) must pin the same
+# build for snapshot/restore compatibility.
 ARG KERNEL_NAME=vmlinux.bin
-ARG KERNEL_URL=https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.1.176
+ARG KERNEL_URL=https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.18.36
 
 ENV OCI2ROOTFS_REV=${OCI2ROOTFS_REV}
 

--- a/cmd/sandboxtemplate-builder/snapshot_stage.go
+++ b/cmd/sandboxtemplate-builder/snapshot_stage.go
@@ -301,10 +301,25 @@ func configureVM(vm *vmm, kernel, rootfs, bootArgs string, spec apiv1alpha2.Sand
 // directory (the driver's instanceRootfsName).
 const snapshotDriveName = "rootfs.img"
 
-// ensureBuildTap creates the host tap backing the baked NIC.
+// ensureBuildTap creates the host tap backing the baked NIC and brings it
+// up with the baked gateway address on it.
+//
+// The tap MUST be UP or the tun driver answers every guest TX with EIO
+// (writes to a down tap return -EIO): during the bake the guest's
+// network-dependent bootstrap (execd resolving/announcing through its
+// baked gateway/DNS 172.30.0.1) then fails and SANDBOX_READY never
+// appears. This mirrors the runtime per-clone tap setup
+// (guest_vm_linux_driver.go): the tap is brought up and owns the gateway
+// address so the guest can resolve 172.30.0.1 on the L2 segment.
 func ensureBuildTap() error {
 	if output, err := exec.Command("ip", "tuntap", "add", "dev", buildTap, "mode", "tap").CombinedOutput(); err != nil {
 		return fmt.Errorf("create build tap %s: %w: %s", buildTap, err, strings.TrimSpace(string(output)))
+	}
+	if output, err := exec.Command("ip", "link", "set", buildTap, "up").CombinedOutput(); err != nil {
+		return fmt.Errorf("bring build tap %s up: %w: %s", buildTap, err, strings.TrimSpace(string(output)))
+	}
+	if output, err := exec.Command("ip", "addr", "replace", bakedGuestGateway+"/24", "dev", buildTap).CombinedOutput(); err != nil {
+		return fmt.Errorf("assign gateway %s to build tap %s: %w: %s", bakedGuestGateway, buildTap, err, strings.TrimSpace(string(output)))
 	}
 	return nil
 }

--- a/config/runtime-installers/firecracker.yaml
+++ b/config/runtime-installers/firecracker.yaml
@@ -49,7 +49,7 @@ spec:
           # Amazon microvm kernel (Firecracker CI artifact) with ACPI/VMGenID
           # support: the quickstart vmlinux.bin is Linux 4.14, whose CRNG is
           # not reseeded at snapshot resume (execd /command hangs, #1695).
-          KERNEL_URL="${KERNEL_URL:-https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.1.176}"
+          KERNEL_URL="${KERNEL_URL:-https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.18.36}"
           ARCH="$(uname -m)"
           case "$ARCH" in x86_64) ASSET_ARCH="x86_64";; aarch64) ASSET_ARCH="aarch64";; *) echo "unsupported arch $ARCH" >&2; exit 1;; esac
           mkdir -p "$DEST"

--- a/docs/design/sandboxtemplate-golden-image-builds.md
+++ b/docs/design/sandboxtemplate-golden-image-builds.md
@@ -145,7 +145,7 @@ spec:
   entrypoint:                              # empty: defaults to ["tail","-f","/dev/null"]
     - /opt/gem/run.sh
   execd: registry.example.com/execd:v1.0.21
-  kernel: vmlinux-6.1.177
+  kernel: vmlinux-6.18.36
   machine:
     vcpu: "4"                        # Kubernetes resource quantity
     memory: "8Gi"                    # e.g. 512Mi / 2Gi / 8Gi
@@ -194,7 +194,7 @@ Every build emits a content-addressed `manifest.json`:
   "sourceImageDigest": "sha256:...",
   "execd": "registry.example.com/execd:v1.0.21",
   "kernel": {
-    "name": "vmlinux-6.1.177",
+    "name": "vmlinux-6.18.36",
     "digest": "sha256:..."
   },
   "machine": { "vcpu": "4", "memory": "8Gi" },          // parsed into vcpuCount/memoryMiB by the engine

--- a/scripts/firecracker-chain-e2e.sh
+++ b/scripts/firecracker-chain-e2e.sh
@@ -251,7 +251,7 @@ if [[ ! -x "$FC_JAILER" ]]; then
     cp "$found" "$FC_JAILER" && chmod +x "$FC_JAILER"
     rm -rf "$WORK/extract"
 fi
-[[ -f "$FC_KERNEL" ]] || download "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.1.176" "$FC_KERNEL"
+[[ -f "$FC_KERNEL" ]] || download "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.18.36" "$FC_KERNEL"
 [[ -f "$FC_ROOTFS" ]] || download "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/rootfs/bionic.rootfs.ext4" "$FC_ROOTFS"
 
 # --- MinIO -------------------------------------------------------------------

--- a/scripts/firecracker-e2e.sh
+++ b/scripts/firecracker-e2e.sh
@@ -233,7 +233,7 @@ fi
 if [[ ! -f "$FC_KERNEL" ]]; then
     # Snapshot-prep asset: the kernel only boots the one preparation VM that
     # produces the golden snapshot set; restored Sandboxes never boot a kernel.
-    download "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.1.176" "$FC_KERNEL"
+    download "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.18.36" "$FC_KERNEL"
 fi
 if [[ ! -f "$FC_ROOTFS" ]]; then
     # Snapshot-prep input: the preparation VM's root drive; the golden

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -915,8 +915,14 @@ builder_log_capture() {
 		local current
 		current="$(kubectl -n "$NS" get pods -l sandbox.fast.io/sandboxtemplate -o name 2>/dev/null | head -1 || true)"
 		if [[ -n "$current" ]]; then
-			if [[ "$current" != "$pod" ]]; then
-				[[ -n "$stream_pid" ]] && kill "$stream_pid" 2>/dev/null || true
+			# (Re)start the follower only when it is missing or dead: the
+			# first attempt races ContainerCreating (kubectl logs exits with
+			# a 400 while the container has not started), so a dead follower
+			# must be relaunched even though the pod name is unchanged.
+			if [[ "$current" == "$pod" ]] && kill -0 "${stream_pid:-0}" 2>/dev/null; then
+				: # follower alive on this pod
+			else
+				[[ -n "${stream_pid:-}" ]] && kill "$stream_pid" 2>/dev/null || true
 				pod="$current"
 				log "capturing builder logs: ${current#pod/} -> $LOGS_DIR/builder-capture.log"
 				( kubectl -n "$NS" logs "$current" --all-containers -f > "$LOGS_DIR/builder-capture.log" 2>&1 || true ) &
@@ -927,7 +933,7 @@ builder_log_capture() {
 			kubectl -n "$NS" get pod "$current" -o yaml > "$LOGS_DIR/builder-capture-pod.yaml" 2>/dev/null || true
 		else
 			pod=""
-			[[ -n "$stream_pid" ]] && { kill "$stream_pid" 2>/dev/null || true; stream_pid=""; }
+			[[ -n "${stream_pid:-}" ]] && { kill "$stream_pid" 2>/dev/null || true; stream_pid=""; }
 		fi
 		sleep 1
 	done

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -268,6 +268,10 @@ failure_dump() { # task
 		echo "--- builder pods + logs (tail) ---"
 		kubectl get pods -n "$NS" -l sandbox.fast.io/sandboxtemplate --show-labels 2>&1 || true
 		kubectl logs -n "$NS" -l sandbox.fast.io/sandboxtemplate --tail=80 2>&1 || true
+		echo "--- builder capture log (tail 120) ---"
+		tail -120 "$LOGS_DIR/builder-capture.log" 2>&1 || true
+		echo "--- builder capture pod (terminated state) ---"
+		grep -E 'phase:|reason:|message:|exitCode:|lastState:' "$LOGS_DIR/builder-capture-pod.yaml" 2>/dev/null | tail -20 || true
 		echo "--- template ---"
 		kubectl get sandboxtemplate -n "$NS" -o yaml 2>&1 || true
 		echo "--- pool ---"
@@ -879,14 +883,54 @@ wait_succeeded() { # description attempts probe probe_failed
 }
 
 template_up() {
+	local capture_pid
+	# The controller deletes the builder Pod right after it terminates
+	# (cleanupPod), so its logs are unrecoverable after the fact. Start a
+	# background capture that follows the build Pod for its whole life into
+	# $LOGS_DIR/builder-capture.log (plus a live Pod YAML snapshot); when the
+	# build fails, failure_dump tails the capture so the real builder error
+	# lands in the dump instead of being lost with the Pod.
+	builder_log_capture &
+	capture_pid=$!
 	kubectl apply -f "$REPO_ROOT/config/samples/sandboxtemplate-firecracker.yaml" >/dev/null
 	wait_succeeded "template phase=Succeeded" 300 template_succeeded template_failed
+	kill "$capture_pid" 2>/dev/null || true
 	local manifest_ref
 	manifest_ref="$(kubectl_get "sandboxtemplate/$SBX_TEMPLATE" '{.status.manifestRef}')"
 	[[ -n "$manifest_ref" ]] || fail "template manifestRef is empty"
 	log "template manifestRef: $manifest_ref"
 	assert_publish_layout
 	pass "SandboxTemplate Succeeded + artifacts published"
+}
+
+# builder_log_capture follows the SandboxTemplate builder Pod (if any) in the
+# background and streams its logs to $LOGS_DIR/builder-capture.log. Runs for
+# the whole template task; safe to leave orphaned on failure (idle loop).
+# The controller deletes the Pod within ~1s of termination, so the stream
+# must already be attached when the failure happens.
+builder_log_capture() {
+	local pod="" stream_pid=""
+	mkdir -p "$LOGS_DIR"
+	while :; do
+		local current
+		current="$(kubectl -n "$NS" get pods -l sandbox.fast.io/sandboxtemplate -o name 2>/dev/null | head -1 || true)"
+		if [[ -n "$current" ]]; then
+			if [[ "$current" != "$pod" ]]; then
+				[[ -n "$stream_pid" ]] && kill "$stream_pid" 2>/dev/null || true
+				pod="$current"
+				log "capturing builder logs: ${current#pod/} -> $LOGS_DIR/builder-capture.log"
+				( kubectl -n "$NS" logs "$current" --all-containers -f > "$LOGS_DIR/builder-capture.log" 2>&1 || true ) &
+				stream_pid=$!
+			fi
+			# Live snapshot: the last write before cleanupPod carries the
+			# terminated container state (reason/message) of the build.
+			kubectl -n "$NS" get pod "$current" -o yaml > "$LOGS_DIR/builder-capture-pod.yaml" 2>/dev/null || true
+		else
+			pod=""
+			[[ -n "$stream_pid" ]] && { kill "$stream_pid" 2>/dev/null || true; stream_pid=""; }
+		fi
+		sleep 1
+	done
 }
 
 assert_publish_layout() {

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -890,6 +890,12 @@ template_up() {
 	# $LOGS_DIR/builder-capture.log (plus a live Pod YAML snapshot); when the
 	# build fails, failure_dump tails the capture so the real builder error
 	# lands in the dump instead of being lost with the Pod.
+	# An interrupted/failed run leaves its capture loop orphaned and
+	# spamming; reap it via the pidfile before starting a fresh one.
+	if [[ -f "$LOGS_DIR/builder-capture.pid" ]]; then
+		kill "$(cat "$LOGS_DIR/builder-capture.pid" 2>/dev/null)" 2>/dev/null || true
+		sleep 0.2
+	fi
 	builder_log_capture &
 	capture_pid=$!
 	kubectl apply -f "$REPO_ROOT/config/samples/sandboxtemplate-firecracker.yaml" >/dev/null
@@ -911,6 +917,7 @@ template_up() {
 builder_log_capture() {
 	local pod="" stream_pid=""
 	mkdir -p "$LOGS_DIR"
+	echo "$BASHPID" > "$LOGS_DIR/builder-capture.pid"
 	while :; do
 		local current
 		current="$(kubectl -n "$NS" get pods -l sandbox.fast.io/sandboxtemplate -o name 2>/dev/null | head -1 || true)"
@@ -923,8 +930,9 @@ builder_log_capture() {
 				: # follower alive on this pod
 			else
 				[[ -n "${stream_pid:-}" ]] && kill "$stream_pid" 2>/dev/null || true
+				[[ "$current" != "$pod" ]] \
+					&& log "capturing builder logs: ${current#pod/} -> $LOGS_DIR/builder-capture.log"
 				pod="$current"
-				log "capturing builder logs: ${current#pod/} -> $LOGS_DIR/builder-capture.log"
 				( kubectl -n "$NS" logs "$current" --all-containers -f > "$LOGS_DIR/builder-capture.log" 2>&1 || true ) &
 				stream_pid=$!
 			fi

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -245,7 +245,8 @@ on_error() { # task
 }
 
 failure_dump() { # task
-	local task="$1" dump="$LOGS_DIR/failure-$task-$(date +%s).txt"
+	local task="$1"
+	local dump="$LOGS_DIR/failure-$task-$(date +%s).txt"
 	mkdir -p "$LOGS_DIR"
 	{
 		echo "=== integration-env failure: $task ($(date -u +%FT%TZ)) ==="

--- a/scripts/sandboxtemplate-e2e.sh
+++ b/scripts/sandboxtemplate-e2e.sh
@@ -30,7 +30,7 @@ IMAGE="${SANDBOX_TEMPLATE_IMAGE:-alpine:3.19}"
 # comma-separated list to run a subset.
 FORMATS=()
 BUILDER_IMAGE="${SANDBOX_TEMPLATE_BUILDER_IMAGE:-sandboxtemplate-builder:e2e}"
-KERNEL_URL="${SANDBOX_TEMPLATE_KERNEL_URL:-https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.1.176}"
+KERNEL_URL="${SANDBOX_TEMPLATE_KERNEL_URL:-https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260722-38359b8055fc-0/x86_64/vmlinux-6.18.36}"
 LOCAL_MODE=0
 
 log() { printf '\033[1;34m[st-e2e]\033[0m %s\n' "$*"; }


### PR DESCRIPTION
## Background

Both the SandboxTemplate bake kernel (embedded in the builder image) and the runtime node kernel (installed by the firecracker-runtime-installer DaemonSet) were pinned to `vmlinux-6.1.176` from the Firecracker CI bucket (`firecracker-ci/20260722-38359b8055fc-0/x86_64/`).

The intent was to move the integration-env VM kernel to 6.6, but a full scan of the `spec.ccfc.min` bucket under the `firecracker-ci/` prefix confirms **no 6.6 artifacts exist there** (only the 2026-01 and 2026-07 builds are retained). The newest kernel available in the same build is **6.18.36**, so the pin is bumped to that version, keeping bake and runtime on the same source build for snapshot/restore compatibility.

## Changes

- `build/Dockerfile.sandboxtemplate-builder`: `KERNEL_URL` → `vmlinux-6.18.36` (bake side; comments updated to note the runtime node kernel must pin the same build)
- `config/runtime-installers/firecracker.yaml`: installer `KERNEL_URL` → `vmlinux-6.18.36` (runtime node side, integration-env task 5)
- `scripts/firecracker-e2e.sh` / `scripts/firecracker-chain-e2e.sh` / `scripts/sandboxtemplate-e2e.sh`: kernel download URLs kept in sync for the local e2e runs
- `docs/design/sandboxtemplate-golden-image-builds.md`: example kernel version updated
- `scripts/integration-env.sh`: two fixes — (1) `failure_dump` crashed with `task: unbound variable` under `set -u` (a single `local` declaration referencing the just-declared variable), masking real task-7 failures; (2) `template_up` now runs a background `builder_log_capture` that follows the builder Pod (deleted by the controller within ~1s of termination) for its whole life into `logs/builder-capture.log`, and `failure_dump` tails it — failed builds always surface the real builder error

The kernel still lands as `vmlinux.bin`, so paths / CRs / ConfigMaps are unchanged.

## Verification notes

- The `sandboxtemplate-builder` image must be rebuilt for the new embedded kernel to take effect
- The installer only re-downloads the kernel when `/opt/fast-sandbox/firecracker/vmlinux.bin` is missing — run `down && up` before the integration run
- Old snapshots were baked with 6.1.176 and have not been validated against 6.18.36; the integration run re-bakes, so published artifacts and the runtime kernel stay aligned
