### PR TITLE
fix(env): unblock the integration environment on modern CPUs and mirr…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,13 @@
 .remote-dev-run.env
 bin
 vendor
+# Local integration-env workspaces: they hold root-owned MinIO/mc state, so
+# leaving them in the build context makes every docker build fail with
+# "error checking context: can't stat ..." once the environment has run.
+.integration-env
+.integration-env-gen
+.firecracker-chain-e2e
+.chain-e2e-gen
 sdk/python/.venv
 **/__pycache__
 **/.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -282,6 +282,8 @@ generated/
 # Local E2E workspaces and helpers
 /.firecracker-chain-e2e/
 /.chain-e2e-gen/
+/.integration-env/
+/.integration-env-gen/
 
 # stray agent binary built by ad-hoc go build
 /firecracker-runtime-agent

--- a/build/Dockerfile.firecracker-runtime-agent
+++ b/build/Dockerfile.firecracker-runtime-agent
@@ -13,6 +13,10 @@ ARG DART_REV=a85f39f13d81241b3d57f7f7fe7b7c84d58b7aa2
 FROM golang:1.25 AS dart-build
 
 ARG DART_REV
+# GOPROXY is overridable (docker build --build-arg GOPROXY=...) for hosts
+# without direct proxy.golang.org access; the default is the Go toolchain one.
+ARG GOPROXY=https://proxy.golang.org,direct
+ENV GOPROXY=${GOPROXY}
 
 RUN git init /src/dart \
     && cd /src/dart \

--- a/build/Dockerfile.sandboxtemplate-builder
+++ b/build/Dockerfile.sandboxtemplate-builder
@@ -52,6 +52,12 @@ RUN cd /src/overlaybd \
 # --- sandboxtemplate-builder binary ----------------------------------------
 FROM golang:1.25 AS builder-build
 
+# GOPROXY is overridable (docker build --build-arg GOPROXY=...) so hosts
+# without direct proxy.golang.org access can download modules from a mirror;
+# the default keeps the Go toolchain behaviour unchanged.
+ARG GOPROXY=https://proxy.golang.org,direct
+ENV GOPROXY=${GOPROXY}
+
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/cmd/sandboxtemplate-builder/snapshot_stage.go
+++ b/cmd/sandboxtemplate-builder/snapshot_stage.go
@@ -99,10 +99,6 @@ func runSnapshotStage(args []string) error {
 	bootLog := filepath.Join(workdir, "boot.console.log")
 	bootSocket := filepath.Join(workdir, "boot.sock")
 	phaseStarted := time.Now()
-	vm, err := startVMM(bootSocket, bootLog, workdir)
-	if err != nil {
-		return err
-	}
 	// random.trust_cpu=on seeds the guest CRNG from RDRAND at boot. The
 	// microVM has no other entropy source (no virtio-rng device, and
 	// Firecracker snapshots preserve the CPUID mask), so without it the CRNG
@@ -113,8 +109,8 @@ func runSnapshotStage(args []string) error {
 	bootArgs := "console=ttyS0 reboot=k panic=1 pci=off nomodules net.ifnames=0 biosdevname=0 random.trust_cpu=on root=/dev/vda rw"
 	bootArgs += " init=" + guestInitPath(spec)
 	bootArgs = bakedNetworkBootArgs(bootArgs)
-	if err := configureVM(vm, kernel, rootfs, bootArgs, spec); err != nil {
-		vm.stop()
+	vm, err := bootPreparationVM(bootSocket, bootLog, workdir, kernel, rootfs, bootArgs, spec)
+	if err != nil {
 		return err
 	}
 	if err := waitForMarker(bootLog, "SANDBOX_READY", readinessTimeout(spec)); err != nil {
@@ -233,13 +229,64 @@ func (vm *vmm) stop() {
 	}
 }
 
+// snapshotCPUTemplate is the static Firecracker CPU template the golden
+// snapshot is built with (see configureVM).
+const snapshotCPUTemplate = "T2"
+
+// cpuTemplateNotPermitted reports whether a boot failure is Firecracker
+// refusing the static CPU template on this host. Static templates are only
+// permitted on the CPU models they were derived from (T2/C3/T2S on Intel
+// Skylake/Cascade Lake, T2A on AMD Milan), so every newer host — Ice Lake,
+// Sapphire Rapids and up — rejects them. The check happens when the vCPUs
+// are built, i.e. at InstanceStart: PUT /machine-config accepts the template
+// and only the start call reports the fault, which is why the retry needs a
+// fresh VMM rather than a second machine-config call.
+func cpuTemplateNotPermitted(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "not permitted to apply the CPU template")
+}
+
+// bootPreparationVM cold-boots the snapshot preparation VM, falling back to
+// the host's unmasked CPUID when the host CPU model refuses the pinned
+// static template. The fallback trades snapshot portability (the artifacts
+// then carry this host's CPU features, so they restore only on
+// CPU-compatible hosts) for the ability to build at all — on a host where
+// no static template is permitted the alternative is no golden image.
+func bootPreparationVM(socket, logPath, workdir, kernel, rootfs, bootArgs string, spec apiv1alpha2.SandboxTemplateSpec) (*vmm, error) {
+	vm, err := startVMM(socket, logPath, workdir)
+	if err != nil {
+		return nil, err
+	}
+	err = configureVM(vm, kernel, rootfs, bootArgs, spec, snapshotCPUTemplate)
+	if err == nil {
+		return vm, nil
+	}
+	vm.stop()
+	if !cpuTemplateNotPermitted(err) {
+		return nil, err
+	}
+	klog.InfoS("host CPU model does not permit the pinned static CPU template; booting the preparation VM with the host CPUID instead (the snapshot becomes host-CPU specific and must be restored on CPU-compatible hosts)",
+		"cpuTemplate", snapshotCPUTemplate, "err", err)
+	vm, err = startVMM(socket, logPath, workdir)
+	if err != nil {
+		return nil, err
+	}
+	if err := configureVM(vm, kernel, rootfs, bootArgs, spec, ""); err != nil {
+		vm.stop()
+		return nil, err
+	}
+	return vm, nil
+}
+
 // configureVM applies the machine config, boot source, root drive, the baked
 // guest NIC, and starts the instance. The NIC (iface eth0, MAC, and the
 // static guest address from the kernel ip= boot args) is baked into the
 // snapshot, so every restored instance resumes with the same guest network
 // (clone networking model); consumers override only the host tap name via
 // network_overrides.
-func configureVM(vm *vmm, kernel, rootfs, bootArgs string, spec apiv1alpha2.SandboxTemplateSpec) error {
+//
+// cpuTemplate is the static Firecracker CPU template to pin, or "" for the
+// host's unmasked CPUID (see bootPreparationVM).
+func configureVM(vm *vmm, kernel, rootfs, bootArgs string, spec apiv1alpha2.SandboxTemplateSpec, cpuTemplate string) error {
 	vcpuCount, err := vcpus(spec.Machine.VCPU)
 	if err != nil {
 		return err
@@ -251,13 +298,18 @@ func configureVM(vm *vmm, kernel, rootfs, bootArgs string, spec apiv1alpha2.Sand
 	// The cpu_template is pinned so the guest's CPUID is identical on every
 	// host: a full snapshot restored on a machine with different CPU
 	// features can fail or misbehave. T2 is the conservative cross-vendor
-	// baseline (fixed CPUID masking).
-	if err := api(vm.socket, "PUT", "/machine-config", map[string]any{
+	// baseline (fixed CPUID masking). An empty cpuTemplate omits the field
+	// entirely (Firecracker rejects an empty enum value) and boots with the
+	// host's own CPUID — see bootPreparationVM.
+	machineConfig := map[string]any{
 		"vcpu_count":   vcpuCount,
 		"mem_size_mib": memSize,
 		"smt":          false,
-		"cpu_template": "T2",
-	}); err != nil {
+	}
+	if cpuTemplate != "" {
+		machineConfig["cpu_template"] = cpuTemplate
+	}
+	if err := api(vm.socket, "PUT", "/machine-config", machineConfig); err != nil {
 		return err
 	}
 	// Entropy device (virtio-rng): the microVM has no other entropy source —

--- a/config/dev/kind-firecracker.yaml
+++ b/config/dev/kind-firecracker.yaml
@@ -23,6 +23,14 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: firecracker
+# Docker Hub is unreachable from this host (registry-1.docker.io blocked), and
+# the node containerd does not read the host docker daemon registry-mirrors:
+# patch the docker.io mirror in so in-cluster pulls (installer curl/alpine)
+# resolve. Drop this block on hosts with direct Docker Hub access.
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+    endpoint = ["https://docker.m.daocloud.io", "https://docker.1ms.run", "https://docker.jiaxin.site"]
 nodes:
 - role: control-plane
   extraMounts:

--- a/config/rbac/base.yaml
+++ b/config/rbac/base.yaml
@@ -40,7 +40,10 @@ rules:
   resources: ["roles", "rolebindings"]
   # update: ensureBuilderRBAC converges pre-existing same-named Role /
   # RoleBinding back onto the enforced shape instead of trusting them.
-  verbs: ["get", "create", "update"]
+  # list/watch: that convergence Get goes through the cached client, whose
+  # informer cannot sync without them (the reconcile would stall forever on
+  # every re-reconcile once the Role exists).
+  verbs: ["get", "list", "watch", "create", "update"]
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "patch", "update"]

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -245,7 +245,11 @@ on_error() { # task
 }
 
 failure_dump() { # task
-	local task="$1" dump="$LOGS_DIR/failure-$task-$(date +%s).txt"
+	# Separate declarations: bash expands every word of a `local` command
+	# before assigning, so referencing $task in the same statement would be an
+	# unbound variable under set -u (the dump would die instead of dumping).
+	local task="$1"
+	local dump="$LOGS_DIR/failure-$task-$(date +%s).txt"
 	mkdir -p "$LOGS_DIR"
 	{
 		echo "=== integration-env failure: $task ($(date -u +%FT%TZ)) ==="
@@ -470,11 +474,13 @@ stateroot_xfs_up() {
 	sudo_ mkdir -p "$XFS_MOUNT_POINT"
 	sudo_ mount -o noatime "$XFS_LOOP_FILE" "$XFS_MOUNT_POINT" \
 		|| die "mount $XFS_LOOP_FILE at $XFS_MOUNT_POINT failed (loop support? try XFS_STATEROOT=0)"
-	# probe: reflink must actually work on the resulting filesystem.
+	# probe: reflink must actually work on the resulting filesystem. The
+	# fresh mount is root-owned, so the probe file is written through sudo_
+	# as well (a non-root runner cannot write it directly).
 	local a b
 	a="$XFS_MOUNT_POINT/.reflink-a"
 	b="$XFS_MOUNT_POINT/.reflink-b"
-	printf 'probe' > "$a"
+	printf 'probe' | sudo_ tee "$a" >/dev/null
 	if sudo_ cp --reflink=always "$a" "$b"; then
 		sudo_ rm -f "$a" "$b"
 		pass "XFS StateRoot ready (reflink CoW rootfs)"
@@ -502,7 +508,10 @@ build_images() {
 	(cd "$REPO_ROOT" && make images COMPONENT=janitor >/dev/null)
 	(cd "$REPO_ROOT" && make images COMPONENT=firecracker-runtime-agent >/dev/null)
 	log "building sandboxtemplate-builder image"
-	docker build --quiet -t "$IMG_BUILDER" \
+	# DOCKER_BUILD_FLAGS is the same knob `make images` exposes (e.g.
+	# --build-arg GOPROXY=... on hosts without direct module access).
+	# shellcheck disable=SC2086
+	docker build ${DOCKER_BUILD_FLAGS:-} --quiet -t "$IMG_BUILDER" \
 		-f "$REPO_ROOT/build/Dockerfile.sandboxtemplate-builder" "$REPO_ROOT" >/dev/null
 	log "building fastctl (host CLI)"
 	mkdir -p "$WORK/bin"
@@ -707,7 +716,10 @@ kind_up() {
 # --- task 3: MinIO + credentials -------------------------------------------------------
 minio_up() {
 	docker rm -f "$MINIO_CONTAINER" >/dev/null 2>&1 || true
-	rm -rf "$MINIO_DATA"
+	# The MinIO container writes its object store as root, so a previous
+	# run's data can only be purged through sudo_ (a non-root runner would
+	# fail on every part.* file and abort the whole up).
+	sudo_ rm -rf "$MINIO_DATA"
 	mkdir -p "$MINIO_DATA"
 	local net
 	net="$(kind_network)"
@@ -878,7 +890,18 @@ wait_succeeded() { # description attempts probe probe_failed
 }
 
 template_up() {
-	kubectl apply -f "$REPO_ROOT/config/samples/sandboxtemplate-firecracker.yaml" >/dev/null
+	# Render SBX_IMAGE / EXECD into the sample so the documented overrides
+	# really select what gets built (the builder pulls with
+	# go-containerregistry, which ignores the docker daemon registry-mirrors,
+	# so a mirror has to be spelled out in the reference itself). Defaults
+	# reproduce the sample verbatim.
+	local template_spec="$WORK/sandboxtemplate-firecracker.yaml"
+	sed -e "s|^  image: .*|  image: $SBX_IMAGE|" \
+		-e "s|^  execd: .*|  execd: $EXECD|" \
+		"$REPO_ROOT/config/samples/sandboxtemplate-firecracker.yaml" > "$template_spec"
+	grep -q "^  image: $SBX_IMAGE\$" "$template_spec" || die "could not render image=$SBX_IMAGE into the template spec"
+	grep -q "^  execd: $EXECD\$" "$template_spec" || die "could not render execd=$EXECD into the template spec"
+	kubectl apply -f "$template_spec" >/dev/null
 	wait_succeeded "template phase=Succeeded" 300 template_succeeded template_failed
 	local manifest_ref
 	manifest_ref="$(kubectl_get "sandboxtemplate/$SBX_TEMPLATE" '{.status.manifestRef}')"
@@ -2726,6 +2749,9 @@ down() {
 		|| fail "MinIO container still present"
 	rm -f "$WORK/agent-registry.json" "$WORK/registry.json"
 	rm -rf "$GEN_DIR"
+	# Root-owned MinIO object store (written by the container); leaving it
+	# behind pollutes the repo and breaks docker build contexts.
+	sudo_ rm -rf "$MINIO_DATA"
 	sysctl_restore
 	stateroot_xfs_down
 	# Purge the runtime cache the environment owns. The pull layer treats a


### PR DESCRIPTION
**minor fix**

- **builder**: boot the preparation VM with the host CPUID when the pinned static cpu_template is refused (only Skylake/Cascade Lake and Milan permit one); the fault surfaces at InstanceStart, so the retry needs a fresh VMM
- **rbac**: controller needs list/watch on roles/rolebindings — ensureRole's Get goes through the cached client, which otherwise stalls every re-reconcile
- **integration-env**: purge the root-owned MinIO store through sudo, and render SBX_IMAGE/EXECD into the template spec so the documented overrides apply
- **ignore** .integration-env{,-gen}: their root-owned state broke docker build contexts; add a GOPROXY build-arg and a docker.io mirror for hosts without direct upstream access