### PR TITLE
feat(firecracker): async image delivery for cold sandbox creates

### DIFF
--- a/cmd/fastctl/cmd/run.go
+++ b/cmd/fastctl/cmd/run.go
@@ -187,12 +187,61 @@ Priority: Flags > Config File > Interactive Input
 		}
 
 		info := resp.GetSandbox()
+		if info == nil {
+			log.Fatalf("Error: CreateSandbox returned no Sandbox observation")
+		}
+		// Cold images are delivered asynchronously: the create returns as
+		// soon as the Sandbox is accepted (runtime Creating) and the
+		// artifact delivery + boot finish in the background. Poll until the
+		// Sandbox is Ready or reaches a terminal failure.
+		if !info.GetReady() {
+			namespace := viper.GetString("namespace")
+			fmt.Printf("Sandbox %s accepted (runtime %s); waiting for image delivery and startup...\n", name, info.GetRuntime().GetState())
+			info = waitForSandboxReady(context.Background(), client, name, namespace)
+		}
+
 		klog.V(4).InfoS("Sandbox created successfully", "name", name, "sandboxUid", info.GetIdentity().GetUid(), "sandboxName", info.GetIdentity().GetName(), "ready", info.GetReady(), "duration", time.Since(start))
 		fmt.Printf("🎉 Sandbox runtime created successfully in %v\n", time.Since(start))
 		fmt.Printf("Name:      %s\n", info.GetIdentity().GetName())
 		fmt.Printf("UID:       %s\n", info.GetIdentity().GetUid())
 		fmt.Printf("Ready:     %t\n", info.GetReady())
 	},
+}
+
+// waitForSandboxReady polls the Sandbox observation until it is Ready or
+// reaches a terminal state. Cold creates park in runtime Creating while the
+// image is delivered asynchronously, so the CLI resolves READY semantics on
+// the client side instead of holding the create RPC open.
+func waitForSandboxReady(ctx context.Context, client fastpathv2.FastPathServiceClient, name, namespace string) *fastpathv2.SandboxInfo {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		response, err := client.GetSandbox(ctx, &fastpathv2.GetSandboxRequest{
+			Sandbox: fastPathSandboxReference(name, namespace),
+		})
+		if err != nil {
+			klog.ErrorS(err, "GetSandbox while waiting for readiness failed", "name", name)
+			log.Fatalf("Error: %v", err)
+		}
+		info := response.GetSandbox()
+		if info == nil {
+			log.Fatalf("Error: GetSandbox returned no Sandbox observation")
+		}
+		if info.GetReady() {
+			return info
+		}
+		switch info.GetRuntime().GetState() {
+		case fastpathv2.RuntimeState_RUNTIME_STATE_FAILED,
+			fastpathv2.RuntimeState_RUNTIME_STATE_UNAVAILABLE,
+			fastpathv2.RuntimeState_RUNTIME_STATE_STOPPED:
+			log.Fatalf("Error: Sandbox %s reached terminal state %s", name, info.GetRuntime().GetState())
+		}
+		select {
+		case <-ctx.Done():
+			log.Fatalf("Error: waiting for Sandbox %s to become ready: %v", name, ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 func init() {

--- a/cmd/fastctl/cmd/run_test.go
+++ b/cmd/fastctl/cmd/run_test.go
@@ -31,7 +31,10 @@ func (m *MockClient) ListSandboxes(ctx context.Context, in *fastpathv2.ListSandb
 	return &fastpathv2.ListSandboxesResponse{}, nil
 }
 func (m *MockClient) GetSandbox(ctx context.Context, in *fastpathv2.GetSandboxRequest, opts ...grpc.CallOption) (*fastpathv2.GetSandboxResponse, error) {
-	return &fastpathv2.GetSandboxResponse{Sandbox: &fastpathv2.SandboxInfo{}}, nil
+	return &fastpathv2.GetSandboxResponse{Sandbox: &fastpathv2.SandboxInfo{
+		Runtime: &fastpathv2.RuntimeInfo{State: fastpathv2.RuntimeState_RUNTIME_STATE_READY},
+		Ready:   true,
+	}}, nil
 }
 func (m *MockClient) GetSandboxDiagnostics(ctx context.Context, in *fastpathv2.SandboxDiagnosticsRequest, opts ...grpc.CallOption) (*fastpathv2.SandboxDiagnosticsResponse, error) {
 	if m.DiagnosticsFunc != nil {

--- a/internal/controlplane/orchestrator/orchestrator.go
+++ b/internal/controlplane/orchestrator/orchestrator.go
@@ -321,9 +321,14 @@ func (o *Orchestrator) createRuntimeOnTarget(ctx context.Context, sandbox *apiv1
 		},
 	}
 	response, createErr := o.FastletClient.CreateSandbox(ctx, fastlet.PodIP, request)
+	// A Created observation may be runtime-Creating: the Fastlet parks cold
+	// Sandboxes (asynchronous image delivery) and returns immediately. The
+	// Controller observes the Sandbox until it converges, so this is an
+	// accepted create, not a failure.
 	if createErr == nil && response != nil &&
 		(response.Disposition == fastletapi.CreateDispositionCreated || response.Disposition == fastletapi.CreateDispositionExisting) &&
-		response.Sandbox != nil && response.Sandbox.Runtime.State == fastletapi.RuntimeStateReady {
+		response.Sandbox != nil &&
+		(response.Sandbox.Runtime.State == fastletapi.RuntimeStateReady || response.Sandbox.Runtime.State == fastletapi.RuntimeStateCreating) {
 		return response, nil
 	}
 	if createErr == nil {

--- a/internal/controlplane/orchestrator/orchestrator_test.go
+++ b/internal/controlplane/orchestrator/orchestrator_test.go
@@ -274,6 +274,34 @@ func TestLostCreateResponseDoesNotInspectOrChangeIdentity(t *testing.T) {
 	require.Equal(t, envelope, *current)
 }
 
+func TestEnsureRuntimeAcceptsParkedColdCreate(t *testing.T) {
+	orchestrator, registry, fastletClient, sandbox := newHarness(t)
+	parameters, err := orchestrator.ResolveRuntime(context.Background(), sandbox)
+	require.NoError(t, err)
+	candidate := candidateFor(parameters)
+	registry.fastlets[candidate.ID] = candidate
+	sandbox.UID = types.UID("sandbox-uid-a")
+	envelope, err := AssignmentForCandidate(candidate, 2, 1, 3, "runtime-a")
+	require.NoError(t, err)
+	require.NoError(t, assignment.SetAssignmentAnnotation(sandbox, envelope))
+	sandbox.Status = statusFromEnvelope(envelope)
+	require.NoError(t, orchestrator.Client.Create(context.Background(), sandbox))
+	fastletClient.create = func(string, *fastletapi.CreateSandboxRequest) (*fastletapi.CreateSandboxResponse, error) {
+		return &fastletapi.CreateSandboxResponse{
+			Disposition: fastletapi.CreateDispositionCreated,
+			Sandbox: &fastletapi.SandboxStatus{
+				SandboxID: string(sandbox.UID),
+				Runtime:   fastletapi.RuntimeObservation{State: fastletapi.RuntimeStateCreating, Message: "sandbox image is being delivered to the node"},
+				DataPlane: fastletapi.DataPlaneObservation{State: fastletapi.DataPlaneStatePending},
+			},
+		}, nil
+	}
+
+	observed, err := orchestrator.EnsureRuntime(context.Background(), sandbox)
+	require.NoError(t, err, "a parked cold create is an accepted create, not a failure")
+	require.Equal(t, fastletapi.RuntimeStateCreating, observed.Runtime.State)
+}
+
 func readyFastletObservation(sandboxID string, generation int64) *fastletapi.SandboxStatus {
 	return &fastletapi.SandboxStatus{
 		SandboxID:          sandboxID,

--- a/internal/fastlet/network/manager.go
+++ b/internal/fastlet/network/manager.go
@@ -249,6 +249,18 @@ func (m *Manager) Acquire(ctx context.Context, owner Owner) (_ *Slot, resultErr 
 	m.miss.Add(1)
 	recordSlotAcquire("miss")
 	result = "empty"
+	klog.ErrorS(ErrNoCleanSlot, "network slot acquire missed",
+		"sandboxUid", owner.SandboxUID, "capacity", m.config.Capacity, "slotCount", len(m.slots))
+	for _, id := range m.sortedSlotIDsLocked() {
+		slot := m.slots[id]
+		boundOwner := ""
+		if slot.Owner.SandboxUID != "" {
+			boundOwner = slot.Owner.SandboxUID
+		}
+		klog.ErrorS(ErrNoCleanSlot, "slot pool detail",
+			"id", id, "phase", slot.Phase, "owner", boundOwner,
+			"generation", slot.Owner.InstanceGeneration, "createdAt", slot.CreatedAt.Format(time.RFC3339Nano))
+	}
 	return nil, ErrNoCleanSlot
 }
 

--- a/internal/fastlet/sandbox/admission.go
+++ b/internal/fastlet/sandbox/admission.go
@@ -71,6 +71,19 @@ func (m *SandboxManager) CreateSandbox(ctx context.Context, req *fastletapi.Crea
 	if bindingFailure, currentAdmission := m.registerDesiredBindings(placeholder, req); bindingFailure != nil {
 		return createFailureWithDisposition(bindingFailure, currentAdmission, fastletapi.CreateDispositionRejectedBeforeSideEffects)
 	}
+	// Async artifact delivery: when the runtime supports it (Firecracker),
+	// a missing image is delivered in the background instead of blocking
+	// this create on the network. The Sandbox parks in image-pending and a
+	// boot worker boots it once the image is committed.
+	if delivery, ok := m.runtime.(ImageDelivery); ok {
+		deliverStatus, deliverErr := delivery.DeliverImage(ctx, input.Sandbox.Spec.Image)
+		if deliverErr != nil {
+			return m.handleRuntimeCreateFailure(ctx, &input, placeholder, deliverErr)
+		}
+		if deliverStatus == ImageDelivering {
+			return m.parkForImageDelivery(req, &input, placeholder, started)
+		}
+	}
 	metadata, err := m.ensureRuntimeForCreate(ctx, started, &input)
 	if err != nil {
 		return m.handleRuntimeCreateFailure(ctx, &input, placeholder, err)
@@ -153,7 +166,17 @@ func (m *SandboxManager) reserveSandboxForCreate(req *fastletapi.CreateSandboxRe
 		return reject(fastletError(fastletapi.ErrorDraining, m.drainReason, true), fastletapi.CreateDispositionRejectedBeforeSideEffects)
 	}
 	if len(m.sandboxes) >= m.capacity {
-		return reject(fastletError(fastletapi.ErrorCapacityRejected, "Fastlet admission capacity is exhausted", true), fastletapi.CreateDispositionRejectedBeforeSideEffects)
+		// A terminal create-failed Sandbox is projected but occupies no
+		// capacity: it must not block new creates.
+		active := 0
+		for _, managed := range m.sandboxes {
+			if managed.Phase != "create-failed" {
+				active++
+			}
+		}
+		if active >= m.capacity {
+			return reject(fastletError(fastletapi.ErrorCapacityRejected, "Fastlet admission capacity is exhausted", true), fastletapi.CreateDispositionRejectedBeforeSideEffects)
+		}
 	}
 	if !m.runtimeResourceAvailable() {
 		return reject(fastletError(fastletapi.ErrorNetworkUnavailable, "Fastlet has no clean runtime/network resource available", true), fastletapi.CreateDispositionRejectedBeforeSideEffects)
@@ -204,6 +227,7 @@ func (m *SandboxManager) handleRuntimeCreateFailure(ctx context.Context, input *
 	disposition := fastletapi.CreateDispositionRejectedBeforeSideEffects
 	if cleanupErr == nil && m.sandboxes[sandboxUID] == placeholder {
 		delete(m.sandboxes, sandboxUID)
+		delete(m.runtimeMessages, sandboxUID)
 	} else if m.sandboxes[sandboxUID] == placeholder {
 		placeholder.Phase = "create-cleanup-failed"
 		disposition = fastletapi.CreateDispositionFailedNeedsCleanup
@@ -358,6 +382,7 @@ func (m *SandboxManager) retryFailedCreateCleanup(ctx context.Context, req *fast
 		return createFailureWithDisposition(fastletErrorWithCause(fastletapi.ErrorRuntimeUnavailable, message, true, cleanupErr), admission, fastletapi.CreateDispositionFailedNeedsCleanup)
 	}
 	delete(m.sandboxes, sandboxUID)
+	delete(m.runtimeMessages, sandboxUID)
 	m.mu.Unlock()
 	m.recordDiagnostic(sandboxUID, "info", "runtime", "cleanup-recovered", "failed Create cleanup converged; retrying the same runtime identity")
 	return m.CreateSandbox(ctx, req)
@@ -418,7 +443,8 @@ func (m *SandboxManager) DeleteSandboxContext(ctx context.Context, req *fastleta
 			m.mu.Unlock()
 			return &fastletapi.DeleteSandboxResponse{}, nil
 		}
-		wasCreating = metadata.Phase == "creating"
+		wasCreating = metadata.Phase == "creating" || metadata.Phase == "image-pending"
+		m.cancelImageBootWorkerLocked(metadata)
 		m.cancelDataPlaneReconcileLocked(metadata)
 		metadata.Phase = "terminating"
 	}
@@ -575,7 +601,7 @@ func (m *SandboxManager) createExistingLocked(existing *SandboxMetadata, request
 		return createFailure(fastletError(fastletapi.ErrorConflict, "Sandbox UID is already bound to a different claim/profile", false), m.admissionStatusLocked())
 	}
 	status := m.sandboxStatusLocked(existing)
-	if existing.Phase == "creating" {
+	if existing.Phase == "creating" || existing.Phase == "image-pending" {
 		failure := fastletError(fastletapi.ErrorInProgress, "Sandbox creation is already in progress", true)
 		return &fastletapi.CreateSandboxResponse{Disposition: fastletapi.CreateDispositionInProgress, Sandbox: &status, Admission: m.admissionStatusLocked(), Error: failure}, failure
 	}
@@ -677,10 +703,13 @@ func (m *SandboxManager) admissionStatusLocked() fastletapi.AdmissionStatus {
 	status := fastletapi.AdmissionStatus{Capacity: m.capacity}
 	for _, metadata := range m.sandboxes {
 		switch metadata.Phase {
-		case "creating", "infra-pending", "initializing-infra", "infra-unavailable", "route-pending", "publishing-route", "route-unavailable", "action-pending", "action-unavailable":
+		case "creating", "image-pending", "infra-pending", "initializing-infra", "infra-unavailable", "route-pending", "publishing-route", "route-unavailable", "action-pending", "action-unavailable":
 			status.Creating++
 		case "terminating", "deleting", "delete-failed", "create-cleanup", "create-cleanup-failed":
 			status.Deleting++
+		case "create-failed":
+			// Terminal create failure: projected for the Controller but it
+			// occupies no admission capacity.
 		default:
 			status.Running++
 		}
@@ -696,6 +725,9 @@ func (m *SandboxManager) admissionStatusLocked() fastletapi.AdmissionStatus {
 func (m *SandboxManager) sandboxStatusLocked(metadata *SandboxMetadata) fastletapi.SandboxStatus {
 	dataPlaneReady := (m.routePublisher == nil || m.routeReady) && routeReadyForPhase(metadata.Phase)
 	runtime, dataPlane := observationsForPhase(metadata.Phase, dataPlaneReady)
+	if message := m.runtimeMessages[metadata.Config.Identity.SandboxUID]; message != "" && metadata.Phase != "running" {
+		runtime.Message = message
+	}
 	return fastletapi.SandboxStatus{
 		SandboxID:          metadata.Config.Identity.SandboxUID,
 		InstanceGeneration: metadata.Config.Identity.InstanceGeneration, RuntimeInstanceID: metadata.Config.Identity.RuntimeInstanceID, AssignmentAttempt: metadata.Config.Identity.AssignmentAttempt,
@@ -710,8 +742,10 @@ func observationsForPhase(phase string, routeReady bool) (fastletapi.RuntimeObse
 	runtime := fastletapi.RuntimeObservation{State: fastletapi.RuntimeStateUnknown}
 	dataPlane := fastletapi.DataPlaneObservation{State: fastletapi.DataPlaneStateUnknown}
 	switch phase {
-	case "creating":
+	case "creating", "image-pending":
 		runtime.State, dataPlane.State = fastletapi.RuntimeStateCreating, fastletapi.DataPlaneStatePending
+	case "create-failed":
+		runtime.State, dataPlane.State = fastletapi.RuntimeStateFailed, fastletapi.DataPlaneStateFailed
 	case "infra-pending", "initializing-infra", "route-pending", "publishing-route":
 		runtime.State, dataPlane.State = fastletapi.RuntimeStateReady, fastletapi.DataPlaneStatePublishing
 	case "infra-unavailable", "route-unavailable":

--- a/internal/fastlet/sandbox/boot_lifecycle.go
+++ b/internal/fastlet/sandbox/boot_lifecycle.go
@@ -1,0 +1,236 @@
+package sandbox
+
+// boot_lifecycle.go drives a cold Sandbox from the image-pending phase to a
+// committed runtime. The Create RPC parks the Sandbox the moment the runtime
+// reports ImageDelivering (the artifact delivery runs in the background on the
+// node); this worker polls the delivery state and, once the image is
+// committed, boots the runtime through the exact same EnsureSandbox -> commit
+// -> data-plane sequence the synchronous create path uses. Delivery failures
+// surface as a terminal create-failed phase instead of retrying forever.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	fastletapi "fast-sandbox/internal/protocol/fastlet"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// initialImageBootPoll is the first delivery poll delay; it doubles up to
+	// maxImageBootPoll between polls.
+	initialImageBootPoll = 300 * time.Millisecond
+	maxImageBootPoll     = 5 * time.Second
+	// imageDeliveryFailLimit is the number of consecutive reported delivery
+	// failures after which the Sandbox transitions to create-failed.
+	imageDeliveryFailLimit = 3
+	// imageBootTimeout bounds one EnsureSandbox boot attempt of the worker.
+	imageBootTimeout = 5 * time.Minute
+)
+
+type imageBootWorker struct {
+	metadata *SandboxMetadata
+	cancel   context.CancelFunc
+}
+
+// parkForImageDelivery parks a cold Sandbox: the placeholder transitions to
+// image-pending, the boot worker takes over delivery -> boot progression, and
+// the Create RPC returns immediately with a Created observation (runtime
+// Creating). Callers of a READY completion poll the Sandbox status instead of
+// holding the RPC open for the artifact transfer.
+func (m *SandboxManager) parkForImageDelivery(req *fastletapi.CreateSandboxRequest, input *fastletapi.EnsureSandboxInput, placeholder *SandboxMetadata, started time.Time) (*fastletapi.CreateSandboxResponse, error) {
+	sandboxUID := input.Sandbox.Identity.SandboxUID
+	message := fmt.Sprintf("sandbox image %q is being delivered to the node", input.Sandbox.Spec.Image)
+	m.mu.Lock()
+	if m.sandboxes[sandboxUID] != placeholder {
+		admission := m.admissionStatusLocked()
+		m.mu.Unlock()
+		return createFailure(fastletError(fastletapi.ErrorConflict, "Sandbox changed before image delivery parked", true), admission)
+	}
+	if placeholder.Phase == "terminating" {
+		admission := m.admissionStatusLocked()
+		go m.asyncDelete(sandboxUID, placeholder)
+		m.mu.Unlock()
+		return createFailure(fastletError(fastletapi.ErrorConflict, "Sandbox was deleted while image delivery was starting", false), admission)
+	}
+	placeholder.Phase = "image-pending"
+	m.runtimeMessages[sandboxUID] = message
+	status := m.sandboxStatusLocked(placeholder)
+	admission := m.admissionStatusLocked()
+	m.mu.Unlock()
+
+	m.startImageBootWorker(placeholder, req, input, started)
+	m.recordDiagnostic(sandboxUID, "info", "runtime", "image-pending", message)
+	klog.InfoS("sandbox parked for async image delivery", "sandboxId", sandboxUID, "image", input.Sandbox.Spec.Image)
+	return &fastletapi.CreateSandboxResponse{
+		Disposition: fastletapi.CreateDispositionCreated,
+		Sandbox:     &status,
+		Admission:   admission,
+	}, nil
+}
+
+// startImageBootWorker parks the delivery progression of a cold Sandbox. It is
+// called after the Create RPC decided to park (parkForImageDelivery). One
+// worker per Sandbox; a replacement metadata instance cancels its predecessor.
+func (m *SandboxManager) startImageBootWorker(metadata *SandboxMetadata, req *fastletapi.CreateSandboxRequest, input *fastletapi.EnsureSandboxInput, started time.Time) {
+	uid := metadata.Config.Identity.SandboxUID
+	ctx, cancel := context.WithCancel(context.Background())
+	m.mu.Lock()
+	if existing, found := m.imageBootWorkers[uid]; found {
+		if existing.metadata == metadata {
+			m.mu.Unlock()
+			cancel()
+			return
+		}
+		existing.cancel()
+	}
+	m.imageBootWorkers[uid] = imageBootWorker{metadata: metadata, cancel: cancel}
+	m.mu.Unlock()
+
+	reqCopy := *req
+	reqCopy.ActionBindings = append([]fastletapi.ActionBindingInput(nil), req.ActionBindings...)
+	inputCopy := *input
+	go m.runImageBootWorker(ctx, metadata, &reqCopy, &inputCopy, started)
+}
+
+// runImageBootWorker polls the async image delivery until it commits, boots
+// the runtime, and hands over to the data-plane lifecycle. It owns the
+// cleanup of a parked Sandbox that is deleted while the worker is alive.
+func (m *SandboxManager) runImageBootWorker(ctx context.Context, metadata *SandboxMetadata, req *fastletapi.CreateSandboxRequest, input *fastletapi.EnsureSandboxInput, started time.Time) {
+	uid := metadata.Config.Identity.SandboxUID
+	delivery, ok := m.runtime.(ImageDelivery)
+	if !ok {
+		m.markCreateFailed(metadata, ErrUnsupportedRuntime)
+		return
+	}
+	defer func() {
+		m.mu.Lock()
+		if worker, found := m.imageBootWorkers[uid]; found && worker.metadata == metadata {
+			delete(m.imageBootWorkers, uid)
+		}
+		terminating := m.sandboxes[uid] == metadata && metadata.Phase == "terminating"
+		m.mu.Unlock()
+		if terminating {
+			go m.asyncDelete(uid, metadata)
+		}
+	}()
+
+	pollDelay := initialImageBootPoll
+	failures := 0
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		m.mu.Lock()
+		current := m.sandboxes[uid]
+		if current != metadata || metadata.Phase != "image-pending" {
+			m.mu.Unlock()
+			return
+		}
+		m.mu.Unlock()
+
+		status, err := delivery.DeliverImage(ctx, input.Sandbox.Spec.Image)
+		if err != nil {
+			failures++
+			if failures >= imageDeliveryFailLimit {
+				m.markCreateFailed(metadata, fmt.Errorf("deliver sandbox image %q: %w", input.Sandbox.Spec.Image, err))
+				return
+			}
+			if !sleepImageBootPoll(ctx, pollDelay) {
+				return
+			}
+			pollDelay = min(pollDelay*2, maxImageBootPoll)
+			continue
+		}
+		failures = 0
+		if status == ImageDelivering {
+			if !sleepImageBootPoll(ctx, pollDelay) {
+				return
+			}
+			pollDelay = min(pollDelay*2, maxImageBootPoll)
+			continue
+		}
+
+		// Image delivered: boot the runtime inside the worker. The commit
+		// below is identical to the synchronous create tail, so lifecycle
+		// hooks, data-plane reconciliation, and readiness observations stay
+		// the same regardless of the delivery path.
+		klog.InfoS("sandbox image delivered; booting runtime", "sandboxId", uid, "image", input.Sandbox.Spec.Image)
+		bootCtx, cancel := context.WithTimeout(ctx, imageBootTimeout)
+		result, ensureErr := m.runtime.EnsureSandbox(bootCtx, input)
+		cancel()
+		if ensureErr != nil {
+			if errors.Is(ensureErr, ErrImageNotReady) {
+				// The committed image vanished under us (cache race): the
+				// delivery layer restarts the pull on the next poll.
+				pollDelay = initialImageBootPoll
+				continue
+			}
+			m.markCreateFailed(metadata, ensureErr)
+			return
+		}
+		m.mu.Lock()
+		stillPending := m.sandboxes[uid] == metadata && metadata.Phase == "image-pending"
+		if stillPending {
+			metadata.Phase = "creating"
+		}
+		m.mu.Unlock()
+		if !stillPending {
+			return
+		}
+		_, _, dataPlaneReady, commitFailure := m.commitRuntimeCreate(req, *input, metadata, result)
+		if commitFailure != nil {
+			return
+		}
+		m.recordRuntimeReadyAndDispatchHooks(result, req, dataPlaneReady)
+		m.continueDataPlaneCreation(result, started, dataPlaneReady)
+		return
+	}
+}
+
+// markCreateFailed projects the terminal create-failed observation of a cold
+// Sandbox whose background boot cannot converge. The Sandbox stays managed so
+// the Controller observes the failure; it does not occupy admission capacity
+// and is removed by the regular delete path.
+func (m *SandboxManager) markCreateFailed(metadata *SandboxMetadata, cause error) {
+	uid := metadata.Config.Identity.SandboxUID
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sandboxes[uid] != metadata {
+		return
+	}
+	if metadata.Phase == "terminating" || metadata.Phase == "deleting" {
+		return
+	}
+	metadata.Phase = "create-failed"
+	m.runtimeMessages[uid] = cause.Error()
+	m.cacheProtection.ProtectHotUntil(metadata.Config.Spec.Image, m.clock.Now().Add(time.Hour))
+	m.recordDiagnosticLocked(uid, "error", "runtime", "create-failed", cause.Error())
+	klog.ErrorS(cause, "cold Sandbox create failed", "sandboxId", uid, "image", metadata.Config.Spec.Image)
+}
+
+func sleepImageBootPoll(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// cancelImageBootWorkerLocked stops the image boot worker of a Sandbox. The
+// caller holds m.mu.
+func (m *SandboxManager) cancelImageBootWorkerLocked(metadata *SandboxMetadata) {
+	uid := metadata.Config.Identity.SandboxUID
+	worker, found := m.imageBootWorkers[uid]
+	if !found || worker.metadata != metadata {
+		return
+	}
+	delete(m.imageBootWorkers, uid)
+	worker.cancel()
+}

--- a/internal/fastlet/sandbox/boot_lifecycle_test.go
+++ b/internal/fastlet/sandbox/boot_lifecycle_test.go
@@ -1,0 +1,192 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	fastletapi "fast-sandbox/internal/protocol/fastlet"
+
+	"github.com/stretchr/testify/require"
+)
+
+// asyncBootRuntime is a MockRuntime with an ImageDelivery switch: the test
+// controls whether DeliverImage reports Delivering, Delivered, or an error.
+type asyncBootRuntime struct {
+	*MockRuntime
+
+	mu            sync.Mutex
+	deliverStatus ImageDeliveryStatus
+	deliverErr    error
+	deliverCalls  int
+}
+
+func newAsyncBootRuntime(status ImageDeliveryStatus) *asyncBootRuntime {
+	return &asyncBootRuntime{MockRuntime: NewMockRuntime(), deliverStatus: status}
+}
+
+func (r *asyncBootRuntime) DeliverImage(context.Context, string) (ImageDeliveryStatus, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deliverCalls++
+	// The real driver parks the create first and only reports an attempt
+	// failure on a later poll; mirror that by reporting Delivering on the
+	// first call even when the fake delivery is about to fail.
+	if r.deliverCalls == 1 && r.deliverErr != nil && r.deliverStatus == ImageDelivering {
+		return ImageDelivering, nil
+	}
+	return r.deliverStatus, r.deliverErr
+}
+
+func (r *asyncBootRuntime) setDeliverStatus(status ImageDeliveryStatus) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deliverStatus = status
+}
+
+func (r *asyncBootRuntime) setDeliverErr(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deliverErr = err
+}
+
+func (r *asyncBootRuntime) deliveryPollCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.deliverCalls
+}
+
+// InspectSandbox mirrors the Firecracker driver: a runtime that never booted
+// reports not-found so the manager message (not a fake "unknown" phase) is
+// projected.
+func (r *asyncBootRuntime) InspectSandbox(_ context.Context, sandboxID string) (*SandboxMetadata, error) {
+	if !r.MockRuntime.HasSandbox(sandboxID) {
+		return nil, ErrSandboxNotFound
+	}
+	return r.MockRuntime.InspectSandbox(context.Background(), sandboxID)
+}
+
+func waitForSandboxState(t *testing.T, manager *SandboxManager, sandboxID string, check func(fastletapi.SandboxStatus) bool) fastletapi.SandboxStatus {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		for _, status := range manager.GetSandboxStatuses(context.Background()) {
+			if status.SandboxID == sandboxID && check(status) {
+				return status
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Sandbox %s did not reach the expected state within 5s (statuses: %+v)", sandboxID, manager.GetSandboxStatuses(context.Background()))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForSandboxGone(t *testing.T, manager *SandboxManager, sandboxID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		gone := true
+		for _, status := range manager.GetSandboxStatuses(context.Background()) {
+			if status.SandboxID == sandboxID {
+				gone = false
+				break
+			}
+		}
+		if gone {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Sandbox %s was not removed within 5s", sandboxID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestCreateDeliveredImageBootsSynchronously(t *testing.T) {
+	runtime := newAsyncBootRuntime(ImageDelivered)
+	manager := NewSandboxManager(runtime)
+
+	response, err := ensureSandboxForTest(context.Background(), manager, runtimeSpecForTest("sb-hot", "sb-hot", "img-hot"))
+	require.NoError(t, err)
+	require.Equal(t, fastletapi.CreateDispositionCreated, response.Disposition)
+	require.Equal(t, fastletapi.RuntimeStateReady, response.Sandbox.Runtime.State)
+	require.True(t, runtime.MockRuntime.GetCreateCalled(), "a delivered image must boot inside the create call")
+}
+
+func TestCreateParksColdImageThenBootsAsync(t *testing.T) {
+	runtime := newAsyncBootRuntime(ImageDelivering)
+	manager := NewSandboxManager(runtime)
+
+	response, err := ensureSandboxForTest(context.Background(), manager, runtimeSpecForTest("sb-cold", "sb-cold", "img-cold"))
+	require.NoError(t, err)
+	require.Equal(t, fastletapi.CreateDispositionCreated, response.Disposition)
+	require.Equal(t, fastletapi.RuntimeStateCreating, response.Sandbox.Runtime.State)
+	require.Contains(t, response.Sandbox.Runtime.Message, "img-cold")
+	require.False(t, runtime.MockRuntime.GetCreateCalled(), "a cold create must return before the runtime boots")
+
+	// The artifact arrives: the boot worker must pick it up and commit the
+	// runtime exactly like the synchronous path.
+	runtime.setDeliverStatus(ImageDelivered)
+	status := waitForSandboxState(t, manager, "sb-cold", func(s fastletapi.SandboxStatus) bool {
+		return s.Runtime.State == fastletapi.RuntimeStateReady
+	})
+	require.Equal(t, fastletapi.DataPlaneStateReady, status.DataPlane.State)
+	require.True(t, runtime.MockRuntime.GetCreateCalled())
+	require.GreaterOrEqual(t, runtime.deliveryPollCount(), 2, "the boot worker must poll the delivery state")
+}
+
+func TestCreateParksThenDeleteWhileDeliveringRemovesSandbox(t *testing.T) {
+	runtime := newAsyncBootRuntime(ImageDelivering)
+	manager := NewSandboxManager(runtime)
+
+	response, err := ensureSandboxForTest(context.Background(), manager, runtimeSpecForTest("sb-del", "sb-del", "img-del"))
+	require.NoError(t, err)
+	require.Equal(t, fastletapi.RuntimeStateCreating, response.Sandbox.Runtime.State)
+
+	_, err = deleteSandboxForTest(manager, "sb-del")
+	require.NoError(t, err)
+	waitForSandboxGone(t, manager, "sb-del")
+	require.True(t, runtime.MockRuntime.GetDeleteCalled(), "the boot worker must hand a parked Sandbox to the delete path")
+}
+
+func TestCreateDeliveryFailureProjectsTerminalStateAndReleasesCapacity(t *testing.T) {
+	runtime := newAsyncBootRuntime(ImageDelivering)
+	runtime.setDeliverErr(errors.New("sandbox image not published"))
+	manager := NewSandboxManager(runtime)
+
+	response, err := ensureSandboxForTest(context.Background(), manager, runtimeSpecForTest("sb-fail", "sb-fail", "img-missing"))
+	require.NoError(t, err)
+	require.Equal(t, fastletapi.RuntimeStateCreating, response.Sandbox.Runtime.State)
+
+	status := waitForSandboxState(t, manager, "sb-fail", func(s fastletapi.SandboxStatus) bool {
+		return s.Runtime.State == fastletapi.RuntimeStateFailed
+	})
+	require.Contains(t, status.Runtime.Message, "not published")
+	require.False(t, runtime.MockRuntime.GetCreateCalled(), "a failed delivery must never boot the runtime")
+
+	// The failed Sandbox occupies no capacity: capacity-1 admission accepts a
+	// second Sandbox once the failing image's delivery state is cleared.
+	runtime2 := newAsyncBootRuntime(ImageDelivering)
+	runtime2.setDeliverErr(errors.New("sandbox image not published"))
+	full, err := NewSandboxManagerWithConfig(runtime2, SandboxManagerConfig{Capacity: 1})
+	require.NoError(t, err)
+	defer func() {
+		if full != nil {
+			_ = full.runtime.Close()
+		}
+	}()
+	first, err := ensureSandboxForTest(context.Background(), full, runtimeSpecForTest("one", "one", "img-one"))
+	require.NoError(t, err)
+	require.Equal(t, fastletapi.RuntimeStateCreating, first.Sandbox.Runtime.State)
+	waitForSandboxState(t, full, "one", func(s fastletapi.SandboxStatus) bool { return s.Runtime.State == fastletapi.RuntimeStateFailed })
+
+	runtime2.setDeliverErr(nil)
+	runtime2.setDeliverStatus(ImageDelivered)
+	second, err := ensureSandboxForTest(context.Background(), full, runtimeSpecForTest("two", "two", "img-two"))
+	require.NoError(t, err)
+	require.Equal(t, fastletapi.CreateDispositionCreated, second.Disposition)
+	require.Equal(t, fastletapi.RuntimeStateReady, second.Sandbox.Runtime.State)
+}

--- a/internal/fastlet/sandbox/manager.go
+++ b/internal/fastlet/sandbox/manager.go
@@ -69,8 +69,17 @@ type SandboxManager struct {
 	registryProvider    registryconfig.Provider
 	routePublisher      RoutePublisher
 	dataPlaneWorkers    map[string]dataPlaneWorker
-	readinessChanged    chan struct{}
-	heartbeatSequence   atomic.Uint64
+	// imageBootWorkers drives cold Sandboxes from the image-pending phase to
+	// a committed runtime: once the async artifact delivery reports
+	// Delivered, the worker boots the runtime (EnsureSandbox) and commits it
+	// exactly like the synchronous create path.
+	imageBootWorkers map[string]imageBootWorker
+	// runtimeMessages carries the per-Sandbox runtime observation message
+	// (e.g. image delivery progress and terminal create failures) projected
+	// onto SandboxStatus.Runtime.Message.
+	runtimeMessages   map[string]string
+	readinessChanged  chan struct{}
+	heartbeatSequence atomic.Uint64
 	// sandboxes  sandboxID -> metadata
 	sandboxes map[string]*SandboxMetadata
 }
@@ -142,6 +151,8 @@ func NewSandboxManagerWithConfig(runtime RuntimeDriver, config SandboxManagerCon
 		readinessChanged: make(chan struct{}),
 		routePublisher:   config.RoutePublisher,
 		dataPlaneWorkers: make(map[string]dataPlaneWorker),
+		imageBootWorkers: make(map[string]imageBootWorker),
+		runtimeMessages:  make(map[string]string),
 		sandboxes:        make(map[string]*SandboxMetadata),
 	}
 	if manager.actionManager != nil {
@@ -405,6 +416,7 @@ func (m *SandboxManager) asyncDelete(sandboxID string, expected *SandboxMetadata
 			FastletPodUID: identity.FastletPodUID,
 		})
 		delete(m.sandboxes, sandboxID)
+		delete(m.runtimeMessages, sandboxID)
 		m.cacheProtection.Unprotect(expected.Config.Spec.Image, fastletcache.ProtectActive)
 		m.cacheProtection.ProtectHotUntil(expected.Config.Spec.Image, m.clock.Now().Add(time.Hour))
 		m.recordDiagnosticLocked(sandboxID, "info", "fastlet", "deleted", "proxy route and runtime resources were deleted")
@@ -427,8 +439,12 @@ func (m *SandboxManager) GetCapacity() int {
 func (m *SandboxManager) GetSandboxStatuses(ctx context.Context) []fastletapi.SandboxStatus {
 	m.mu.RLock()
 	snapshots := make(map[string]SandboxMetadata, len(m.sandboxes))
+	messages := make(map[string]string, len(m.sandboxes))
 	for sandboxID, metadata := range m.sandboxes {
 		snapshots[sandboxID] = *metadata
+		if message := m.runtimeMessages[sandboxID]; message != "" && metadata.Phase != "running" {
+			messages[sandboxID] = message
+		}
 	}
 	proxyReady := m.routePublisher == nil || m.routeReady
 	m.mu.RUnlock()
@@ -438,6 +454,9 @@ func (m *SandboxManager) GetSandboxStatuses(ctx context.Context) []fastletapi.Sa
 		identity := meta.Config.Identity
 		dataPlaneReady := proxyReady && routeReadyForPhase(meta.Phase)
 		runtimeObservation, dataPlaneObservation := observationsForPhase(meta.Phase, dataPlaneReady)
+		if message := messages[sandboxID]; message != "" {
+			runtimeObservation.Message = message
+		}
 		if inspected, err := m.runtime.InspectSandbox(ctx, sandboxID); err == nil {
 			runtimeObservation.Message = inspected.Phase
 		}

--- a/internal/fastlet/sandbox/runtime.go
+++ b/internal/fastlet/sandbox/runtime.go
@@ -14,6 +14,13 @@ type AccessDescriptorProvider = runtimecontract.AccessDescriptorProvider
 type CapabilityReport = runtimecontract.CapabilityReport
 type RoutePublication = dataplane.RoutePublication
 type RoutePublisher = dataplane.RoutePublisher
+type ImageDelivery = runtimecontract.ImageDelivery
+type ImageDeliveryStatus = runtimecontract.ImageDeliveryStatus
+
+const (
+	ImageDelivering = runtimecontract.ImageDelivering
+	ImageDelivered  = runtimecontract.ImageDelivered
+)
 
 var (
 	ErrUnsupportedRuntime     = runtimecontract.ErrUnsupportedRuntime
@@ -23,4 +30,5 @@ var (
 	ErrInfraUnavailable       = runtimecontract.ErrInfraUnavailable
 	ErrSandboxProfileMismatch = runtimecontract.ErrSandboxProfileMismatch
 	ErrInvalidConfig          = runtimecontract.ErrInvalidConfig
+	ErrImageNotReady          = runtimecontract.ErrImageNotReady
 )

--- a/internal/runtime/contract/runtime.go
+++ b/internal/runtime/contract/runtime.go
@@ -47,6 +47,35 @@ type ArtifactCache interface {
 	PullImage(ctx context.Context, image string) error
 }
 
+// ImageDeliveryStatus reports the delivery state of an image that is not
+// (yet) present in the local cache.
+type ImageDeliveryStatus string
+
+const (
+	// ImageDelivering reports that the artifact delivery is in flight on the
+	// node; the caller must poll again later instead of blocking.
+	ImageDelivering ImageDeliveryStatus = "Delivering"
+	// ImageDelivered reports that the image is committed in the local cache
+	// and the Sandbox can boot from it.
+	ImageDelivered ImageDeliveryStatus = "Delivered"
+)
+
+// ImageDelivery is the optional runtime extension for asynchronous artifact
+// delivery. Runtimes whose first boot can require a cold transfer of the
+// Sandbox image (Firecracker) implement it so the create path never blocks on
+// the network: a missing image parks the Sandbox in a delivery phase while a
+// node-side pull runs in the background.
+//
+// DeliverImage guarantees that an attempt to deliver image is in flight (it is
+// idempotent and safe to call concurrently) and reports the current state
+// without waiting for the transfer to finish. A non-nil error means delivery
+// is impossible right now (e.g. no runtime-agent in local mode) and the caller
+// must not park; delivery failures that happen asynchronously are reported by
+// a later call.
+type ImageDelivery interface {
+	DeliverImage(ctx context.Context, image string) (ImageDeliveryStatus, error)
+}
+
 type ResourceRecoverer interface {
 	RecoverRuntimeResources(ctx context.Context, managed []*Metadata) error
 }

--- a/internal/runtime/firecracker/agent/pull.go
+++ b/internal/runtime/firecracker/agent/pull.go
@@ -14,9 +14,12 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"fast-sandbox/internal/registryconfig"
 	runtimecontract "fast-sandbox/internal/runtime/contract"
+
+	"k8s.io/klog/v2"
 )
 
 // Client pulls published Firecracker artifacts for an image reference into
@@ -121,7 +124,7 @@ func WithDART(base string) Option {
 // rebuild of the same reference (last-writer-wins index) is therefore only
 // picked up after clearing the cache directory or switching to a new tag —
 // the intended trade-off for warm-image preheating.
-func (c *Client) PullImage(ctx context.Context, stateRoot, image string) error {
+func (c *Client) PullImage(ctx context.Context, stateRoot, image string) (resultErr error) {
 	if strings.TrimSpace(image) == "" {
 		return fmt.Errorf("%w: image reference is required", runtimecontract.ErrInvalidConfig)
 	}
@@ -134,6 +137,18 @@ func (c *Client) PullImage(ctx context.Context, stateRoot, image string) error {
 	if err := os.MkdirAll(dir, cacheDirMode); err != nil {
 		return fmt.Errorf("prepare image cache: %w", err)
 	}
+
+	klog.InfoS("firecracker agent pull started", "image", image, "stateRoot", stateRoot)
+	started := time.Now()
+	completed := false
+	defer func() {
+		elapsed := time.Since(started)
+		if completed {
+			klog.InfoS("firecracker agent pull completed", "image", image, "elapsed", elapsed.String())
+			return
+		}
+		klog.ErrorS(resultErr, "firecracker agent pull failed", "image", image, "elapsed", elapsed.String())
+	}()
 
 	index, err := fetchIndex(ctx, c.s3, image)
 	if err != nil {
@@ -173,7 +188,11 @@ func (c *Client) PullImage(ctx context.Context, stateRoot, image string) error {
 			return err
 		}
 	}
-	return commitManifest(dir, payload)
+	if err := commitManifest(dir, payload); err != nil {
+		return err
+	}
+	completed = true
+	return nil
 }
 
 // getArtifact streams one native artifact object. In DART mode the download

--- a/internal/runtime/firecracker/agent_wiring_test.go
+++ b/internal/runtime/firecracker/agent_wiring_test.go
@@ -189,19 +189,20 @@ func TestSetAgentSocketEmptySwitchesToLocalMode(t *testing.T) {
 	require.Nil(t, client)
 }
 
-func TestEnsureSandboxColdCreatePullsMissingImage(t *testing.T) {
+// TestEnsureSandboxColdCreateNeverDeliversSynchronously: a cold image with a
+// configured agent must NOT block the create on the node-side pull. The
+// driver reports ErrImageNotReady without touching the agent — asynchronous
+// delivery belongs to DeliverImage (image_delivery_test.go), which Fastlet
+// drives before the Sandbox can boot.
+func TestEnsureSandboxColdCreateNeverDeliversSynchronously(t *testing.T) {
 	fixture := newDriverFixture(t)
 	agent := &fakeAgentClient{}
 	fixture.installAgent(agent)
 
-	// The image is NOT cached and the agent cannot materialize it (fake):
-	// the create must ask the agent for the pull (on-demand loading) and
-	// then fail with ErrImageNotReady — not reject without ever trying.
 	_, err := fixture.driver.EnsureSandbox(context.Background(), ensureInput(&fixture.sandboxSpec))
 	require.ErrorIs(t, err, ErrImageNotReady)
 	pins, _, _ := agent.snapshot()
-	require.Equal(t, []string{fixture.sandboxSpec.Spec.Image}, pins)
-	require.Equal(t, "warm-pull-pod-1-"+imageKey(fixture.sandboxSpec.Spec.Image), agent.pinReqs[0])
+	require.Empty(t, pins, "EnsureSandbox must not pull a missing image inline")
 }
 
 func TestEnsureSandboxCachedImageNeverPins(t *testing.T) {

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -70,6 +70,14 @@ type Driver struct {
 	// in memory: the GC evicts by this instead of filesystem timestamps.
 	// Guarded by mu.
 	imageUseCount map[string]int64
+	// imageDeliveries tracks the asynchronous artifact delivery of images
+	// requested by DeliverImage (image_delivery.go). The map itself is
+	// guarded by mu; each tracker has its own mutex.
+	imageDeliveries map[string]*imageDelivery
+	// imageDeliveryAttemptTimeout and imageDeliveryFailureWindow tune the
+	// background delivery; zero values select the package defaults.
+	imageDeliveryAttemptTimeout time.Duration
+	imageDeliveryFailureWindow  time.Duration
 	// nodeCleanup is the node janitor client for residual VMM cleanup after
 	// DeleteSandbox (set by fastlet when the profile requires it; nil in
 	// local/host mode).
@@ -376,33 +384,15 @@ func (d *Driver) EnsureSandbox(ctx context.Context, input *fastletapi.EnsureSand
 		return nil, fmt.Errorf("%w: firecracker requires the Fastlet network manager", ErrNetworkUnavailable)
 	}
 
-	// On-demand image loading: a create whose image is not yet cached asks
-	// the node runtime-agent to pull it (PinImage proxy, artifact bytes via
-	// the DART data plane) instead of failing admission with
-	// ErrImageNotReady. A cached image never touches the agent (sandbox
-	// creates do not pin: only the pod-level warm pull pins once, and every
-	// DeleteSandbox unpins once). Local mode (no agent socket) and
-	// unreachable-agent fallbacks keep the pre-warmed behavior unchanged:
-	// a still-missing image reports ErrImageNotReady exactly as before.
+	// Image readiness: a create whose image is not yet cached never blocks
+	// on the node-side pull. Fastlet routes cold creates through the
+	// driver's asynchronous delivery (DeliverImage): the artifact set is
+	// pulled in the background and the Sandbox is booted once the commit
+	// point appears in the local cache. Local mode (no agent socket) keeps
+	// the pre-warmed behavior: a still-missing image reports
+	// ErrImageNotReady and the create fails exactly as before.
 	if _, err := resolveRootfsImage(stateRoot, spec.Image); err != nil {
-		if !errors.Is(err, ErrImageNotReady) {
-			return nil, err
-		}
-		client, clientErr := d.agentClientOrNil()
-		if clientErr != nil {
-			return nil, clientErr
-		}
-		if client != nil {
-			if _, err := client.PinImage(ctx, d.warmPullRequestID(spec.Image), spec.Image); err != nil {
-				if !errors.Is(err, errAgentUnreachable) {
-					return nil, err
-				}
-				// The agent is absent mid-flight: fall through, the local
-				// check below reports the missing image as before.
-			} else if _, err := resolveRootfsImage(stateRoot, spec.Image); err != nil {
-				return nil, err
-			}
-		}
+		return nil, err
 	}
 
 	directory, err := ensureSandboxDir(stateRoot, identity.SandboxUID)
@@ -441,6 +431,12 @@ func (d *Driver) EnsureSandbox(ctx context.Context, input *fastletapi.EnsureSand
 	slot, err := manager.Acquire(acquireCtx, owner)
 	observability.End(acquireSpan, err)
 	if err != nil {
+		snapshot := manager.Snapshot()
+		klog.ErrorS(err, "firecracker network slot acquire failed",
+			"sandboxId", identity.SandboxUID,
+			"generation", identity.InstanceGeneration, "attempt", identity.AssignmentAttempt,
+			"capacity", snapshot.Capacity, "clean", snapshot.Clean,
+			"bound", snapshot.Bound, "destroying", snapshot.Destroying)
 		return nil, fmt.Errorf("%w: acquire Firecracker network slot: %v", ErrNetworkUnavailable, err)
 	}
 	acquireDur := time.Since(createStarted)

--- a/internal/runtime/firecracker/image_delivery.go
+++ b/internal/runtime/firecracker/image_delivery.go
@@ -1,0 +1,187 @@
+package firecracker
+
+// image_delivery.go implements the asynchronous artifact delivery of the
+// driver (runtimecontract.ImageDelivery): a create whose rootfs image is not
+// cached never blocks on the node-side pull. DeliverImage guarantees one
+// background delivery attempt per image is in flight and reports the image as
+// Delivering; the caller (Fastlet) parks the Sandbox and polls. A finished
+// attempt reports its result: Delivered once the committed cache is visible,
+// or the sticky attempt error so polling callers can fail the Sandbox with a
+// terminal observation instead of retrying forever.
+//
+// Delivery attempts are single-flight per image: concurrent create intents
+// for the same cold image coalesce into one PinImage (the agent journal
+// dedupes replays by the pod-scoped warm-pull request id anyway). A failed
+// attempt stays sticky for a short report window so polling callers observe
+// the failure at least once; after the window a later call starts a fresh
+// attempt, which lets a re-created Sandbox recover once the image becomes
+// available.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	runtimecontract "fast-sandbox/internal/runtime/contract"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// defaultImageDeliveryAttemptTimeout bounds one background delivery
+	// attempt (image index + manifest + artifact set transfer).
+	defaultImageDeliveryAttemptTimeout = 30 * time.Minute
+
+	// defaultImageDeliveryFailureWindow keeps a failed delivery sticky for
+	// this long: within the window DeliverImage reports the attempt error
+	// instead of immediately starting a doomed attempt, so a polling worker
+	// can count failures; after it, a new attempt is started on demand.
+	defaultImageDeliveryFailureWindow = 30 * time.Second
+)
+
+// imageDelivery tracks the delivery state of one image.
+type imageDelivery struct {
+	mu        sync.Mutex
+	inFlight  bool      // a delivery attempt is running
+	failedErr error     // result of the last finished attempt, when it failed
+	failedAt  time.Time // when the last attempt failed
+}
+
+// DeliverImage implements runtimecontract.ImageDelivery. A cached image
+// reports Delivered without touching the agent. A missing image with no
+// runtime-agent configured is an error (local mode cannot deliver); otherwise
+// one background delivery attempt per image is kept in flight and the image
+// reports Delivering. A recent attempt failure is reported once (sticky
+// window); afterwards the next call starts a fresh attempt.
+func (d *Driver) DeliverImage(_ context.Context, image string) (runtimecontract.ImageDeliveryStatus, error) {
+	d.mu.RLock()
+	stateRoot := d.config.StateRoot
+	d.mu.RUnlock()
+	if strings.TrimSpace(image) == "" {
+		return "", fmt.Errorf("%w: image reference is required", ErrInvalidConfig)
+	}
+	if _, err := resolveRootfsImage(stateRoot, image); err == nil {
+		d.touchImage(image)
+		return runtimecontract.ImageDelivered, nil
+	}
+	client, err := d.agentClientOrNil()
+	if err != nil {
+		return "", err
+	}
+	if client == nil {
+		return "", fmt.Errorf("%w: %q is not cached and no runtime-agent is configured to deliver it", ErrImageNotReady, image)
+	}
+
+	d.mu.Lock()
+	entry := d.imageDeliveryLocked(image)
+	d.mu.Unlock()
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.inFlight {
+		return runtimecontract.ImageDelivering, nil
+	}
+	if entry.failedErr != nil && time.Since(entry.failedAt) < d.deliveryFailureWindowSetting() {
+		failed := entry.failedErr
+		return "", failed
+	}
+	entry.inFlight = true
+	entry.failedErr = nil
+	entry.failedAt = time.Time{}
+	go d.runImageDeliveryAttempt(image, entry)
+	return runtimecontract.ImageDelivering, nil
+}
+
+// imageDeliveryLocked returns (creating if needed) the delivery tracker of an
+// image. The caller holds d.mu.
+func (d *Driver) imageDeliveryLocked(image string) *imageDelivery {
+	if d.imageDeliveries == nil {
+		d.imageDeliveries = make(map[string]*imageDelivery)
+	}
+	key := imageKey(image)
+	entry := d.imageDeliveries[key]
+	if entry == nil {
+		entry = &imageDelivery{}
+		d.imageDeliveries[key] = entry
+	}
+	return entry
+}
+
+// runImageDeliveryAttempt performs one PinImage pull in the background and
+// records the terminal result on the tracker. Success is verified locally:
+// the agent journal replays a committed PinImage without re-pulling, so a
+// cache purged under a committed pin must surface as a failed attempt (with
+// a diagnosable error) instead of a success that never materializes.
+func (d *Driver) runImageDeliveryAttempt(image string, entry *imageDelivery) {
+	timeout := d.deliveryAttemptTimeoutSetting()
+	if timeout <= 0 {
+		timeout = defaultImageDeliveryAttemptTimeout
+	}
+	attemptContext, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	klog.InfoS("firecracker image delivery attempt started", "image", image, "timeout", timeout.String())
+	err := d.pinImageForDelivery(attemptContext, image)
+	if err == nil {
+		d.mu.RLock()
+		stateRoot := d.config.StateRoot
+		d.mu.RUnlock()
+		if _, resolveErr := resolveRootfsImage(stateRoot, image); resolveErr != nil {
+			err = fmt.Errorf("%w: runtime-agent reports %q delivered but no commit point exists in the local cache (cache purged under an idempotent pin?); rebuild the environment or clear the agent journal to re-pull", ErrImageNotReady, image)
+		} else {
+			d.touchImage(image)
+		}
+	}
+
+	entry.mu.Lock()
+	entry.inFlight = false
+	if err == nil {
+		entry.failedErr = nil
+		entry.failedAt = time.Time{}
+	} else {
+		entry.failedErr = err
+		entry.failedAt = time.Now()
+	}
+	entry.mu.Unlock()
+
+	if err == nil {
+		klog.InfoS("firecracker image delivery completed", "image", image)
+		return
+	}
+	klog.ErrorS(err, "firecracker image delivery attempt failed", "image", image)
+}
+
+// pinImageForDelivery pins (and thereby pulls) an image on the runtime-agent.
+// The pod-scoped warm-pull request id makes replays idempotent on the agent.
+func (d *Driver) pinImageForDelivery(ctx context.Context, image string) error {
+	client, err := d.agentClientOrNil()
+	if err != nil {
+		return err
+	}
+	if client == nil {
+		return fmt.Errorf("%w: runtime-agent disappeared while delivering %q", ErrImageNotReady, image)
+	}
+	if _, err := client.PinImage(ctx, d.warmPullRequestID(image), image); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Driver) deliveryAttemptTimeoutSetting() time.Duration {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.imageDeliveryAttemptTimeout > 0 {
+		return d.imageDeliveryAttemptTimeout
+	}
+	return defaultImageDeliveryAttemptTimeout
+}
+
+func (d *Driver) deliveryFailureWindowSetting() time.Duration {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.imageDeliveryFailureWindow > 0 {
+		return d.imageDeliveryFailureWindow
+	}
+	return defaultImageDeliveryFailureWindow
+}

--- a/internal/runtime/firecracker/image_delivery_test.go
+++ b/internal/runtime/firecracker/image_delivery_test.go
@@ -1,0 +1,209 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	runtimecontract "fast-sandbox/internal/runtime/contract"
+
+	"github.com/stretchr/testify/require"
+)
+
+// materializingAgent is a fake agent whose PinImage commits the rootfs into
+// the shared cache root, mirroring the real agent's pull-commit behavior.
+// noCommit simulates an agent journal replay: PinImage succeeds without
+// materializing any artifact.
+type materializingAgent struct {
+	*fakeAgentClient
+	cacheRoot string
+	mu        sync.Mutex
+	pinErr    error
+	pinCount  int
+	noCommit  bool
+}
+
+func (m *materializingAgent) PinImage(ctx context.Context, requestID, image string) (string, error) {
+	m.mu.Lock()
+	err := m.pinErr
+	m.mu.Unlock()
+	if err != nil {
+		return "", err
+	}
+	digest, err := m.fakeAgentClient.PinImage(ctx, requestID, image)
+	if err != nil {
+		return "", err
+	}
+	m.mu.Lock()
+	m.pinCount++
+	noCommit := m.noCommit
+	m.mu.Unlock()
+	if noCommit {
+		return digest, nil
+	}
+	dir := filepath.Join(m.cacheRoot, imageCacheDir, imageKey(image))
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return "", err
+	}
+	return digest, os.WriteFile(filepath.Join(dir, rootfsImageName), []byte("rootfs-image-data"), 0o640)
+}
+
+func (m *materializingAgent) setPinErr(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pinErr = err
+}
+
+func (m *materializingAgent) deliveredPins() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.pinCount
+}
+
+// installMaterializingAgent wires a materializing agent into a fixture.
+func (f *driverFixture) installMaterializingAgent(agent *materializingAgent) {
+	f.driver.newAgentClient = func(string) (AgentClient, error) { return agent, nil }
+	f.driver.agentSocket = "/run/fast-sandbox/firecracker/runtime.sock"
+	f.driver.podUID = "pod-1"
+}
+
+func TestDeliverImageReportsDeliveredWhenCached(t *testing.T) {
+	fixture := newDriverFixture(t)
+	fixture.prepareCachedImage(t, fixture.sandboxSpec.Spec.Image)
+
+	status, err := fixture.driver.DeliverImage(context.Background(), fixture.sandboxSpec.Spec.Image)
+	require.NoError(t, err)
+	require.Equal(t, runtimecontract.ImageDelivered, status)
+}
+
+func TestDeliverImageLocalModeMissingIsImpossible(t *testing.T) {
+	fixture := newDriverFixture(t)
+
+	status, err := fixture.driver.DeliverImage(context.Background(), fixture.sandboxSpec.Spec.Image)
+	require.ErrorIs(t, err, ErrImageNotReady)
+	require.Equal(t, runtimecontract.ImageDeliveryStatus(""), status)
+
+	status, err = fixture.driver.DeliverImage(context.Background(), "")
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Equal(t, runtimecontract.ImageDeliveryStatus(""), status)
+}
+
+func TestDeliverImageKicksBackgroundAttemptUntilCommitted(t *testing.T) {
+	fixture := newDriverFixture(t)
+	agent := &materializingAgent{fakeAgentClient: &fakeAgentClient{}, cacheRoot: fixture.stateRoot}
+	fixture.installMaterializingAgent(agent)
+
+	started := time.Now()
+	status, err := fixture.driver.DeliverImage(context.Background(), fixture.sandboxSpec.Spec.Image)
+	require.NoError(t, err)
+	require.Equal(t, runtimecontract.ImageDelivering, status)
+
+	require.Eventually(t, func() bool {
+		_, resolveErr := resolveRootfsImage(fixture.stateRoot, fixture.sandboxSpec.Spec.Image)
+		return resolveErr == nil
+	}, 5*time.Second, 20*time.Millisecond, "background delivery must commit the image")
+
+	require.GreaterOrEqual(t, agent.deliveredPins(), 1)
+	require.Less(t, time.Since(started), 5*time.Second, "DeliverImage must never block on the transfer")
+
+	status, err = fixture.driver.DeliverImage(context.Background(), fixture.sandboxSpec.Spec.Image)
+	require.NoError(t, err)
+	require.Equal(t, runtimecontract.ImageDelivered, status)
+}
+
+// TestDeliverImageReportsReplayWithoutLocalCommitAsFailure: the agent journal
+// replays a committed PinImage without re-pulling, so a cache purged under a
+// committed pin must surface as a terminal attempt error (never as a success
+// that loops forever).
+func TestDeliverImageReportsReplayWithoutLocalCommitAsFailure(t *testing.T) {
+	fixture := newDriverFixture(t)
+	agent := &materializingAgent{fakeAgentClient: &fakeAgentClient{}, cacheRoot: fixture.stateRoot, noCommit: true}
+	fixture.installMaterializingAgent(agent)
+
+	status, err := fixture.driver.DeliverImage(context.Background(), fixture.sandboxSpec.Spec.Image)
+	require.NoError(t, err)
+	require.Equal(t, runtimecontract.ImageDelivering, status)
+
+	var reported error
+	require.Eventually(t, func() bool {
+		_, err := fixture.driver.DeliverImage(context.Background(), fixture.sandboxSpec.Spec.Image)
+		if err != nil {
+			reported = err
+			return true
+		}
+		return false
+	}, 5*time.Second, 20*time.Millisecond, "a replay without a local commit point must fail the attempt")
+	require.ErrorIs(t, reported, ErrImageNotReady)
+	require.Contains(t, reported.Error(), "no commit point")
+	require.NotZero(t, agent.deliveredPins())
+}
+
+func TestDeliverImageIsSingleFlight(t *testing.T) {
+	fixture := newDriverFixture(t)
+	agent := &materializingAgent{fakeAgentClient: &fakeAgentClient{}, cacheRoot: fixture.stateRoot}
+	fixture.installMaterializingAgent(agent)
+
+	var statuses = make(chan runtimecontract.ImageDeliveryStatus, 2)
+	for range 2 {
+		go func() {
+			status, err := fixture.driver.DeliverImage(context.Background(), fixture.sandboxSpec.Spec.Image)
+			require.NoError(t, err)
+			statuses <- status
+		}()
+	}
+	for range 2 {
+		require.Equal(t, runtimecontract.ImageDelivering, <-statuses)
+	}
+	require.Eventually(t, func() bool {
+		_, resolveErr := resolveRootfsImage(fixture.stateRoot, fixture.sandboxSpec.Spec.Image)
+		return resolveErr == nil
+	}, 5*time.Second, 20*time.Millisecond)
+	require.Equal(t, 1, agent.deliveredPins(), "concurrent deliveries must coalesce into one attempt")
+}
+
+func TestDeliverImageReportsFailureOnceThenRecoversAfterWindow(t *testing.T) {
+	fixture := newDriverFixture(t)
+	agent := &materializingAgent{fakeAgentClient: &fakeAgentClient{}, cacheRoot: fixture.stateRoot}
+	fixture.installMaterializingAgent(agent)
+	// Shorten the sticky window so the test observes failure AND the
+	// window-expiry retry without waiting real minutes.
+	fixture.driver.imageDeliveryFailureWindow = 300 * time.Millisecond
+	boom := errors.New("remote image index 404")
+
+	agent.setPinErr(boom)
+	status, err := fixture.driver.DeliverImage(context.Background(), fixture.sandboxSpec.Spec.Image)
+	require.NoError(t, err)
+	require.Equal(t, runtimecontract.ImageDelivering, status)
+
+	// The finished attempt failure is reported at most once per window.
+	var reported error
+	require.Eventually(t, func() bool {
+		_, err := fixture.driver.DeliverImage(context.Background(), fixture.sandboxSpec.Spec.Image)
+		if err != nil {
+			reported = err
+			return true
+		}
+		return false
+	}, 5*time.Second, 20*time.Millisecond, "the failed attempt must surface to polling callers")
+	require.ErrorIs(t, reported, boom)
+
+	// Within the window the failure stays sticky (no doomed new attempt).
+	_, err = fixture.driver.DeliverImage(context.Background(), fixture.sandboxSpec.Spec.Image)
+	require.ErrorIs(t, err, boom)
+
+	// After the window a fresh attempt runs; once the remote recovers the
+	// image is delivered.
+	time.Sleep(400 * time.Millisecond)
+	agent.setPinErr(nil)
+	status, err = fixture.driver.DeliverImage(context.Background(), fixture.sandboxSpec.Spec.Image)
+	require.NoError(t, err)
+	require.Equal(t, runtimecontract.ImageDelivering, status)
+	require.Eventually(t, func() bool {
+		_, resolveErr := resolveRootfsImage(fixture.stateRoot, fixture.sandboxSpec.Spec.Image)
+		return resolveErr == nil
+	}, 5*time.Second, 20*time.Millisecond)
+}


### PR DESCRIPTION
## Summary

A Firecracker Sandbox create whose rootfs image is **not yet cached** used to run the whole node-side artifact pull (index -> manifest -> multi-GiB rootfs/memory transfer via the runtime-agent) **inside the create request**. The create RPC stalled for the full download and could blow past client timeouts.

This change makes image delivery truly asynchronous when the image is missing locally: the create RPC returns as soon as the Sandbox is accepted (runtime `Creating`), the artifact is pulled in the background on the node, and the Sandbox boots once the image is committed — no retry storm, no RPC held hostage by the network.

## Design

Cold-image creates follow the existing two-phase pattern the codebase already uses for data-plane readiness (`infra-pending` -> worker -> `running`):

```
CreateSandbox RPC
  └─ runtime implements ImageDelivery?  (only firecracker today)
       ├─ DeliverImage == Delivered  ──▶ synchronous boot (unchanged path)
       ├─ DeliverImage error          ──▶ synchronous failure (local mode, unchanged)
       └─ DeliverImage == Delivering  ──▶ park: placeholder -> "image-pending",
                                          RPC returns Created immediately
                                          boot worker polls delivery, then
                                          EnsureSandbox -> commit -> data-plane tail
```

- **Driver (`internal/runtime/firecracker/image_delivery.go`)**: `DeliverImage` keeps one single-flight background `PinImage` attempt per image (same pod-scoped warm-pull request id, so the agent journal dedupes replays and the image stays pinned). `EnsureSandbox` never pulls inline anymore; a cold image reports `ErrImageNotReady` and is booted only after delivery commits. Failed attempts are sticky for a short window (reported to pollers), then a later call starts a fresh attempt so a re-created Sandbox recovers once the image becomes available.
- **Fastlet (`internal/fastlet/sandbox/boot_lifecycle.go` + state machine)**: new phases `image-pending` (runtime `Creating`) and `create-failed` (terminal, runtime `Failed` + message, no admission capacity consumed). A boot worker drives delivery -> boot -> commit using the exact same EnsureSandbox/commit/hooks sequence as the synchronous path. Delete during park/boot cancels the worker and hands over to the existing async delete path.
- **Control plane**: `Orchestrator.CreateRuntimeOnCandidate` accepts a `Created` observation with runtime `Creating` (parked) — the controller's existing `ObserveRuntime` loop converges the Sandbox to Ready. gRPC `CreateSandbox` therefore returns promptly instead of blocking.
- **fastctl**: `run` polls `GetSandbox` until Ready or a terminal state (Failed/Unavailable/Stopped), implementing READY semantics client-side.

## Behavior matrix (who is affected)

| Scenario | Before | After |
|---|---|---|
| Non-firecracker runtimes | unchanged | unchanged (no `ImageDelivery`) |
| Firecracker, image cached | synchronous create | identical synchronous create |
| Firecracker, cold, no runtime-agent (local mode) | create fails | identical failure |
| Firecracker, cold, agent present | create RPC blocks on full pull | **create returns accepted; delivery + boot run in background** |

If the remote image does not exist (404), the Sandbox projects a terminal `Failed` observation instead of retrying forever; recovery is delete + re-create (the driver failure window expires automatically and allows a fresh attempt).

## Notes for consumers

- `CREATE_COMPLETION_READY` no longer means "block until Ready" for cold images — the create returns once accepted (runtime `Creating`). Callers must poll `GetSandbox` / the Sandbox CR Ready condition (fastctl `run` already does this).

## Tests

- Driver: async kick -> commit, single-flight coalescing, sticky failure reporting + window recovery, EnsureSandbox never pulls inline.
- Fastlet: cold create parks and returns immediately, boot worker converges to Ready after delivery, delete while delivering removes the Sandbox, delivery failure projects the terminal state and releases admission capacity.
- Orchestrator: accepted create may observe runtime Creating.
- Ran with `-race`: `internal/runtime/firecracker/...`, `internal/fastlet/sandbox`, `internal/controlplane/...`, `cmd/fastctl/cmd`, plus `go build ./...` and full e2e-suite compilation.
