### PR TITLE
fix(firecracker): cold-create readiness gating + per-template index key

### DIFF
--- a/api/v1alpha2/sandboxtemplate_types.go
+++ b/api/v1alpha2/sandboxtemplate_types.go
@@ -156,6 +156,19 @@ type SandboxTemplateSpec struct {
 	// +optional
 	Execd string `json:"execd,omitempty"`
 
+	// IndexKey optionally names an additional content-addressed image-index
+	// key the publish stage writes alongside the default sha256(image) key.
+	// Use case: per-template artifact identity — the OpenSandbox server sets
+	// it to the template ID so two templates of the same source image never
+	// alias each other's artifact sets or node caches. The index payload's
+	// image field equals the key it is written under, so pull-side byte
+	// matching works unchanged. The default key stays last-writer-wins for
+	// warmImages and older clients.
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-zA-Z0-9._-]+)*(:[a-zA-Z0-9._-]{1,127})?$`
+	// +kubebuilder:validation:MaxLength=255
+	// +optional
+	IndexKey string `json:"indexKey,omitempty"`
+
 	// Kernel is the guest kernel to embed; it must be present in the builder
 	// image under this name (the builder image embeds one kernel at build
 	// time via the KERNEL_NAME build arg).

--- a/cmd/sandboxtemplate-builder/publish.go
+++ b/cmd/sandboxtemplate-builder/publish.go
@@ -68,7 +68,7 @@ func publish(ctx context.Context, spec apiv1alpha2.SandboxTemplateSpec, workdir 
 	// The image index is uploaded last: a consumer that can resolve the
 	// index is guaranteed a complete artifact set (artifacts, checksums,
 	// and manifest are all already in place).
-	if err := publishImageIndex(ctx, aws, args, spec.Image, manifestURI, sha256Of(manifestBytes), spec.Output.Publish); err != nil {
+	if err := publishImageIndex(ctx, aws, args, spec.Image, manifestURI, sha256Of(manifestBytes), spec.Output.Publish, spec.IndexKey); err != nil {
 		return "", err
 	}
 	return manifestURI, nil
@@ -101,25 +101,52 @@ func imageIndexPayload(image, manifestURI, artifactDigest string) ([]byte, error
 	return json.MarshalIndent(document, "", "  ")
 }
 
-// publishImageIndex uploads the image index object under the store root so
-// consumers can resolve the published artifact set from the image reference
-// alone. The index lives outside the per-build digest namespace, so a
-// rebuild of the same image reference atomically moves the pointer.
+// publishImageIndex uploads the image index object(s) under the store root
+// so consumers can resolve the published artifact set from the image
+// reference alone. The index lives outside the per-build digest namespace,
+// so a rebuild of the same image reference atomically moves the pointer.
 //
 // The index key is derived from the raw image reference string and must be
 // byte-identical to the consumer-side reference (SandboxSpec.Image): no
 // normalization, no default tags, no whitespace trimming. Any divergence
 // breaks the addressing chain.
 //
+// When spec.indexKey is set, the same payload is additionally published
+// under that key with the payload image field equal to the key, giving the
+// build an exact, immutable identity: the OpenSandbox server sets it to the
+// template ID, so two templates of the same source image never alias each
+// other's artifact sets or node caches, while the default sha256(image) key
+// stays last-writer-wins for warmImages and older clients.
+//
 // Concurrent builds of the same image reference against the same store
 // root are last-writer-wins: every build is complete before its index is
 // written, so no half-published state is ever observable, but the winner
 // is not deterministic (publishers should serialize per image).
-func publishImageIndex(ctx context.Context, aws string, args []string, image, manifestURI, artifactDigest, storeRoot string) error {
+func publishImageIndex(ctx context.Context, aws string, args []string, image, manifestURI, artifactDigest, storeRoot string, indexKey string) error {
 	if strings.TrimSpace(image) == "" {
 		return fmt.Errorf("publish image index: image reference is required (empty image would collide on the empty-hash index key)")
 	}
-	payload, err := imageIndexPayload(image, manifestURI, artifactDigest)
+	for _, key := range indexKeys(image, indexKey) {
+		if err := publishOneImageIndex(ctx, aws, args, key, manifestURI, artifactDigest, storeRoot); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// indexKeys returns the image-index keys a build publishes under: the raw
+// image reference (default, last-writer-wins) plus the optional exact
+// spec.indexKey identity when set to something else.
+func indexKeys(image, indexKey string) []string {
+	keys := []string{image}
+	if key := strings.TrimSpace(indexKey); key != "" && key != image {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func publishOneImageIndex(ctx context.Context, aws string, args []string, key, manifestURI, artifactDigest, storeRoot string) error {
+	payload, err := imageIndexPayload(key, manifestURI, artifactDigest)
 	if err != nil {
 		return err
 	}
@@ -134,9 +161,9 @@ func publishImageIndex(ctx context.Context, aws string, args []string, image, ma
 	if err := local.Close(); err != nil {
 		return err
 	}
-	key := "index/" + imageIndexKey(image) + ".json"
-	target := strings.TrimRight(storeRoot, "/") + "/" + key
-	return uploadWithRetry(ctx, aws, args, local.Name(), target, key)
+	objectKey := "index/" + imageIndexKey(key) + ".json"
+	target := strings.TrimRight(storeRoot, "/") + "/" + objectKey
+	return uploadWithRetry(ctx, aws, args, local.Name(), target, objectKey)
 }
 
 // publishRetries is how many times a transient upload failure is retried.

--- a/cmd/sandboxtemplate-builder/publish_test.go
+++ b/cmd/sandboxtemplate-builder/publish_test.go
@@ -66,12 +66,54 @@ func TestPublishImageIndexRejectsEmptyImage(t *testing.T) {
 	for _, image := range []string{"", "   ", "\t\n"} {
 		err := publishImageIndex(context.Background(), "aws", []string{"s3", "cp"}, image,
 			"s3://bucket/sandbox-images/0123456789abcdef/manifest.json",
-			"deadbeef", "s3://bucket/sandbox-images")
+			"deadbeef", "s3://bucket/sandbox-images", "")
 		if err == nil {
 			t.Fatalf("expected an error for empty image reference %q", image)
 		}
 		if !strings.Contains(err.Error(), "image reference is required") {
 			t.Fatalf("error %q does not mention the required guard", err)
+		}
+	}
+}
+
+// TestIndexKeys verifies which index keys a build publishes under: the raw
+// image reference always, plus the exact spec.indexKey identity when set
+// (deduplicated and whitespace-trimmed).
+func TestIndexKeys(t *testing.T) {
+	const image = "alpine:3.19"
+	if got := indexKeys(image, ""); len(got) != 1 || got[0] != image {
+		t.Fatalf("indexKeys(%q, empty) = %v, want [%q]", image, got, image)
+	}
+	if got := indexKeys(image, "   "); len(got) != 1 || got[0] != image {
+		t.Fatalf("indexKeys(%q, blank) = %v, want [%q]", image, got, image)
+	}
+	if got := indexKeys(image, image); len(got) != 1 {
+		t.Fatalf("indexKeys with key == image must deduplicate, got %v", got)
+	}
+	got := indexKeys(image, " tpl-796f5f33-1183 ")
+	if len(got) != 2 || got[0] != image || got[1] != "tpl-796f5f33-1183" {
+		t.Fatalf("indexKeys = %v, want [%q tpl-796f5f33-1183]", got, image)
+	}
+}
+
+// TestImageIndexPayloadMatchesKey verifies the per-key identity contract:
+// the payload written under a key carries that key in its image field, so
+// pull-side byte matching accepts requests by either the source image or
+// the exact template key.
+func TestImageIndexPayloadMatchesKey(t *testing.T) {
+	for _, key := range []string{"alpine:3.19", "tpl-796f5f33-1183"} {
+		payload, err := imageIndexPayload(key, "s3://b/m", "digest")
+		if err != nil {
+			t.Fatalf("imageIndexPayload(%q): %v", key, err)
+		}
+		var document struct {
+			Image string `json:"image"`
+		}
+		if err := json.Unmarshal(payload, &document); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if document.Image != key {
+			t.Fatalf("payload image = %q, want the index key %q", document.Image, key)
 		}
 	}
 }

--- a/config/crd/sandbox.fast.io_sandboxtemplates.yaml
+++ b/config/crd/sandbox.fast.io_sandboxtemplates.yaml
@@ -217,6 +217,19 @@ spec:
               image:
                 description: Image is the OCI image reference to convert.
                 type: string
+              indexKey:
+                description: |-
+                  IndexKey optionally names an additional content-addressed image-index
+                  key the publish stage writes alongside the default sha256(image) key.
+                  Use case: per-template artifact identity — the OpenSandbox server sets
+                  it to the template ID so two templates of the same source image never
+                  alias each other's artifact sets or node caches. The index payload's
+                  image field equals the key it is written under, so pull-side byte
+                  matching works unchanged. The default key stays last-writer-wins for
+                  warmImages and older clients.
+                maxLength: 255
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-zA-Z0-9._-]+)*(:[a-zA-Z0-9._-]{1,127})?$
+                type: string
               init:
                 description: |-
                   Init is the injected PID 1 path inside the rootfs. The init script

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -388,10 +388,15 @@ func (d *Driver) EnsureSandbox(ctx context.Context, input *fastletapi.EnsureSand
 	// on the node-side pull. Fastlet routes cold creates through the
 	// driver's asynchronous delivery (DeliverImage): the artifact set is
 	// pulled in the background and the Sandbox is booted once the commit
-	// point appears in the local cache. Local mode (no agent socket) keeps
-	// the pre-warmed behavior: a still-missing image reports
+	// point appears in the local cache. The check covers the COMPLETE
+	// restore set (rootfs + vmstate + memory) and runs BEFORE the network
+	// slot is acquired: a partially delivered cache reports
+	// ErrImageNotReady here instead of burning a slot on the restore-path
+	// checks below, so a parked boot worker polling during the delivery
+	// window cannot exhaust the slot pool. Local mode (no agent socket)
+	// keeps the pre-warmed behavior: a still-missing image reports
 	// ErrImageNotReady and the create fails exactly as before.
-	if _, err := resolveRootfsImage(stateRoot, spec.Image); err != nil {
+	if err := verifyRestorableImage(stateRoot, spec.Image); err != nil {
 		return nil, err
 	}
 

--- a/internal/runtime/firecracker/image_delivery.go
+++ b/internal/runtime/firecracker/image_delivery.go
@@ -49,12 +49,13 @@ type imageDelivery struct {
 	failedAt  time.Time // when the last attempt failed
 }
 
-// DeliverImage implements runtimecontract.ImageDelivery. A cached image
-// reports Delivered without touching the agent. A missing image with no
-// runtime-agent configured is an error (local mode cannot deliver); otherwise
-// one background delivery attempt per image is kept in flight and the image
-// reports Delivering. A recent attempt failure is reported once (sticky
-// window); afterwards the next call starts a fresh attempt.
+// DeliverImage implements runtimecontract.ImageDelivery. An image whose
+// complete restore set is cached reports Delivered without touching the
+// agent. A missing image with no runtime-agent configured is an error (local
+// mode cannot deliver); otherwise one background delivery attempt per image
+// is kept in flight and the image reports Delivering. A recent attempt
+// failure is reported once (sticky window); afterwards the next call starts
+// a fresh attempt.
 func (d *Driver) DeliverImage(_ context.Context, image string) (runtimecontract.ImageDeliveryStatus, error) {
 	d.mu.RLock()
 	stateRoot := d.config.StateRoot
@@ -62,7 +63,7 @@ func (d *Driver) DeliverImage(_ context.Context, image string) (runtimecontract.
 	if strings.TrimSpace(image) == "" {
 		return "", fmt.Errorf("%w: image reference is required", ErrInvalidConfig)
 	}
-	if _, err := resolveRootfsImage(stateRoot, image); err == nil {
+	if err := verifyRestorableImage(stateRoot, image); err == nil {
 		d.touchImage(image)
 		return runtimecontract.ImageDelivered, nil
 	}
@@ -110,10 +111,11 @@ func (d *Driver) imageDeliveryLocked(image string) *imageDelivery {
 }
 
 // runImageDeliveryAttempt performs one PinImage pull in the background and
-// records the terminal result on the tracker. Success is verified locally:
-// the agent journal replays a committed PinImage without re-pulling, so a
-// cache purged under a committed pin must surface as a failed attempt (with
-// a diagnosable error) instead of a success that never materializes.
+// records the terminal result on the tracker. Success is verified locally
+// against the complete restore set: the agent journal replays a committed
+// PinImage without re-pulling, so a cache purged under a committed pin must
+// surface as a failed attempt (with a diagnosable error) instead of a
+// success that never materializes.
 func (d *Driver) runImageDeliveryAttempt(image string, entry *imageDelivery) {
 	timeout := d.deliveryAttemptTimeoutSetting()
 	if timeout <= 0 {
@@ -127,8 +129,8 @@ func (d *Driver) runImageDeliveryAttempt(image string, entry *imageDelivery) {
 		d.mu.RLock()
 		stateRoot := d.config.StateRoot
 		d.mu.RUnlock()
-		if _, resolveErr := resolveRootfsImage(stateRoot, image); resolveErr != nil {
-			err = fmt.Errorf("%w: runtime-agent reports %q delivered but no commit point exists in the local cache (cache purged under an idempotent pin?); rebuild the environment or clear the agent journal to re-pull", ErrImageNotReady, image)
+		if resolveErr := verifyRestorableImage(stateRoot, image); resolveErr != nil {
+			err = fmt.Errorf("%w: runtime-agent reports %q delivered but no committed restore set exists in the local cache (cache purged under an idempotent pin?); rebuild the environment or clear the agent journal to re-pull", ErrImageNotReady, image)
 		} else {
 			d.touchImage(image)
 		}

--- a/internal/runtime/firecracker/image_delivery_test.go
+++ b/internal/runtime/firecracker/image_delivery_test.go
@@ -49,7 +49,18 @@ func (m *materializingAgent) PinImage(ctx context.Context, requestID, image stri
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return "", err
 	}
-	return digest, os.WriteFile(filepath.Join(dir, rootfsImageName), []byte("rootfs-image-data"), 0o640)
+	// The real agent commits the complete restore set; a partial commit
+	// (rootfs only) must NOT count as delivered.
+	for name, payload := range map[string]string{
+		rootfsImageName:     "rootfs-image-data",
+		vmstateSnapshotName: "vmstate-snapshot-data",
+		memorySnapshotName:  "memory-snapshot-data",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(payload), 0o640); err != nil {
+			return "", err
+		}
+	}
+	return digest, nil
 }
 
 func (m *materializingAgent) setPinErr(err error) {
@@ -138,7 +149,7 @@ func TestDeliverImageReportsReplayWithoutLocalCommitAsFailure(t *testing.T) {
 		return false
 	}, 5*time.Second, 20*time.Millisecond, "a replay without a local commit point must fail the attempt")
 	require.ErrorIs(t, reported, ErrImageNotReady)
-	require.Contains(t, reported.Error(), "no commit point")
+	require.Contains(t, reported.Error(), "no committed restore set")
 	require.NotZero(t, agent.deliveredPins())
 }
 
@@ -206,4 +217,29 @@ func TestDeliverImageReportsFailureOnceThenRecoversAfterWindow(t *testing.T) {
 		_, resolveErr := resolveRootfsImage(fixture.stateRoot, fixture.sandboxSpec.Spec.Image)
 		return resolveErr == nil
 	}, 5*time.Second, 20*time.Millisecond)
+}
+
+// TestDeliverImagePartialCacheIsNotDelivered: a cache with only the rootfs
+// committed (snapshots still transferring) must keep reporting Delivering and
+// re-attempt delivery, never Delivered — the readiness criterion is the
+// complete restore set, the same one EnsureSandbox's restore path enforces.
+// This is the regression test for the cold-create slot burn: a partial-cache
+// Delivered let the boot worker poll EnsureSandbox, whose post-acquire
+// snapshot check then release-destroyed a network slot per attempt.
+func TestDeliverImagePartialCacheIsNotDelivered(t *testing.T) {
+	fixture := newDriverFixture(t)
+	image := fixture.sandboxSpec.Spec.Image
+	dir := filepath.Join(fixture.stateRoot, imageCacheDir, imageKey(image))
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, rootfsImageName), []byte("rootfs-image-data"), 0o640))
+
+	// Local mode (no agent): a partial cache is NOT ready, so delivery is
+	// impossible and the call reports ErrImageNotReady — never Delivered.
+	status, err := fixture.driver.DeliverImage(context.Background(), image)
+	require.ErrorIs(t, err, ErrImageNotReady)
+	require.Equal(t, runtimecontract.ImageDeliveryStatus(""), status)
+
+	// The same criterion gates the synchronous create path: a partial cache
+	// parks (or fails in local mode) before any network slot is acquired.
+	require.ErrorIs(t, verifyRestorableImage(fixture.stateRoot, image), ErrImageNotReady)
 }

--- a/internal/runtime/firecracker/images.go
+++ b/internal/runtime/firecracker/images.go
@@ -64,6 +64,24 @@ func resolveRootfsImage(stateRoot, image string) (string, error) {
 	return path, nil
 }
 
+// verifyRestorableImage verifies the COMPLETE restore set of an image is
+// committed in the local cache: rootfs plus both golden snapshots. This is
+// the single readiness criterion shared by async delivery and EnsureSandbox,
+// so a partially delivered cache (rootfs committed while vmstate/memory are
+// still transferring) never reports ready. Without it, a parked boot worker
+// polls EnsureSandbox in the delivery window, and every attempt acquires a
+// network slot only to release-destroy it on the snapshot check — burning
+// the slot pool faster than replenishment and failing the cold create.
+func verifyRestorableImage(stateRoot, image string) error {
+	if _, err := resolveRootfsImage(stateRoot, image); err != nil {
+		return err
+	}
+	if _, _, err := resolveRestoreSnapshotFiles(stateRoot, image); err != nil {
+		return err
+	}
+	return nil
+}
+
 // listCachedImages returns the converted image references stored under the
 // StateRoot, keyed by their content-addressed cache directory.
 func listCachedImages(stateRoot string) ([]string, error) {


### PR DESCRIPTION
## 1. fix: gate cold-create readiness on the complete restore set

Async cold delivery had two readiness criteria that disagreed:
`DeliverImage` (and `EnsureSandbox`'s pre-acquire check) considered an image ready when the **rootfs commit point** existed, while the restore path requires **rootfs + vmstate + memory**. In the delivery window the parked boot worker saw `Delivered`, called `EnsureSandbox`, and the post-acquire snapshot check failed with `ErrImageNotReady` — whose release path **destroys the network slot**. The ~75ms poll loop burned the 5-slot pool faster than replenishment; the exhausted acquire surfaced as `ErrNetworkUnavailable`, treated as terminal, and the cold create failed even though the artifact set completed seconds later.

Fix: one criterion everywhere (`verifyRestorableImage` = rootfs + both snapshots), checked **before any network slot is acquired**; a partial cache keeps reporting `Delivering` and re-attempts delivery.

## 2. feat: per-template index key (spec.indexKey)

The image index is keyed by `sha256(source image)` with last-writer-wins semantics, so two templates built from the same source image alias each other: which artifact set a sandbox loads depends on node cache history rather than the selected template, and snapshot-memory mismatches can reject the create.

`spec.indexKey` (the OpenSandbox server sets it to the template ID, `tpl-<uuid>`): the publish stage writes the index under **both** the default image key (kept for warmImages and older clients) and the exact key, with the payload `image` field equal to the key it is written under — pull-side byte matching, node caches, and journals then keep the two templates' artifact sets fully separate.

## Tests

- `TestDeliverImagePartialCacheIsNotDelivered` (regression for #1); delivery fake commits the full restore set like the real agent
- `TestIndexKeys` / `TestImageIndexPayloadMatchesKey` (dual-key publish, dedup/trim, key=identity contract)
- `go test ./internal/runtime/firecracker/ ./internal/fastlet/sandbox/ ./internal/fastlet/network/ ./cmd/sandboxtemplate-builder/` pass

## End-to-end verification

Through the OpenSandbox `fast-sandbox-env` integration environment (kind + KVM): cold create parks quietly during the ~22s DART pull and boots once the full set commits; warm creates converge in ~400ms; six sandboxes (1 cold + 5 warm) pass the full lifecycle verify including egress policy attach/update.