### PR TITLE
fix(fastlet): harden guest-vm network against stale neighbours and CIDR misalignment

### DIFF
--- a/build/Dockerfile.fastlet
+++ b/build/Dockerfile.fastlet
@@ -6,7 +6,9 @@ FROM golang:1.25-alpine
 # EXPOSE 2345
 
 WORKDIR /workspace
-RUN apk add --no-cache iproute2 iptables e2fsprogs
+# tcpdump: per-slot dataplane diagnosis from inside the fastlet netns
+# (kubectl exec ... -- ip netns exec <slot> tcpdump -i vmtap0)
+RUN apk add --no-cache iproute2 iptables e2fsprogs tcpdump
 COPY .build/linux-amd64/fastlet .
 COPY .build/linux-amd64/sandbox-init /opt/fast-sandbox/bin/sandbox-init
 COPY .build/linux-amd64/sandbox-tunnel /opt/fast-sandbox/bin/sandbox-tunnel

--- a/cmd/fastlet/main.go
+++ b/cmd/fastlet/main.go
@@ -6,8 +6,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	apiv1alpha2 "fast-sandbox/api/v1alpha2"
@@ -127,6 +129,17 @@ func main() {
 		configurable.SetRegistryProvider(registryProvider)
 	}
 	if runtimeProfile.UsesFastletNetNS() {
+		tuneNeighborGCThresholds()
+		// The slot CIDR must not overlap any live pod/node route (CNI pod
+		// CIDR, Docker bridge pool, VPC overlay): the slot bridge would
+		// hijack the range and the isolation rules would blackhole it.
+		if err := fastletnetwork.DetectCIDROverlap(ctx,
+			getEnv("FAST_SANDBOX_NETWORK_CIDR", fastletnetwork.DefaultPrivateCIDR),
+			getEnv("FAST_SANDBOX_NETWORK_BRIDGE", fastletnetwork.DefaultBridge),
+			fastletnetwork.ExecRunner{}); err != nil {
+			klog.ErrorS(err, "Fastlet slot CIDR conflicts with live host routes; set FAST_SANDBOX_NETWORK_CIDR to a free range")
+			os.Exit(1)
+		}
 		networkManager, err := newNetworkManager(capacityFromEnvironment(), podUID, runtimeProfile.NetworkMode)
 		if err != nil {
 			klog.ErrorS(err, "Failed to configure Fastlet-owned network")
@@ -197,8 +210,8 @@ func newNetworkManager(capacity int, podUID string, networkMode runtimecatalog.N
 	config := fastletnetwork.DefaultConfig(capacity, podUID)
 	config.PodName = os.Getenv("POD_NAME")
 	config.PodNamespace = os.Getenv("NAMESPACE")
-	config.PrivateCIDR = getEnv("FAST_SANDBOX_NETWORK_CIDR", config.PrivateCIDR)
-	config.Bridge = getEnv("FAST_SANDBOX_NETWORK_BRIDGE", config.Bridge)
+	config.PrivateCIDR = getEnv("FAST_SANDBOX_NETWORK_CIDR", fastletnetwork.DefaultPrivateCIDR)
+	config.Bridge = getEnv("FAST_SANDBOX_NETWORK_BRIDGE", fastletnetwork.DefaultBridge)
 	config.EgressDevice = getEnv("FAST_SANDBOX_NETWORK_EGRESS_DEVICE", "")
 	config.StateRoot = getEnv("FAST_SANDBOX_NETWORK_STATE_ROOT", config.StateRoot)
 	config.NetNSRoot = getEnv("FAST_SANDBOX_NETWORK_NETNS_ROOT", config.NetNSRoot)
@@ -218,6 +231,27 @@ func newNetworkManager(capacity int, podUID string, networkMode runtimecatalog.N
 
 type networkConfigurable interface {
 	SetNetworkManager(*fastletnetwork.Manager)
+}
+
+// tuneNeighborGCThresholds raises the neighbour cache GC thresholds so a
+// full slot pool (plus host peers) does not thrash the ARP cache into
+// constant eviction and re-resolution. Best-effort: fastlet may lack the
+// privilege in restricted environments and slot preparation must not
+// depend on it.
+func tuneNeighborGCThresholds() {
+	for _, tuning := range []struct {
+		name  string
+		value int
+	}{
+		{"net.ipv4.neigh.default.gc_thresh1", 4096},
+		{"net.ipv4.neigh.default.gc_thresh2", 8192},
+		{"net.ipv4.neigh.default.gc_thresh3", 16384},
+	} {
+		argument := fmt.Sprintf("%s=%d", tuning.name, tuning.value)
+		if output, err := exec.Command("sysctl", "-w", argument).CombinedOutput(); err != nil {
+			klog.Warningf("raise %s failed: %v: %s", tuning.name, err, strings.TrimSpace(string(output)))
+		}
+	}
 }
 
 type infraConfigurable interface {

--- a/cmd/sandboxtemplate-builder/manifest.go
+++ b/cmd/sandboxtemplate-builder/manifest.go
@@ -91,13 +91,15 @@ func buildManifest(spec apiv1alpha2.SandboxTemplateSpec, sourceDigest, kernel, r
 		},
 		// The guest network baked into the snapshot (clone networking
 		// model): the restored guest owns a static eth0 address/MAC; the
-		// consumer replaces only the host tap via network_overrides.
+		// consumer replaces only the host tap via network_overrides and
+		// validates the MTU against its slot data plane.
 		"guestNetwork": map[string]any{
 			"iface":   "eth0",
 			"mac":     bakedGuestMAC,
 			"ip":      bakedGuestIP,
 			"gateway": bakedGuestGateway,
 			"netmask": bakedGuestNetmask,
+			"mtu":     bakedGuestMTU,
 		},
 		"entrypoint": spec.Entrypoint,
 		"init":       spec.Init,

--- a/cmd/sandboxtemplate-builder/snapshot_stage.go
+++ b/cmd/sandboxtemplate-builder/snapshot_stage.go
@@ -43,6 +43,11 @@ const (
 	bakedGuestIP      = "172.30.0.3"
 	bakedGuestGateway = "172.30.0.1"
 	bakedGuestNetmask = "255.255.255.0"
+	// bakedGuestMTU is the eth0 MTU frozen into the snapshot: the boot args
+	// set no MTU, so the kernel default applies. Recorded in the manifest so
+	// consumers can validate it against the host-side slot MTU (a mismatch
+	// makes large transfers depend on PMTUD recovery).
+	bakedGuestMTU = 1500
 )
 
 // runSnapshotStage drives a Firecracker VM from cold boot to a validated

--- a/internal/fastlet/network/cidr_conflict.go
+++ b/internal/fastlet/network/cidr_conflict.go
@@ -1,0 +1,79 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// DetectCIDROverlap reports live IPv4 routes that overlap the Fastlet slot
+// CIDR. The slot bridge installs a connected route for the CIDR and the
+// sibling-isolation rules reject the whole range, so any pre-existing
+// pod/node route inside it (CNI pod CIDR, Docker bridge pool, VPC overlay
+// route) would be hijacked or blackholed. Routes via the slot bridge itself
+// are expected on restart and ignored. Fastlet refuses to start on a
+// conflict instead of silently producing half-broken sandboxes.
+func DetectCIDROverlap(ctx context.Context, cidr, bridgeDevice string, runner CommandRunner) error {
+	slotPrefix, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return fmt.Errorf("parse slot CIDR %q: %w", cidr, err)
+	}
+	if !slotPrefix.Addr().Is4() {
+		return fmt.Errorf("slot CIDR %q is not IPv4", cidr)
+	}
+	slotPrefix = slotPrefix.Masked()
+	output, err := runner.Run(ctx, "ip", "-4", "route", "show")
+	if err != nil {
+		return fmt.Errorf("read IPv4 routes: %w", err)
+	}
+	var conflicts []string
+	for _, line := range strings.Split(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 || fields[0] == "default" {
+			continue
+		}
+		if routeDevice(fields) == bridgeDevice {
+			continue
+		}
+		routePrefix, ok := parseRouteDestination(fields[0])
+		if !ok {
+			continue
+		}
+		if prefixesOverlap(slotPrefix, routePrefix) {
+			conflicts = append(conflicts, strings.TrimSpace(line))
+		}
+	}
+	if len(conflicts) > 0 {
+		return fmt.Errorf("slot CIDR %s overlaps live host routes: %s; set FAST_SANDBOX_NETWORK_CIDR to a free range", cidr, strings.Join(conflicts, "; "))
+	}
+	return nil
+}
+
+// routeDevice extracts the egress device of an `ip route` line (empty when
+// absent).
+func routeDevice(fields []string) string {
+	for index := 0; index+1 < len(fields); index++ {
+		if fields[index] == "dev" {
+			return fields[index+1]
+		}
+	}
+	return ""
+}
+
+// parseRouteDestination parses an `ip route` destination column: a prefix
+// ("172.30.0.0/24") or a bare address (an implicit host route).
+func parseRouteDestination(field string) (netip.Prefix, bool) {
+	if prefix, err := netip.ParsePrefix(field); err == nil && prefix.Addr().Is4() {
+		return prefix.Masked(), true
+	}
+	if address, err := netip.ParseAddr(field); err == nil && address.Is4() {
+		return netip.PrefixFrom(address, address.BitLen()), true
+	}
+	return netip.Prefix{}, false
+}
+
+// prefixesOverlap reports whether two prefixes contain any common address.
+func prefixesOverlap(a, b netip.Prefix) bool {
+	return a.Contains(b.Addr()) || b.Contains(a.Addr())
+}

--- a/internal/fastlet/network/cidr_conflict_test.go
+++ b/internal/fastlet/network/cidr_conflict_test.go
@@ -1,0 +1,79 @@
+package network
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type routeRunner struct {
+	routes string
+}
+
+func (r *routeRunner) Run(_ context.Context, command string, args ...string) ([]byte, error) {
+	return []byte(r.routes), nil
+}
+
+func TestDetectCIDROverlapClean(t *testing.T) {
+	runner := &routeRunner{routes: strings.Join([]string{
+		"default via 10.244.0.1 dev eth0",
+		"10.244.1.0/24 dev eth0 proto kernel scope link src 10.244.1.5",
+		"10.96.0.0/12 via 10.244.0.1 dev eth0 metric 10",
+		"172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1",
+	}, "\n")}
+	require.NoError(t, DetectCIDROverlap(context.Background(), "172.30.0.0/24", "fsb0", runner))
+}
+
+func TestDetectCIDROverlapIgnoresOwnBridgeAndDefault(t *testing.T) {
+	runner := &routeRunner{routes: strings.Join([]string{
+		"default via 172.30.0.254 dev eth0",
+		// The slot bridge's own connected route (present on restart).
+		"172.30.0.0/24 dev fsb0 proto kernel scope link src 172.30.0.1",
+	}, "\n")}
+	require.NoError(t, DetectCIDROverlap(context.Background(), "172.30.0.0/24", "fsb0", runner))
+}
+
+func TestDetectCIDROverlapReportsConflicts(t *testing.T) {
+	// A Docker bridge pool covering the slot CIDR.
+	runner := &routeRunner{routes: strings.Join([]string{
+		"default via 10.244.0.1 dev eth0",
+		"10.244.1.0/24 dev eth0 proto kernel scope link src 10.244.1.5",
+		"172.30.0.0/16 dev docker0 proto kernel scope link src 172.30.0.1",
+	}, "\n")}
+	err := DetectCIDROverlap(context.Background(), "172.30.0.0/24", "fsb0", runner)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "172.30.0.0/16 dev docker0")
+
+	// A more specific route inside a widened slot CIDR (CNI per-node pod
+	// routes carved out of the same /16).
+	runner = &routeRunner{routes: "172.30.4.0/26 via 10.0.0.9 dev tun0"}
+	err = DetectCIDROverlap(context.Background(), "172.30.0.0/16", "fsb0", runner)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "172.30.4.0/26")
+
+	// A bare host route (implicit /32) inside the slot CIDR.
+	runner = &routeRunner{routes: "172.30.0.7 dev eth0"}
+	err = DetectCIDROverlap(context.Background(), "172.30.0.0/24", "fsb0", runner)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "172.30.0.7")
+}
+
+func TestDetectCIDROverlapRejectsInvalidCIDR(t *testing.T) {
+	require.Error(t, DetectCIDROverlap(context.Background(), "not-a-cidr", "fsb0", &routeRunner{}))
+	require.Error(t, DetectCIDROverlap(context.Background(), "fd00::/64", "fsb0", &routeRunner{}))
+}
+
+func TestParseRouteDestination(t *testing.T) {
+	prefix, ok := parseRouteDestination("172.30.0.0/16")
+	require.True(t, ok)
+	require.Equal(t, "172.30.0.0/16", prefix.String())
+
+	prefix, ok = parseRouteDestination("10.1.2.3")
+	require.True(t, ok)
+	require.Equal(t, "10.1.2.3/32", prefix.String())
+
+	_, ok = parseRouteDestination("unreachable")
+	require.False(t, ok)
+}

--- a/internal/fastlet/network/guest_vm_linux_driver.go
+++ b/internal/fastlet/network/guest_vm_linux_driver.go
@@ -3,8 +3,13 @@ package network
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/netip"
+	"time"
 )
+
+// arpWarmupDialTimeout bounds the warm-up datagram dial in ApplyGuest.
+const arpWarmupDialTimeout = 300 * time.Millisecond
 
 // guestVMDefaultTapName is the fixed tap name of the guest-VM (Firecracker)
 // data plane. The tap lives inside the slot network namespace (the VMM
@@ -69,6 +74,14 @@ func (d *GuestVMNetNSDriver) Prepare(ctx context.Context, slot *Slot) error {
 		if _, err := d.runner.Run(ctx, d.ipCommand, arguments...); err != nil {
 			return fmt.Errorf("prepare guest-VM namespace tap: %w", err)
 		}
+	}
+	// Faster ARP re-resolution inside the namespace (guest gateway via the
+	// proxy-ARP tap, host gateway via eth0); the default 1 s retransmit
+	// stalls the first guest packets after every restore. Best-effort: the
+	// tuning is a latency optimization and must never fail preparation.
+	for _, device := range []string{guestVMDefaultTapName, "eth0"} {
+		_, _ = d.runner.Run(ctx, d.ipCommand, "netns", "exec", slot.NetNSName,
+			d.sysctlCommand, "-w", "net.ipv4.neigh."+device+".retrans_time_ms=100")
 	}
 	rules := [][]string{
 		// The namespace gateway (bridge address) stays reachable (DNS proxy
@@ -141,6 +154,16 @@ func (d *GuestVMNetNSDriver) ApplyGuest(ctx context.Context, slot *Slot, guestIP
 		if err := checkThenAdd(ctx, d.runner, d.ipCommand, arguments); err != nil {
 			return fmt.Errorf("apply guest NAT rules: %w", err)
 		}
+	}
+	// ARP warm-up: one datagram to the slot IP forces the host bridge to
+	// resolve the address against the netns eth0 (which owns it) right
+	// away, instead of letting the first business packet hit a stale or
+	// incomplete neighbour entry. The netns answers ARP independently of
+	// the VM state; the DNATed datagram itself is dropped until the guest
+	// resumes, which is harmless. Best-effort.
+	if conn, dialErr := net.DialTimeout("udp", net.JoinHostPort(slot.IP, "9"), arpWarmupDialTimeout); dialErr == nil {
+		_, _ = conn.Write([]byte{0})
+		_ = conn.Close()
 	}
 	return nil
 }

--- a/internal/fastlet/network/guest_vm_linux_driver.go
+++ b/internal/fastlet/network/guest_vm_linux_driver.go
@@ -68,6 +68,12 @@ func (d *GuestVMNetNSDriver) Prepare(ctx context.Context, slot *Slot) error {
 		// neighbour cache then points slot IPs at random netns and packets
 		// never reach the right one.
 		{"netns", "exec", slot.NetNSName, d.sysctlCommand, "-w", "net.ipv4.conf." + guestVMDefaultTapName + ".proxy_arp=1"},
+		// The kernel queues proxy ARP replies for proxy_delay (default 80
+		// ticks = 800ms) so a real owner could answer first; on this tap the
+		// proxy IS the only answer for the baked gateway, and the guest's
+		// first egress packet (SYN-ACK!) blocks on it — the entire
+		// first-request stall after restore (measured 792ms on vmtap0).
+		{"netns", "exec", slot.NetNSName, d.sysctlCommand, "-w", "net.ipv4.neigh." + guestVMDefaultTapName + ".proxy_delay=0"},
 		{"netns", "exec", slot.NetNSName, d.sysctlCommand, "-w", "net.ipv4.ip_forward=1"},
 	}
 	for _, arguments := range commands {

--- a/internal/fastlet/network/guest_vm_linux_driver_test.go
+++ b/internal/fastlet/network/guest_vm_linux_driver_test.go
@@ -76,6 +76,9 @@ func TestGuestVMNetNSDriverPrepare(t *testing.T) {
 	// and its replies and egress flow through the namespace.
 	require.Contains(t, joined, "ip netns exec ns-1 sysctl -w net.ipv4.conf.vmtap0.proxy_arp=1")
 	require.NotContains(t, joined, "net.ipv4.conf.all.proxy_arp=1")
+	// Proxy ARP replies must not pay the default 800ms proxy_delay: the
+	// guest's first egress packet after restore blocks on the gateway reply.
+	require.Contains(t, joined, "ip netns exec ns-1 sysctl -w net.ipv4.neigh.vmtap0.proxy_delay=0")
 	require.Contains(t, joined, "ip netns exec ns-1 sysctl -w net.ipv4.ip_forward=1")
 	// Faster ARP re-resolution on both namespace devices (the guest resolves
 	// its baked gateway through the proxy-ARP tap; egress resolves the host

--- a/internal/fastlet/network/guest_vm_linux_driver_test.go
+++ b/internal/fastlet/network/guest_vm_linux_driver_test.go
@@ -77,6 +77,11 @@ func TestGuestVMNetNSDriverPrepare(t *testing.T) {
 	require.Contains(t, joined, "ip netns exec ns-1 sysctl -w net.ipv4.conf.vmtap0.proxy_arp=1")
 	require.NotContains(t, joined, "net.ipv4.conf.all.proxy_arp=1")
 	require.Contains(t, joined, "ip netns exec ns-1 sysctl -w net.ipv4.ip_forward=1")
+	// Faster ARP re-resolution on both namespace devices (the guest resolves
+	// its baked gateway through the proxy-ARP tap; egress resolves the host
+	// gateway through eth0).
+	require.Contains(t, joined, "ip netns exec ns-1 sysctl -w net.ipv4.neigh.vmtap0.retrans_time_ms=100")
+	require.Contains(t, joined, "ip netns exec ns-1 sysctl -w net.ipv4.neigh.eth0.retrans_time_ms=100")
 	// The forward rules accept the gateway, guest egress and ingress,
 	// reject siblings (only traffic originating from the tap to the private
 	// CIDR), and accept established connections.

--- a/internal/fastlet/network/linux_driver.go
+++ b/internal/fastlet/network/linux_driver.go
@@ -168,6 +168,14 @@ func (d *LinuxNetNSDriver) Destroy(ctx context.Context, slot *Slot) error {
 			result = errors.Join(result, err)
 		}
 	}
+	// The host-side neighbour entry for the slot IP survives the veth: with
+	// the next owner of the reused private address it stays STALE and points
+	// at the dead veth MAC, so frames are flooded to a gone port and dropped
+	// until ARP re-resolves. Remove it eagerly (best-effort: a missing entry
+	// or an unresolvable device is not a destroy failure).
+	if slot.IP != "" && slot.Bridge != "" {
+		_, _ = d.runner.Run(ctx, d.ipCommand, "neigh", "del", slot.IP, "dev", slot.Bridge)
+	}
 	if slot.NetNSName != "" {
 		if err := deleteNetNSWithRetry(ctx, d.runner, d.ipCommand, slot.NetNSName); err != nil && !isMissingNetworkResource(err) {
 			result = errors.Join(result, err)
@@ -191,7 +199,15 @@ func (d *LinuxNetNSDriver) ensureBridge(ctx context.Context, slot *Slot) error {
 		}
 	}
 	_, err := d.runner.Run(ctx, d.ipCommand, "link", "set", slot.Bridge, "up")
-	return err
+	if err != nil {
+		return err
+	}
+	// Faster ARP re-resolution on the shared bridge (default retransmit is
+	// 1 s; a stale neighbour entry then stalls first packets for seconds).
+	// Best-effort: the tuning is a latency optimization and must never fail
+	// slot preparation.
+	_, _ = d.runner.Run(ctx, d.sysctlCommand, "-w", "net.ipv4.neigh."+slot.Bridge+".retrans_time_ms=100")
+	return nil
 }
 
 func (d *LinuxNetNSDriver) ensureEgress(ctx context.Context, slot *Slot) error {

--- a/internal/fastlet/network/linux_driver_test.go
+++ b/internal/fastlet/network/linux_driver_test.go
@@ -56,6 +56,28 @@ func TestLinuxNetNSDriverPrepareBuildsIsolatedNetwork(t *testing.T) {
 	require.Contains(t, joined, "iptables -t nat -A POSTROUTING")
 	require.Contains(t, joined, "ip netns exec fsb-test iptables -A OUTPUT -d 172.30.0.1/32 -j ACCEPT")
 	require.Contains(t, joined, "ip netns exec fsb-test iptables -A OUTPUT -d 172.30.0.0/24 -j REJECT")
+	// The shared bridge gets faster ARP re-resolution so stale neighbour
+	// entries recover in ~100 ms instead of seconds.
+	require.Contains(t, joined, "sysctl -w net.ipv4.neigh.fsb0.retrans_time_ms=100")
+}
+
+func TestLinuxNetNSDriverDestroyRemovesBridgeNeighbour(t *testing.T) {
+	runner := &recordingRunner{}
+	driver := NewLinuxNetNSDriver(LinuxDriverConfig{Runner: runner})
+	slot := &Slot{
+		NetNSName: "fsb-test", HostVeth: "fh123", Bridge: "fsb0",
+		Address: "172.30.0.2/24", IP: "172.30.0.2", PrivateCIDR: "172.30.0.0/24",
+		Gateway: "172.30.0.1", NetNSPath: filepath.Join(t.TempDir(), "netns", "fsb-test"),
+	}
+	require.NoError(t, driver.Destroy(context.Background(), slot))
+
+	joined := strings.Join(runner.commands, "\n")
+	// The bridge neighbour entry for the slot IP must not outlive the veth:
+	// a stale entry keeps forwarding to the dead MAC and drops traffic for
+	// the next owner of the reused private address.
+	require.Contains(t, joined, "ip link delete fh123")
+	require.Contains(t, joined, "ip neigh del 172.30.0.2 dev fsb0")
+	require.Contains(t, joined, "ip netns delete fsb-test")
 }
 
 func TestDefaultRouteDevice(t *testing.T) {

--- a/internal/fastlet/network/manager.go
+++ b/internal/fastlet/network/manager.go
@@ -25,6 +25,12 @@ const currentSlotVersion = 1
 const (
 	DefaultPrivateCIDR = "172.30.0.0/24"
 	DefaultBridge      = "fsb0"
+	// DefaultMTU matches the guest eth0 MTU baked into templates (the
+	// kernel default; boot args cannot set MTU), so the default data plane
+	// is MSS-aligned without PMTUD. Overlay deployments must lower it via
+	// FAST_SANDBOX_NETWORK_MTU (the create-time guest MTU warning then
+	// flags the resulting mismatch).
+	DefaultMTU = 1500
 )
 
 type Config struct {
@@ -47,7 +53,7 @@ type Config struct {
 func DefaultConfig(capacity int, podUID string) Config {
 	return Config{
 		Capacity: capacity, PodUID: podUID, PrivateCIDR: DefaultPrivateCIDR,
-		Bridge: DefaultBridge, MTU: 1450,
+		Bridge: DefaultBridge, MTU: DefaultMTU,
 		StateRoot: "/run/fast-sandbox/network", NetNSRoot: "/run/netns",
 		HostNetNSRoot: "/run/fast-sandbox/netns", ReplenishTimeout: time.Minute,
 	}
@@ -77,7 +83,7 @@ func NewManager(config Config, driver Driver, store StateStore) (*Manager, error
 		config.Bridge = DefaultBridge
 	}
 	if config.MTU <= 0 {
-		config.MTU = 1450
+		config.MTU = DefaultMTU
 	}
 	if config.NetNSRoot == "" || config.HostNetNSRoot == "" || config.StateRoot == "" {
 		return nil, fmt.Errorf("state, Fastlet netns, and host netns roots are required")

--- a/internal/fastlet/network/manager.go
+++ b/internal/fastlet/network/manager.go
@@ -20,6 +20,13 @@ import (
 
 const currentSlotVersion = 1
 
+// Defaults of the Fastlet slot data plane; exported for callers (fastlet
+// main) that need the same values for pre-flight validation.
+const (
+	DefaultPrivateCIDR = "172.30.0.0/24"
+	DefaultBridge      = "fsb0"
+)
+
 type Config struct {
 	Capacity         int
 	PodUID           string
@@ -39,8 +46,8 @@ type Config struct {
 
 func DefaultConfig(capacity int, podUID string) Config {
 	return Config{
-		Capacity: capacity, PodUID: podUID, PrivateCIDR: "172.30.0.0/24",
-		Bridge: "fsb0", MTU: 1450,
+		Capacity: capacity, PodUID: podUID, PrivateCIDR: DefaultPrivateCIDR,
+		Bridge: DefaultBridge, MTU: 1450,
 		StateRoot: "/run/fast-sandbox/network", NetNSRoot: "/run/netns",
 		HostNetNSRoot: "/run/fast-sandbox/netns", ReplenishTimeout: time.Minute,
 	}
@@ -64,10 +71,10 @@ func NewManager(config Config, driver Driver, store StateStore) (*Manager, error
 		return nil, fmt.Errorf("capacity, Pod UID, network driver, and state store are required")
 	}
 	if config.PrivateCIDR == "" {
-		config.PrivateCIDR = "172.30.0.0/24"
+		config.PrivateCIDR = DefaultPrivateCIDR
 	}
 	if config.Bridge == "" {
-		config.Bridge = "fsb0"
+		config.Bridge = DefaultBridge
 	}
 	if config.MTU <= 0 {
 		config.MTU = 1450

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"sync"
@@ -454,10 +456,19 @@ func (d *Driver) EnsureSandbox(ctx context.Context, input *fastletapi.EnsureSand
 	// comes from the cached manifest guestNetwork; the BakedGuestIP
 	// convention is the fallback for hand-seeded caches. Slots are prepared
 	// before the image is known, so the NAT rules are applied now.
-	guestIP, err := resolveBakedGuestIP(stateRoot, spec.Image, slot)
+	guestIP, guestMTU, err := resolveBakedGuestIP(stateRoot, spec.Image, slot)
 	if err != nil {
 		releaseSlot()
 		return nil, err
+	}
+	if guestMTU > 0 && guestMTU != slot.MTU {
+		// The guest MTU is frozen in the snapshot while the host side (netns
+		// eth0, guest tap) carries the slot MTU. A mismatch relies on
+		// PMTUD for every large transfer: oversized guest frames are dropped
+		// or fragmented until an ICMP needfrag recovers the path, which
+		// surfaces as intermittent network IO stalls.
+		klog.Warningf("baked guest MTU %d differs from slot MTU %d (sandbox %s, image %s); align the template or FAST_SANDBOX_NETWORK_MTU to avoid PMTU-dependent stalls",
+			guestMTU, slot.MTU, identity.SandboxUID, spec.Image)
 	}
 	if err := manager.ApplyGuest(ctx, owner, guestIP); err != nil {
 		releaseSlot()
@@ -856,21 +867,83 @@ func (d *Driver) launchVM(ctx context.Context, plan launchConfig, slot *fastletn
 	return launch(ctx, launcher, plan)
 }
 
-// resolveBakedGuestIP returns the baked guest address of the image: the
-// manifest guestNetwork is authoritative; the BakedGuestIP convention
+// validateManifestGuestNetwork checks the baked guest network of a template
+// against the slot data plane it is restored into. The guest address,
+// gateway, and netmask are frozen in the snapshot while the runtime CIDR
+// comes from the environment: on a mismatch the guest keeps a half-working
+// data plane (its frozen gateway no longer terminates DNS, the baked
+// address escapes the IPAM reservation and can shadow another slot), so the
+// restore must fail loudly instead.
+func validateManifestGuestNetwork(slot *fastletnetwork.Slot, network manifestGuestNetwork) error {
+	prefix, err := netip.ParsePrefix(slot.PrivateCIDR)
+	if err != nil {
+		return fmt.Errorf("%w: parse slot private CIDR %q: %v", ErrInvalidConfig, slot.PrivateCIDR, err)
+	}
+	address, err := netip.ParseAddr(network.IP)
+	if err != nil || !address.Is4() {
+		return fmt.Errorf("%w: invalid baked guest IP %q", ErrInvalidConfig, network.IP)
+	}
+	if !prefix.Contains(address) {
+		return fmt.Errorf("%w: baked guest IP %s is outside the private CIDR %s", ErrInvalidConfig, network.IP, slot.PrivateCIDR)
+	}
+	// The guest-VM IPAM reserves exactly gateway + 2; any other baked
+	// address can be handed to another slot and shadowed by its netns.
+	conventional, err := fastletnetwork.BakedGuestIP(slot)
+	if err != nil {
+		return fmt.Errorf("%w: derive reserved guest address: %v", ErrInvalidConfig, err)
+	}
+	if network.IP != conventional {
+		return fmt.Errorf("%w: baked guest IP %s does not match the reserved address %s (gateway + 2); rebuild the template or align FAST_SANDBOX_NETWORK_CIDR", ErrInvalidConfig, network.IP, conventional)
+	}
+	if network.Gateway != "" && network.Gateway != slot.Gateway {
+		return fmt.Errorf("%w: baked guest gateway %s does not match the runtime gateway %s (guest DNS and proxy-ARP termination break)", ErrInvalidConfig, network.Gateway, slot.Gateway)
+	}
+	if network.Netmask != "" {
+		bits, ok := netmaskBits(network.Netmask)
+		if !ok {
+			return fmt.Errorf("%w: invalid baked guest netmask %q", ErrInvalidConfig, network.Netmask)
+		}
+		if bits != prefix.Bits() {
+			return fmt.Errorf("%w: baked guest netmask %s (/%d) does not match the private CIDR %s (/%d)", ErrInvalidConfig, network.Netmask, bits, slot.PrivateCIDR, prefix.Bits())
+		}
+	}
+	return nil
+}
+
+// netmaskBits converts a dotted IPv4 netmask to its prefix length; it
+// reports false for malformed or non-contiguous masks.
+func netmaskBits(mask string) (int, bool) {
+	address := net.ParseIP(mask)
+	if address == nil || address.To4() == nil {
+		return 0, false
+	}
+	ones, bits := net.IPMask(address.To4()).Size()
+	if ones == 0 || bits != 32 {
+		return 0, false
+	}
+	return ones, true
+}
+
+// resolveBakedGuestIP returns the baked guest address of the image and its
+// recorded MTU (0 when unknown): the manifest guestNetwork is authoritative
+// and validated against the slot data plane; the BakedGuestIP convention
 // (gateway + 2, the builder/E2E prep baked address) is the fallback for
-// hand-seeded caches without a manifest guest network.
-func resolveBakedGuestIP(stateRoot, image string, slot *fastletnetwork.Slot) (string, error) {
-	if guestIP, ok, err := readCachedManifestGuestNetwork(stateRoot, image); err != nil {
-		return "", fmt.Errorf("%w: read cached manifest guest network: %v", ErrImageNotReady, err)
+// hand-seeded caches without a manifest guest network (such caches carry no
+// MTU and are inherently derived from the runtime CIDR).
+func resolveBakedGuestIP(stateRoot, image string, slot *fastletnetwork.Slot) (string, int, error) {
+	if guestNetwork, ok, err := readCachedManifestGuestNetwork(stateRoot, image); err != nil {
+		return "", 0, fmt.Errorf("%w: read cached manifest guest network: %v", ErrImageNotReady, err)
 	} else if ok {
-		return guestIP, nil
+		if err := validateManifestGuestNetwork(slot, guestNetwork); err != nil {
+			return "", 0, err
+		}
+		return guestNetwork.IP, guestNetwork.MTU, nil
 	}
 	guestIP, err := fastletnetwork.BakedGuestIP(slot)
 	if err != nil {
-		return "", fmt.Errorf("%w: derive baked guest IP: %v", ErrInvalidConfig, err)
+		return "", 0, fmt.Errorf("%w: derive baked guest IP: %v", ErrInvalidConfig, err)
 	}
-	return guestIP, nil
+	return guestIP, 0, nil
 }
 
 // prepareInstance assembles the per-instance runtime assets: the writable

--- a/internal/runtime/firecracker/driver_test.go
+++ b/internal/runtime/firecracker/driver_test.go
@@ -267,8 +267,9 @@ func (f *driverFixture) prepareCachedImage(t *testing.T, image string) {
 	manifest, err := json.Marshal(map[string]any{
 		"machine": map[string]any{"vcpu": "2", "memory": "1Gi"},
 		// The baked guest address every slot netns translates its slot IP
-		// to (per-clone clone model).
-		"guestNetwork": map[string]any{"iface": "eth0", "mac": "02:00:00:00:00:01", "ip": "172.30.0.9", "gateway": "172.30.0.1", "netmask": "255.255.255.0"},
+		// to (per-clone clone model). Must stay the reserved convention
+		// address (gateway + 2 of the runtime CIDR).
+		"guestNetwork": map[string]any{"iface": "eth0", "mac": "02:00:00:00:00:01", "ip": "172.30.0.3", "gateway": "172.30.0.1", "netmask": "255.255.255.0"},
 	})
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), manifest, 0o640))
@@ -433,7 +434,7 @@ func TestEnsureSandboxBootsVM(t *testing.T) {
 	// bound slot records the baked guest address all slots translate to.
 	slot, exists := fixture.manager.Lookup("sandbox-1")
 	require.True(t, exists)
-	require.Equal(t, "172.30.0.9", slot.GuestIP)
+	require.Equal(t, "172.30.0.3", slot.GuestIP)
 
 	calls := fixture.server.recordedCalls()
 	// v1.16 restore: LoadSnapshot is the first (and only pre-boot) API call;
@@ -862,15 +863,83 @@ func TestResolveBakedGuestIPFallsBackWithoutManifest(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, memorySnapshotName), []byte("memory"), 0o640))
 
 	// No manifest: the BakedGuestIP convention (gateway + 2, the baked
-	// address of the builder/E2E prep) is the fallback.
-	guestIP, err := resolveBakedGuestIP(stateRoot, image, &fastletnetwork.Slot{Gateway: "172.30.0.1"})
+	// address of the builder/E2E prep) is the fallback; no MTU is known.
+	guestIP, guestMTU, err := resolveBakedGuestIP(stateRoot, image, &fastletnetwork.Slot{Gateway: "172.30.0.1"})
 	require.NoError(t, err)
 	require.Equal(t, "172.30.0.3", guestIP)
+	require.Zero(t, guestMTU)
+
+	// A manifest without an MTU keeps reporting the baked address only.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(
+		`{"guestNetwork":{"ip":"172.30.0.3"}}`), 0o640))
+	guestIP, guestMTU, err = resolveBakedGuestIP(stateRoot, image, &fastletnetwork.Slot{Gateway: "172.30.0.1", PrivateCIDR: "172.30.0.0/24"})
+	require.NoError(t, err)
+	require.Equal(t, "172.30.0.3", guestIP)
+	require.Zero(t, guestMTU)
+
+	// A manifest with an MTU reports it so callers can validate the slot
+	// data plane against the frozen guest value.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(
+		`{"guestNetwork":{"ip":"172.30.0.3","mtu":1500}}`), 0o640))
+	guestIP, guestMTU, err = resolveBakedGuestIP(stateRoot, image, &fastletnetwork.Slot{Gateway: "172.30.0.1", PrivateCIDR: "172.30.0.0/24"})
+	require.NoError(t, err)
+	require.Equal(t, "172.30.0.3", guestIP)
+	require.Equal(t, 1500, guestMTU)
 
 	// A corrupt manifest fails explicitly instead of silently guessing.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), []byte("{"), 0o640))
-	_, err = resolveBakedGuestIP(stateRoot, image, &fastletnetwork.Slot{Gateway: "172.30.0.1"})
+	_, _, err = resolveBakedGuestIP(stateRoot, image, &fastletnetwork.Slot{Gateway: "172.30.0.1"})
 	require.Error(t, err)
+}
+
+// TestResolveBakedGuestIPRejectsRuntimeMismatch covers the frozen guest
+// network (manifest) vs runtime CIDR alignment: the manifest is only
+// authoritative when it describes the subnet the slot data plane actually
+// implements.
+func TestResolveBakedGuestIPRejectsRuntimeMismatch(t *testing.T) {
+	stateRoot := t.TempDir()
+	image := "example.com/app:v1"
+	dir := filepath.Join(stateRoot, imageCacheDir, imageKey(image))
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	slot := &fastletnetwork.Slot{Gateway: "172.30.0.1", PrivateCIDR: "172.30.0.0/24"}
+
+	writeManifest := func(payload string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(payload), 0o640))
+	}
+
+	// The aligned case (builder convention) passes.
+	writeManifest(`{"guestNetwork":{"ip":"172.30.0.3","gateway":"172.30.0.1","netmask":"255.255.255.0","mtu":1500}}`)
+	guestIP, guestMTU, err := resolveBakedGuestIP(stateRoot, image, slot)
+	require.NoError(t, err)
+	require.Equal(t, "172.30.0.3", guestIP)
+	require.Equal(t, 1500, guestMTU)
+
+	// A baked address outside the runtime CIDR.
+	writeManifest(`{"guestNetwork":{"ip":"10.5.0.3","gateway":"10.5.0.1","netmask":"255.255.255.0"}}`)
+	_, _, err = resolveBakedGuestIP(stateRoot, image, slot)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "outside the private CIDR")
+
+	// A baked address inside the CIDR but not the reserved convention
+	// address: the IPAM only reserves gateway+2, any other address can be
+	// allocated to a sibling slot and shadow the guest.
+	writeManifest(`{"guestNetwork":{"ip":"172.30.0.9","gateway":"172.30.0.1"}}`)
+	_, _, err = resolveBakedGuestIP(stateRoot, image, slot)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "reserved address")
+
+	// A baked gateway differing from the runtime gateway: guest DNS and
+	// proxy-ARP termination break.
+	writeManifest(`{"guestNetwork":{"ip":"172.30.0.3","gateway":"10.5.0.1"}}`)
+	_, _, err = resolveBakedGuestIP(stateRoot, image, slot)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "runtime gateway")
+
+	// A baked netmask differing from the runtime prefix length.
+	writeManifest(`{"guestNetwork":{"ip":"172.30.0.3","gateway":"172.30.0.1","netmask":"255.255.0.0"}}`)
+	_, _, err = resolveBakedGuestIP(stateRoot, image, slot)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "netmask")
 }
 
 func TestCloseResetsDriver(t *testing.T) {

--- a/internal/runtime/firecracker/restore.go
+++ b/internal/runtime/firecracker/restore.go
@@ -62,30 +62,39 @@ func readCachedManifestMachine(stateRoot, image string) (manifestMachine, bool, 
 	return document.Machine, true, nil
 }
 
-// readCachedManifestGuestNetwork loads the baked guest address from the
-// cached manifest (builder records guestNetwork.ip). It reports false when
-// the manifest is absent or carries no guest network (hand-seeded local
-// cache); the caller falls back to the BakedGuestIP convention.
-func readCachedManifestGuestNetwork(stateRoot, image string) (string, bool, error) {
+// manifestGuestNetwork is the guest network baked into a template snapshot
+// (clone networking model). MTU is 0 for manifests recorded before the field
+// existed (the kernel default was baked implicitly).
+type manifestGuestNetwork struct {
+	IP      string `json:"ip"`
+	Gateway string `json:"gateway"`
+	Netmask string `json:"netmask"`
+	MTU     int    `json:"mtu"`
+}
+
+// readCachedManifestGuestNetwork loads the baked guest network from the
+// cached manifest (builder records guestNetwork.ip, guestNetwork.mtu). It
+// reports false when the manifest is absent or carries no guest network
+// (hand-seeded local cache); the caller falls back to the BakedGuestIP
+// convention.
+func readCachedManifestGuestNetwork(stateRoot, image string) (manifestGuestNetwork, bool, error) {
 	payload, err := os.ReadFile(cachedManifestPath(stateRoot, image))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return "", false, nil
+			return manifestGuestNetwork{}, false, nil
 		}
-		return "", false, err
+		return manifestGuestNetwork{}, false, err
 	}
 	var document struct {
-		GuestNetwork struct {
-			IP string `json:"ip"`
-		} `json:"guestNetwork"`
+		GuestNetwork manifestGuestNetwork `json:"guestNetwork"`
 	}
 	if err := json.Unmarshal(payload, &document); err != nil {
-		return "", false, fmt.Errorf("decode cached manifest: %w", err)
+		return manifestGuestNetwork{}, false, fmt.Errorf("decode cached manifest: %w", err)
 	}
 	if document.GuestNetwork.IP == "" {
-		return "", false, nil
+		return manifestGuestNetwork{}, false, nil
 	}
-	return document.GuestNetwork.IP, true, nil
+	return document.GuestNetwork, true, nil
 }
 
 // validateRestoreMachineConfig validates the Sandbox request against the


### PR DESCRIPTION
## Problem

Slot churn on the shared bridge (`fsb0`) left stale neighbour entries pointing at dead veth MACs: the first packets to a reused slot IP were flooded to a gone tap and dropped until ARP re-resolved (default retransmit 1 s → seconds of stall per reuse). The E2E suite worked around this manually with `ip neigh flush dev <bridge>`.

Two latent configuration hazards were also unguarded:

- the baked guest network (frozen in the snapshot) was never validated against the runtime CIDR — a mismatch left the guest half-working (frozen gateway no longer terminates DNS, baked address escapes the IPAM reservation)
- the slot CIDR itself (default `172.30.0.0/24`, inside `172.16.0.0/12`) was never checked against live host routes (Docker bridge pools, Calico/VPC overlays)

## Changes

Neighbour / ARP (fastlet-network):
- drop the bridge neighbour entry for the slot IP on destroy (`ip neigh del <ip> dev <bridge>`)
- `retrans_time_ms=100` on the shared bridge and the in-namespace devices (`vmtap0`, `eth0`)
- raise `neigh gc_thresh1/2/3` (4096/8192/16384) at fastlet startup
- one-datagram ARP warm-up after `ApplyGuest` so the bridge resolves the slot IP immediately

MTU visibility:
- record `guestNetwork.mtu` in template manifests (kernel default 1500)
- warn on create when it differs from the slot MTU (PMTU-dependent stalls)

Fail-fast guards (R1):
- restore refuses a template whose manifest guest network (`ip`/`gateway`/`netmask`) misaligns with the runtime CIDR (must be the reserved `gateway+2` address, runtime gateway, matching prefix length)
- fastlet refuses to start when the slot CIDR overlaps any live host route (`DetectCIDROverlap`, own bridge routes excluded on restart)

## Notes

- Behavior change: previously "changed runtime CIDR + old templates" half-worked (broken DNS, hard to debug); now restore fails explicitly. Pre-existing environments should be checked before rollout.
- Long-term structural fix (per-slot point-to-point topology removing the shared bridge) tracked in #49.

## Testing

- `go test ./internal/fastlet/network/... ./internal/runtime/firecracker/... ./cmd/sandboxtemplate-builder/...` green, with new unit tests covering the neighbour teardown command, retrans sysctls, CIDR overlap detection (Docker pool / CNI per-node route / host route), and the four guest-network misalignment cases
- remaining `go test ./...` failures are pre-existing macOS-environment issues (verified identical on pristine master via stash)