### PR TITLE
refactor: align OpenSandbox integration with Fast Sandbox naming

### DIFF
--- a/config/samples/pool-firecracker-egress.yaml
+++ b/config/samples/pool-firecracker-egress.yaml
@@ -44,15 +44,15 @@ spec:
         # IfNotPresent: the integration environment kind-loads the image
         # into the nodes; Always would force a docker.io pull per restart.
         imagePullPolicy: IfNotPresent
-        # Fleet profile is required: it serves the Sandbox Actions Handler
+        # Fast Sandbox profile is required: it serves the Sandbox Actions Handler
         # endpoints (/_fastlet/v1/actions[/status]) that the Fastlet uses.
         # Without it egress runs the sidecar profile (policy-file driven)
         # and exposes no actions surface.
         env:
         - name: OPENSANDBOX_EGRESS_PROFILE
-          value: "fleet"
+          value: "fast-sandbox"
         # dns+nft: DNS-based domain policy plus the per-subject nft rules
-        # (table opensandbox-fleet, subj_ chains). dns-only would neither
+        # (table opensandbox-fast-sandbox, subj_ chains). dns-only would neither
         # block IP-direct traffic nor create the subj_ chains the
         # integration test asserts on unload.
         - name: OPENSANDBOX_EGRESS_MODE

--- a/docs/design/egress-integration-plan-tasks.md
+++ b/docs/design/egress-integration-plan-tasks.md
@@ -111,7 +111,7 @@
 
 **位置**：`internal/dataplane/fastletproxy/proxy.go`（`parseTarget`）
 
-- [ ] `parseTarget` 增加 `/v1/sandboxfleets/{sandboxId}/egress/*` 分支：
+- [ ] `parseTarget` 增加 `/v1/sandboxes/{sandboxId}/egress/*` 分支：
   - 解析 sandbox 路由（sandboxId 定位）
   - 校验 route credential（与现有分支一致）
   - 目标 = egress listener（127.0.0.1:18080，host 转发语义见任务 3）

--- a/docs/design/egress-integration-plan.md
+++ b/docs/design/egress-integration-plan.md
@@ -123,13 +123,19 @@ OSEP-0022 原方案：egress 通过**观察 fastlet slot-store 文件**（
 
 ### B. egress 构建与集成（直接集成，非 mock）
 
-**直接用 PR #1678 head 分支构建真实 egress**（已确认可构建）：
+**历史构建基准：PR #1678 的固定提交**（当时已确认可构建）：
 
 ```text
 repo:    Pangjiping/OpenSandbox @ feat/egress-actions-handler（pin commit 460b1cb）
-路径:    components/egress/（fastsandbox.go / fastsandbox_actions.go / pkg/actionhandler / pkg/fastsandboxnft）
+路径:    components/egress/（fleet.go / fleet_actions.go / pkg/actionhandler / pkg/fleetnft）
 产物:    egress 镜像（集成环境 `kind load docker-image`）
 ```
+
+以上保留 `460b1cb` 构建基准中的历史路径。后续
+[OpenSandbox PR #1811](https://github.com/opensandbox-group/OpenSandbox/pull/1811)
+将 `fleet*.go` / `pkg/fleetnft` 重命名为 `fastsandbox*.go` / `pkg/fastsandboxnft`。
+当前样例使用 `fast-sandbox` profile，需构建并加载包含该重命名的 Egress 镜像；
+上述历史提交的镜像不适用于当前样例。
 
 - **pin commit 缓解 PR 未合入的演进风险**：PR 合并后切官方 tag/镜像；
 - **交叉验证（mock 无法替代的核心价值）**：fast-sandbox

--- a/docs/design/egress-integration-plan.md
+++ b/docs/design/egress-integration-plan.md
@@ -4,7 +4,7 @@
 >
 > 日期：2026-08-29
 >
-> 依赖：OpenSandbox PR #1678（egress fleet profile 改造，待合并）；
+> 依赖：OpenSandbox PR #1678（egress fast-sandbox profile 改造，待合并）；
 > fast-sandbox #30（Sandbox Actions 协议与 CRD，已合入 master）。
 >
 > 关联：OSEP-0022（多沙箱 egress 控制面）、opensandbox-group/OpenSandbox#1582、
@@ -74,8 +74,8 @@ OSEP-0022 原方案：egress 通过**观察 fastlet slot-store 文件**（
 | **host-process 交付模式** | `InfraDeliveryMode` 新增 `host-process`：Pool revision 携带、但不进 in-sandbox 的 sandbox-init supervisor 配置；egress daemon 由 FastletTemplate 部署；readiness 探测 Pod-netns listener | fast-sandbox（本期） |
 | **fastlet-proxy host upstream** | egress route 转发到 Pod-netns listener（`127.0.0.1:18080`）而非 sandbox Access 地址 | fast-sandbox（延后，credential 通道） |
 | **UID 传播** | proxy 注入 `X-Fast-Sandbox-Uid`（subject 标识） | fast-sandbox（延后，credential 通道） |
-| **egress route parsing** | `parseTarget` 增加 `/v1/sandboxfleets/{sandboxId}/egress/*` 分支（凭据校验 + 目标 egress） | fast-sandbox（延后，credential 通道） |
-| **egress 实现/部署** | OpenSandbox fleet egress（PR #1678）+ 集成环境部署（host 域组件，共享 slot-store 不需要了——actions 驱动） | OpenSandbox |
+| **egress route parsing** | `parseTarget` 增加 `/v1/sandboxes/{sandboxId}/egress/*` 分支（凭据校验 + 目标 egress） | fast-sandbox（延后，credential 通道） |
+| **egress 实现/部署** | OpenSandbox fast-sandbox egress（PR #1678）+ 集成环境部署（host 域组件，共享 slot-store 不需要了——actions 驱动） | OpenSandbox |
 | **firecracker 衔接验证** | data-plane-ready 时机（restore + 网络就绪）；clone 网络下 egress 流量 src=slot.IP（#28 已保证唯一性） | 集成测试 |
 
 ## 集成架构
@@ -127,7 +127,7 @@ OSEP-0022 原方案：egress 通过**观察 fastlet slot-store 文件**（
 
 ```text
 repo:    Pangjiping/OpenSandbox @ feat/egress-actions-handler（pin commit 460b1cb）
-路径:    components/egress/（fleet.go / fleet_actions.go / pkg/actionhandler / pkg/fleetnft）
+路径:    components/egress/（fastsandbox.go / fastsandbox_actions.go / pkg/actionhandler / pkg/fastsandboxnft）
 产物:    egress 镜像（集成环境 `kind load docker-image`）
 ```
 

--- a/docs/guides/egress-protocol-verification.md
+++ b/docs/guides/egress-protocol-verification.md
@@ -10,7 +10,7 @@
 >   `internal/fastlet/action/manager.go`（HTTPCaller / buildRequest）+ 投递语义；
 > - OpenSandbox 侧：`Pangjiping/OpenSandbox @ feat/egress-actions-handler`
 >   pin `460b1cb`，`components/egress/pkg/actionhandler/actionhandler.go` +
->   `components/egress/fleet_actions.go`（lifecycle 语义）+ `fleet_server.go`
+>   `components/egress/fastsandbox_actions.go`（lifecycle 语义）+ `fastsandbox_server.go`
 >   （status 端点）。
 >
 > 方法：两侧独立实现同一协议（`sandbox.fast.io/actions/v1`），逐字段字节级
@@ -67,7 +67,7 @@ fastlet 请求构造核对：`buildRequest`（`manager.go:914`）总是填充
 | REMOVE_BINDING fence 不匹配 | **200 忽略**（永不卸载当前 subject） | 删除幂等 | ✅ |
 | REMOVE_BINDING 未注册 subject | 200（清理缓存） | 删除幂等 | ✅ |
 
-幂等/重放核对（egress 侧 `fleet_actions.go` vs fast-sandbox `manager.go`）：
+幂等/重放核对（egress 侧 `fastsandbox_actions.go` vs fast-sandbox `manager.go`）：
 
 - SET_BINDING 重放：`RegisterAndEnforce` 幂等；input 更新对 active subject 原地应用、**不重放 Hooks** —— 与 fastlet `replayHooks` 逻辑一致；
 - egress 重启：新 `instanceId`（status 端点）→ fastlet 检测变化 → 置 Pending 并重放最新 SET_BINDING + 已到达 Hooks（`manager.go:318`）——与 egress 侧注释契约一致；
@@ -106,5 +106,5 @@ fast-sandbox `HTTPCaller.Status`（`manager.go:46`）：非 200 / apiVersion 不
 
 - fast-sandbox 协议：`internal/protocol/action/types.go`、`internal/fastlet/action/manager.go`
 - egress 协议：`Pangjiping/OpenSandbox @ 460b1cb` `components/egress/pkg/actionhandler/actionhandler.go`、
-  `components/egress/fleet_actions.go`、`components/egress/fleet_server.go`
+  `components/egress/fastsandbox_actions.go`、`components/egress/fastsandbox_server.go`
 - 方案：`docs/design/egress-integration-plan.md`；任务清单：`docs/design/egress-integration-plan-tasks.md`

--- a/docs/guides/egress-protocol-verification.md
+++ b/docs/guides/egress-protocol-verification.md
@@ -10,8 +10,13 @@
 >   `internal/fastlet/action/manager.go`（HTTPCaller / buildRequest）+ 投递语义；
 > - OpenSandbox 侧：`Pangjiping/OpenSandbox @ feat/egress-actions-handler`
 >   pin `460b1cb`，`components/egress/pkg/actionhandler/actionhandler.go` +
->   `components/egress/fastsandbox_actions.go`（lifecycle 语义）+ `fastsandbox_server.go`
+>   `components/egress/fleet_actions.go`（lifecycle 语义）+ `fleet_server.go`
 >   （status 端点）。
+>
+> 命名说明：本文保留上述固定提交中的历史文件名。后续
+> [OpenSandbox PR #1811](https://github.com/opensandbox-group/OpenSandbox/pull/1811)
+> 将 `fleet_actions.go` / `fleet_server.go` 重命名为
+> `fastsandbox_actions.go` / `fastsandbox_server.go`；本核对表的验证基准不变。
 >
 > 方法：两侧独立实现同一协议（`sandbox.fast.io/actions/v1`），逐字段字节级
 > 核对 + egress 侧 `go build ./components/egress/...` 编译验证（已通过，
@@ -67,7 +72,7 @@ fastlet 请求构造核对：`buildRequest`（`manager.go:914`）总是填充
 | REMOVE_BINDING fence 不匹配 | **200 忽略**（永不卸载当前 subject） | 删除幂等 | ✅ |
 | REMOVE_BINDING 未注册 subject | 200（清理缓存） | 删除幂等 | ✅ |
 
-幂等/重放核对（egress 侧 `fastsandbox_actions.go` vs fast-sandbox `manager.go`）：
+幂等/重放核对（egress 侧 `fleet_actions.go` vs fast-sandbox `manager.go`）：
 
 - SET_BINDING 重放：`RegisterAndEnforce` 幂等；input 更新对 active subject 原地应用、**不重放 Hooks** —— 与 fastlet `replayHooks` 逻辑一致；
 - egress 重启：新 `instanceId`（status 端点）→ fastlet 检测变化 → 置 Pending 并重放最新 SET_BINDING + 已到达 Hooks（`manager.go:318`）——与 egress 侧注释契约一致；
@@ -106,5 +111,5 @@ fast-sandbox `HTTPCaller.Status`（`manager.go:46`）：非 200 / apiVersion 不
 
 - fast-sandbox 协议：`internal/protocol/action/types.go`、`internal/fastlet/action/manager.go`
 - egress 协议：`Pangjiping/OpenSandbox @ 460b1cb` `components/egress/pkg/actionhandler/actionhandler.go`、
-  `components/egress/fastsandbox_actions.go`、`components/egress/fastsandbox_server.go`
+  `components/egress/fleet_actions.go`、`components/egress/fleet_server.go`
 - 方案：`docs/design/egress-integration-plan.md`；任务清单：`docs/design/egress-integration-plan-tasks.md`

--- a/docs/guides/opensandbox-integration.md
+++ b/docs/guides/opensandbox-integration.md
@@ -1,6 +1,6 @@
 # OpenSandbox integration
 
-OpenSandbox can use Fast Sandbox as a fleets backend while keeping its public
+OpenSandbox can use Fast Sandbox as a runtime backend while keeping its public
 SDK and Execd protocol unchanged. Fast Sandbox supplies low-latency lifecycle
 operations, Pool placement, runtime creation, Infra Component injection, and a
 transparent route to the selected Sandbox service.
@@ -76,7 +76,7 @@ OpenSandbox should use one stable Sandbox ID as Fast Sandbox `request_id`.
 | Sandbox ID | `request_id` |
 | Resource namespace | `namespace` |
 | Image URI | `image` |
-| Fleet/Pool selection | `pool_ref` |
+| SandboxPool selection | `pool_ref` |
 | Entrypoint | `command` and `args` |
 | Environment | `envs` |
 | Working directory | `working_dir` |
@@ -272,7 +272,7 @@ See [Private Registries](private-registries.md).
 
 ## Unsupported semantics
 
-The Fast Sandbox fleets model does not provide:
+The Fast Sandbox runtime model does not provide:
 
 - per-Sandbox Kubernetes volumes;
 - snapshot, pause, or resume;

--- a/scripts/integration-env.sh
+++ b/scripts/integration-env.sh
@@ -2503,7 +2503,7 @@ egress_dyn_v4_has() { # sandbox ip
 	uid="$(kubectl -n "$NS" get sandbox "$1" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
 	[[ -n "$uid" ]] || return 1
 	set="subj_s_${uid//-/_}_dyn_v4"
-	kubectl -n "$NS" exec "pod/$pod" -c egress -- nft list set inet opensandbox-fleet "$set" 2>/dev/null | grep -q "$2"
+	kubectl -n "$NS" exec "pod/$pod" -c egress -- nft list set inet opensandbox-fast-sandbox "$set" 2>/dev/null | grep -q "$2"
 }
 
 # EGRESS_IP is a well-known, reliably reachable public address used for
@@ -2521,7 +2521,7 @@ egress_binding_ready() { # sandbox
 
 # egress_nft_subjects_clean asserts the per-subject chains are really gone
 # from the host data plane on every pool pod. The egress image implements
-# enforcement with nft (table opensandbox-fleet, per-subject chain
+# enforcement with nft (table opensandbox-fast-sandbox, per-subject chain
 # subj_<id>), so the CLI must be present; a missing CLI fails the stage
 # instead of skipping the assertion.
 egress_nft_subjects_clean() {
@@ -2745,7 +2745,7 @@ egress_subject_present() { # sandbox pod
 	uid="$(kubectl -n "$NS" get sandbox "$1" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
 	[[ -n "$uid" ]] || return 1
 	kubectl -n "$NS" exec "pod/$2" -c egress -- \
-		nft list chain inet opensandbox-fleet "subj_s_${uid//-/_}" 2>/dev/null | grep -q "chain subj_s_"
+		nft list chain inet opensandbox-fast-sandbox "subj_s_${uid//-/_}" 2>/dev/null | grep -q "chain subj_s_"
 }
 
 egress_subject_absent() { # sandbox pod
@@ -2753,7 +2753,7 @@ egress_subject_absent() { # sandbox pod
 	uid="$(kubectl -n "$NS" get sandbox "$1" -o jsonpath='{.metadata.uid}' 2>/dev/null)"
 	[[ -n "$uid" ]] || return 0
 	! kubectl -n "$NS" exec "pod/$2" -c egress -- \
-		nft list chain inet opensandbox-fleet "subj_s_${uid//-/_}" 2>/dev/null | grep -q "chain subj_s_"
+		nft list chain inet opensandbox-fast-sandbox "subj_s_${uid//-/_}" 2>/dev/null | grep -q "chain subj_s_"
 }
 
 egress_count_gt() { # count


### PR DESCRIPTION
Align the OpenSandbox integration with the renamed Egress `fast-sandbox` profile. Pool samples now set `OPENSANDBOX_EGRESS_PROFILE=fast-sandbox`, and integration checks inspect the `opensandbox-fast-sandbox` nftables table. Update the integration and design documentation to use the current component names and paths.

Deploy this alongside the OpenSandbox naming refactor; older Egress images expect the previous profile and table names. No compatibility aliases are provided for the experimental integration.

Validation: `bash -n scripts/integration-env.sh`, YAML parsing and profile-value checks, documentation reference/name checks, and `git diff --check` passed. Linux network namespace and Firecracker integration tests were not run on the macOS development host.

Companion implementation: https://github.com/opensandbox-group/OpenSandbox/pull/1811
