### PR TITLE
docs(design): ADR + glossary for template-vm CLI (remote template -> …

### DIFF
--- a/docs/design/adr-template-vm-cli.en.md
+++ b/docs/design/adr-template-vm-cli.en.md
@@ -1,0 +1,164 @@
+# ADR: template-vm CLI — A Standalone CLI That Creates VMs from Remote Templates
+
+> Document type: Architecture Decision Record (ADR)
+>
+> Date: 2026-09-10
+>
+> Status: Confirmed (converged after three design-interview rounds)
+>
+> Companion glossary: [template-vm-cli-glossary.md](./template-vm-cli-glossary.md) (Chinese)
+
+## Context
+
+We need a standalone CLI tool: given a `template.json` (registry repo + template_id +
+dockerAuth), it restores a running VM on the local host from a template stored in a
+remote OCI registry. A template is a **pair** of overlaybd images:
+`${repo}:${template_id}_rootfs` and `${repo}:${template_id}_snapfiles`. The device creation goes through overlaybd-ublkd;
+the VMM resume path follows AgentENV and other firecracker sandbox implementation.
+
+This tool **bypasses every control plane** (no fast-sandbox fastpath/CRD/reconciler
+involvement). It is a single-host data-plane tool.
+
+## Decisions
+
+### ADR-001 Code location: a standalone binary inside the fast-sandbox repo
+
+- **Decision**: the code lives in `fast-sandbox/cmd/template-vm/` (Go, cobra), as a
+  sibling of fastctl. It is NOT wired into fastctl's subcommand tree and does NOT
+  reuse the fastpath gRPC stack.
+- **Rationale**: the user explicitly requested a standalone CLI hosted in the
+  fast-sandbox repository. With zero control-plane interaction, a separate binary
+  prevents data-plane dependencies (oras, ublkd client) from leaking into the
+  control plane via the layering rules enforced by
+  `internal/architecture/dependencies_test.go`.
+- **Trade-off**: fastctl's endpoint/config plumbing cannot be reused — this tool
+  does not need it either (there is no server to talk to).
+
+### ADR-002 Device creation: overlaybd-ublkd (HTTP over unix socket)
+
+- **Decision**: call the overlaybd-ublkd control API: `POST /v1/add {"config": <path>}` /
+  `POST /v1/del {"dev_id": N}` / `GET /v1/list`. The socket defaults to
+  `/var/run/overlaybd-ublk/ublkd.sock` (overridable via flag).
+- **Rationale**: user requirement, per the official overlaybd
+  [standalone-usage.md](https://github.com/containerd/overlaybd/blob/main/docs/standalone-usage.md#overlaybd-ublkd-many-devices-in-one-process).
+- **Rejected alternatives** (investigation findings):
+  - AgentENV `uvm-ublk-daemon`: JSON RPC over a unix socket
+    (`DaemonRequest::CreateOverlaybd`), not HTTP, and coupled to AgentENV's
+    image.json/config model;
+  - accelerated-container-image `overlaybd-attacher`: tcmu-based, not ublk.
+- **Deployment assumption**: ublkd is pre-deployed via systemd (upstream unit
+  template `/opt/overlaybd/overlaybd-ublkd.service`); the CLI only checks socket
+  reachability at startup and never launches the daemon itself.
+- **Caveats**: `resize` needs kernel 6.11+ (UBLK_F_UPDATE_SIZE) and is out of scope;
+  daemon-owned devices must be deleted through its API; mounting a writable image
+  twice is rejected by the daemon (upper-layer exclusivity protection).
+
+### ADR-003 Template resolution: pull manifests with oras, generate config.v1.json in the CLI
+
+- **Decision**: the CLI uses an oras/distribution client with the dockerAuth from
+  template.json to pull both image manifests, then generates `config.v1.json`
+  the way accelerated-container-image does
+  (`OverlayBDBSConfig{lowers[], upper?, repoBlobUrl}`, see `pkg/types/types.go`).
+- **Details**: the rootfs config carries an `upper` (a local hybrid writable layer;
+  create the empty data/index files before `add`); the snapfiles config has no
+  `upper` (read-only). `repoBlobUrl` points at
+  `https://<registry>/v2/<repo>/blobs`; overlaybd performs range reads against it
+  at runtime.
+- **Credential handoff**: the dockerAuth (a docker config json string) is merged into
+  overlaybd's global credential file (default `/opt/overlaybd/cred.json`; overlaybd
+  lazily reloads it per remote_path), otherwise on-demand pulls fail with 401.
+  The merge must be atomic (tmp+rename) and file-locked so concurrent CLI
+  instances cannot clobber each other.
+
+### ADR-004 Kernel: host-local, validated against metadata, flag-overridable
+
+- **Decision**: the kernel is not distributed with the images. The
+  `metadata.json.kernel_version` maps to a vmlinux under a host convention
+  directory (default `/opt/template-vm/kernels/vmlinux-<kernel_version>`,
+  overridable with `--kernel`). A missing file is a hard error.
+
+### ADR-005 memfile: raw memory file mmap (Firecracker File backend)
+
+- **Decision**: after read-only mounting the snapfiles device, firecracker
+  `PUT /snapshot/load` uses
+  `mem_backend = {backend_type: "File", backend_path: <mnt>/memfile}`.
+- **Rationale**: The memfile lives inside ext4 on a ublk device, so page faults 
+  flow through ext4 → ublk → overlaybd remote range reads; the guest's first 
+  writes are copy-on-written into anonymous pages inside the firecracker process 
+  and never touch the read-only layer.
+
+### ADR-006 In-disk layout convention: ext4 + fixed paths
+
+- **Decision**: the snapfiles device is ext4 with fixed paths after mount:
+  `/vmstate.bin`, `/memfile`, `/metadata.json`. This is an **existing external
+  convention that the CLI adapts to**; changes on the builder side require
+  versioned announcements.
+- **Risk**: the convention is currently only verbal; verify paths and the FS type
+  against a real sample image during integration testing.
+
+### ADR-007 Machine spec source: metadata.json is authoritative, flags may override
+
+- **Decision**: `vcpu_count / memory_mb / disk_size_mb` etc. come from
+  metadata.json; the CLI offers `--vcpu / --memory-mb / --kernel` overrides.
+  Pre-flight validation: `hypervisor_type` currently supports only `firecracker`
+  (any other value, e.g. `dragonball`, fails with Unsupported — a VMM abstraction
+  seam is reserved); `cpu_arch` must match the host; the local firecracker binary
+  version must be compatible with `firecracker_version` (mismatch is an error by
+  default, downgraded to a warning with `--force`).
+
+### ADR-008 rootfs upper: hybrid writable layer, no commit by default
+
+- **Decision**: each sandbox gets its own LSMT hybrid-mode upper (data/index in the
+  state directory), discarded when the VM is destroyed. The `overlaybd-commit` +
+  push-back-to-registry flow triggered by sandbox snapshot requests is **out of
+  scope for this iteration**; the extension point is reserved.
+
+### ADR-009 Command surface and lifecycle: create / list / delete
+
+- **Decision**: semantics follow aenv (start = bring a sandbox up from a template;
+  no start/resume distinction). The MVP has three commands:
+  - `template-vm create -f template.json [--kernel ...] [--vcpu ...] [--network=none]`
+  - `template-vm list`: enumerate the state directory + verify pid liveness
+  - `template-vm delete <sandbox_id>`: kill firecracker → umount snapfiles →
+    ublkd `del` both devices → remove the state directory (strictly reversed
+    order; every step reports failures but cleanup continues best-effort)
+- **Layout**: state directory `/var/lib/template-vm/sandboxes/<id>/` (upper,
+  config.v1.json, mount point, state.json); runtime directory
+  `/run/template-vm/sandboxes/<id>/` (api socket, serial log).
+
+### ADR-010 Networking: NetworkProvider abstraction, MVP supports none
+
+- **Decision**: metadata.json's `network{host_dev_name, mac}` belongs to an existing
+  networking stack (`cnid-*`). The CLI defines a NetworkProvider interface
+  (Acquire(metadata) → device + cleanup callback); the concrete integration spec
+  is **pending input from the networking side**. The MVP defaults to
+  `--network=none` so the snapshot-resume main path is unblocked.
+- **Open input**: the device-allocation interface of that networking stack (to be
+  captured in a follow-up ADR once provided).
+
+## Create flow (strictly ordered; failures roll back in reverse)
+
+1. Parse template.json; verify sandbox_id is free (state directory absent).
+2. oras-pull the rootfs and snapfiles manifests → ordered layer digest lists.
+3. Merge dockerAuth into `/opt/overlaybd/cred.json` (atomic write).
+4. rootfs: create the hybrid upper (data/index) → generate config.v1.json with
+   upper → ublkd `/v1/add` → record dev_id.
+5. snapfiles: generate read-only config.v1.json → `/v1/add` → mount -o ro →
+   read metadata.json / validate (ADR-007).
+6. Resolve the kernel path (ADR-004); launch the version-matched firecracker
+   (api socket under the runtime directory).
+7. Resume: `PUT /drives/rootfs` (path=/dev/ublkbN, drive_id consistent with
+   vmstate; PATCH first if not) → `PUT /snapshot/load` (vmstate.bin + memfile
+   File backend) → networking (NetworkProvider or none) → `PATCH /vm` resume.
+8. Persist the state file; print sandbox info (id, pid, ublk devices, socket path).
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Existing templates with hypervisor_type=dragonball cannot be resumed | Hard pre-flight validation with a clear error; VMM abstraction reserved |
+| vmstate version incompatible with the host firecracker | `firecracker_version` check; `--force` escape hatch |
+| In-disk layout is only a verbal convention | Verify with a real image during integration; paths centralized in one constants block |
+| Concurrent cred.json clobbering | Atomic write (tmp+rename) + file lock |
+| ublkd device leakage (CLI crash) | state.json records dev_ids; delete is idempotent; a janitor may be added later |
+| Kernel requirements | Baseline ublk support suffices (overlaybd upstream validated on a 5.10 backport kernel; 6.11+ only needed for resize) |

--- a/docs/design/adr-template-vm-cli.md
+++ b/docs/design/adr-template-vm-cli.md
@@ -1,0 +1,143 @@
+# ADR: template-vm CLI —— 从远程 template 创建 VM 的独立 CLI
+
+> 文档类型：架构决策记录（ADR）
+>
+> 日期：2026-09-10
+>
+> 状态：已确认（三轮设计访谈收敛）
+>
+> 配套术语表：[template-vm-cli-glossary.md](./template-vm-cli-glossary.md)
+
+## 背景
+
+需要一个独立 CLI 工具：输入一份 `template.json`（registry repo + template_id +
+dockerAuth），把存放在远程 OCI registry 中的模板（一对 overlaybd 镜像：
+`${repo}:${template_id}_rootfs` 与 `${repo}:${template_id}_snapfiles`）在本机
+恢复为一台运行中的 VM。创盘走 overlaybd-ublkd, VMM 恢复路径参考 AgentENV 或其他
+sandbox项目的实现。
+
+本工具**不经过任何控制面**（不碰 fast-sandbox 的 fastpath/CRD/reconciler），
+是单机数据面工具。
+
+## 决策清单
+
+### ADR-001 代码落点：fast-sandbox 仓库内独立二进制
+
+- **决策**：代码放 `fast-sandbox/cmd/template-vm/`（Go，cobra），与 fastctl 平级；
+  不挂进 fastctl 子命令树，不复用 fastpath gRPC。
+- **理由**：用户明确「独立 CLI + 放 fast-sandbox 仓库」。与 fast-sandbox 控制面
+  零交互，独立二进制避免 `internal/architecture/dependencies_test.go` 的分层
+  规则把数据面依赖（oras、ublkd client）洩入控制面。
+- **取舍**：无法复用 fastctl 的 endpoint/config 基建——本工具也不需要（无服务端）。
+
+### ADR-002 创盘通道：overlaybd-ublkd（HTTP over unix socket）
+
+- **决策**：调用 overlaybd-ublkd 的控制 API：`POST /v1/add {"config": <path>} /
+  POST /v1/del {"dev_id": N} / GET /v1/list`，socket 默认
+  `/var/run/overlaybd-ublk/ublkd.sock`（flag 可覆盖）。
+- **理由**：用户指定，参考 overlaybd 官方
+  [standalone-usage.md](https://github.com/containerd/overlaybd/blob/main/docs/standalone-usage.md#overlaybd-ublkd-many-devices-in-one-process)。
+- **排除项**（调研结论）：
+  - AgentENV `uvm-ublk-daemon`：unix socket + JSON RPC（`DaemonRequest::CreateOverlaybd`），
+    非 HTTP，且与 AgentENV 的 image.json/config 模型耦合；
+  - accelerated-container-image `overlaybd-attacher`：tcmu 路径，非 ublk。
+- **部署假设**：ublkd 由 systemd 预部署（官方 unit 模板
+  `/opt/overlaybd/overlaybd-ublkd.service`）；CLI 启动时仅做 socket 可达性检查，
+  不负责拉起 daemon。
+- **注意**：`resize` 需要内核 6.11+（UBLK_F_UPDATE_SIZE），本期不用；daemon 持有
+  的设备必须经其 API 删除；writable 镜像二次挂载会被 daemon 拒绝（upper 排他保护）。
+
+### ADR-003 模板解析：oras 拉 manifest，CLI 生成 config.v1.json
+
+- **决策**：CLI 用 oras/distribution client + template.json 的 dockerAuth 拉取两个
+  镜像的 manifest，按 accelerated-container-image 的方式生成
+  `config.v1.json`（`OverlayBDBSConfig{lowers[], upper?, repoBlobUrl}`，
+  见 `pkg/types/types.go`）。
+- **细节**：rootfs 的 config 含 `upper`（本地 hybrid 可写层，先创建空 data/index
+  再 add）；snapfiles 的 config 无 `upper`（只读）。`repoBlobUrl` 指向
+  `https://<registry>/v2/<repo>/blobs`，overlaybd 运行时按 range 拉块。
+- **凭证转写**：dockerAuth（docker config json）合入 overlaybd 全局凭证文件
+  （默认 `/opt/overlaybd/cred.json`，overlaybd 按 remote_path 惰性 reload），
+  否则按需拉块 401。合入需原子写 + 备份，避免并发 CLI 实例互相覆盖。
+
+### ADR-004 kernel：宿主机本地，metadata 校验 + flag 覆盖
+
+- **决策**：kernel 不随镜像分发。`metadata.json.kernel_version` 映射到宿主机约定
+  目录下的 vmlinux（默认约定 `/opt/template-vm/kernels/vmlinux-<kernel_version>`，
+  可用 `--kernel` 显式覆盖）；文件缺失则报错。
+
+### ADR-005 memfile：裸内存文件 mmap（Firecracker Backend File）
+
+- **决策**：snapfiles 盘只读挂载后，firecracker `PUT /snapshot/load` 使用
+  `mem_backend = {backend_type: "File", backend_path: <mnt>/memfile}`。
+- **理由**：memfile 位于 ublk 块设备上的 ext4 内，page fault
+  沿 ext4 → ublk → overlaybd 远端 range read 链路惰性拉取；guest 首写在
+  firecracker 进程地址空间内 COW 为匿名页，不污染只读层。
+
+### ADR-006 盘内布局约定：ext4 + 固定路径
+
+- **决策**：snapfiles 设备为 ext4，挂载后固定路径 `/vmstate.bin`、`/memfile`、
+  `/metadata.json`。**既有规范，CLI 适配**；构建侧改动需版本化公告。
+- **风险**：规范目前仅有口头约定，联调时需用真实样例镜像验证路径与 FS 类型。
+
+### ADR-007 规格来源：metadata.json 权威 + flag 覆盖
+
+- **决策**：`vcpu_count / memory_mb / disk_size_mb` 等以 metadata.json 为准；
+  CLI 提供 `--vcpu / --memory-mb / --kernel` 覆盖。启动前校验：
+  `hypervisor_type` 当前仅支持 `firecracker`（其他值报 Unsupported，预留 VMM
+  抽象接口）；`cpu_arch` 与宿主一致；本机 firecracker 二进制版本与
+  `firecracker_version` 兼容（不兼容默认报错，`--force` 可降级为警告）。
+
+### ADR-008 rootfs upper：hybrid 可写层，默认不 commit
+
+- **决策**：每 sandbox 一份 LSMT hybrid 模式 upper（data/index 存于
+  状态目录），VM 销毁即丢弃。sandbox 快照触发的 `overlaybd-commit` + 推回
+  registry 流程**本期不实现**，接口位置预留。
+
+### ADR-009 命令面与生命周期：create / list / delete
+
+- **决策**：参考 aenv 语义（start = 从模板直接拉起，不区分 start/resume），
+  MVP 三命令：
+  - `template-vm create -f template.json [--kernel ...] [--vcpu ...] [--network=none]`
+  - `template-vm list`：枚举状态目录 + 校验 pid 存活
+  - `template-vm delete <sandbox_id>`：杀 firecracker → umount snapfiles →
+    ublkd `del` 两个设备 → 清理状态目录（顺序严格逆序，任何一步失败都报告并继续
+    尽最大努力清理）
+- **布局**：状态目录 `/var/lib/template-vm/sandboxes/<id>/`（upper、
+  config.v1.json、挂载点、state.json）；运行目录 `/run/template-vm/sandboxes/<id>/`
+  （api socket、serial 日志）。
+
+### ADR-010 网络：NetworkProvider 抽象，MVP 支持 none
+
+- **决策**：metadata.json 的 `network{host_dev_name, mac}` 属既有网络体系
+  （`cnid-*`）。CLI 定义 NetworkProvider 接口（Acquire(metadata) → 设备 +
+  清理回调），具体对接规范**待网络侧提供**；MVP 默认 `--network=none` 跳过，
+  不阻塞快照恢复主链路。
+- **未决输入**：网络体系的设备分配接口（待用户提供后另起 ADR 补充）。
+
+## create 主流程（编排顺序，严格分步、失败逆序回滚）
+
+1. 解析 template.json；校验 sandbox_id 未占用（状态目录不存在）。
+2. oras 拉取 rootfs / snapfiles 两个 manifest → 层 digest 列表。
+3. dockerAuth 合入 `/opt/overlaybd/cred.json`（原子写）。
+4. rootfs：创建 hybrid upper（data/index）→ 生成含 upper 的 config.v1.json →
+   ublkd `/v1/add` → 记录 dev_id。
+5. snapfiles：生成只读 config.v1.json → `/v1/add` → mount -o ro →
+   读 metadata.json / 校验（ADR-007）。
+6. 解析 kernel 路径（ADR-004）；启动匹配版本的 firecracker（api socket 于
+   运行目录）。
+7. 恢复：`PUT /drives/rootfs`（path=/dev/ublkbN，drive_id 与 vmstate 一致；
+   不一致则先 PATCH）→ `PUT /snapshot/load`（vmstate.bin + memfile File backend）
+   → 网络（NetworkProvider 或 none）→ `PATCH /vm` resume。
+8. 落状态文件，输出 sandbox 信息（id、pid、ublk 设备、socket 路径）。
+
+## 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| hypervisor_type=dragonball 的存量模板无法恢复 | 启动前硬校验 + 明确报错；VMM 抽象预留 |
+| vmstate 版本与宿主 firecracker 不兼容 | `firecracker_version` 校验；`--force` 逃生门 |
+| 盘内布局仅口头约定 | 联调用真实镜像验证；路径集中为一个常量区块 |
+| cred.json 并发覆盖 | 原子写（tmp+rename）+ 文件锁 |
+| ublkd 设备泄漏（CLI 崩溃后） | state.json 记录 dev_id；delete 幂等；后续可加 janitor |
+| 内核要求 | ublk 基础能力即可（overlaybd 官方在 5.10 backport 内核验证过；6.11+ 仅 resize 需要） |

--- a/docs/design/template-vm-cli-glossary.md
+++ b/docs/design/template-vm-cli-glossary.md
@@ -1,0 +1,52 @@
+# Glossary: template-vm CLI
+
+> 文档类型：术语表
+>
+> 日期：2026-09-10
+>
+> 配套 ADR：[adr-template-vm-cli.md](./adr-template-vm-cli.md)
+
+本术语表统一「从远程 template 创建 VM」的 CLI 工具（下称 **template-vm**）涉及的
+全部领域名词。
+
+## 输入与标识
+
+| 术语 | 定义 |
+|------|------|
+| **template.json** | CLI 的唯一输入清单。字段：`sandbox_id`、`template.{repo, template_id, auth}`、`metadata`（透传的用户元数据，当前为空语义，预留）。 |
+| **Template（模板）** | 远程 OCI registry 中**一对** overlaybd 镜像的合称，由 `repo + template_id` 唯一标识。不含 K8s SandboxTemplate CRD 语义（本工具不经过任何控制面）。 |
+| **rootfs 镜像** | `${repo}:${template_id}_rootfs`。overlaybd 格式，承载 VM 系统盘全部数据，恢复时以 virtio-blk 通入 guest。 |
+| **snapfiles 镜像** | `${repo}:${template_id}_snapfiles`。overlaybd 格式，盘内为 ext4 文件系统，存放恢复 VM 必需的描述信息与内存状态（见「盘内布局约定」）。 |
+| **sandbox_id** | 用户在 template.json 中指定的本地唯一标识（如 `tianping-test`），是本地状态目录、ublk 设备归属、list/delete 的主键。 |
+
+## 镜像与设备
+
+| 术语 | 定义 |
+|------|------|
+| **overlaybd** | 按需加载的块设备格式（LSMT 索引 + 数据段），支持从 registry 按 range 远程拉块。项目：<https://github.com/containerd/overlaybd>。 |
+| **config.v1.json** | overlaybd 设备配置文件，结构为 `OverlayBDBSConfig{lowers[], upper?, repoBlobUrl}`（定义见 accelerated-container-image `pkg/types/types.go`）。CLI 负责依据镜像 manifest 生成它。无 `upper` = 只读设备；有 `upper` = 可写设备。 |
+| **overlaybd-ublkd** | overlaybd 官方集中式 ublk daemon（单进程托管多设备，共享一棵 cache 树）。控制 API 为 **HTTP over root-only unix socket**（默认 `/var/run/overlaybd-ublk/ublkd.sock`）：`POST /v1/add {config}` / `POST /v1/del {dev_id}` / `GET /v1/list` / `POST /v1/shutdown`。 |
+| **ublk 设备** | `/dev/ublkbN`，由 overlaybd-ublkd 创建。rootfs 与 snapfiles 各占一个。 |
+| **upper（可写层）** | rootfs 设备的可写顶层，使用 LSMT **hybrid** 模式（`RWType::Hybrid`，`FLAG_HYBRID_RW=5`，与 sparse_rw 互斥）。每 sandbox 一份本地 data/index 文件。默认**不 commit、不推回 registry**；sandbox 快照请求触发的 commit 回写属后续迭代，本期不实现。 |
+| **lower（只读层）** | overlaybd 镜像在 registry 中的各数据层，以 digest 寻址，写入 config.v1.json 的 `lowers[]`。 |
+
+## 快照恢复
+
+| 术语 | 定义 |
+|------|------|
+| **vmstate.bin** | VMM 私有序列化的虚拟机状态（vCPU 寄存器、设备状态、VM 配置）。版本敏感：恢复侧 VMM 版本必须与拍摄侧兼容。 |
+| **memfile** | guest 物理内存的**裸文件**（非 LSMT 层）。恢复时 VMM 直接 `mmap` 它；按需加载发生在块层：page fault → ext4 → ublk → overlaybd 远端 range read。 |
+| **metadata.json** | snapfiles 盘内的 VM 规格**权威**来源。字段含 `vcpu_count / memory_mb / disk_size_mb / firecracker_version / kernel_version / hypervisor_type / network{host_dev_name, mac} / cpu_arch / cpu_model / envd_version / default_user / default_workdir / created_at` 等。CLI flag 可覆盖其中规格类字段。 |
+| **hypervisor_type** | metadata.json 字段，决定恢复路径分派。当前仅实现 `firecracker`；`dragonball` 等其他值报 `Unsupported`（预留 VMM 抽象）。 |
+| **envd** | guest 内 agent（OpenSandbox 运行时），metadata.json 记录其版本；本期 CLI 不依赖 exec 通道，字段仅作记录与兼容校验参考。 |
+
+## 布局与运行时
+
+| 术语 | 定义 |
+|------|------|
+| **盘内布局约定** | snapfiles ublk 设备（ext4）挂载后的固定路径：`/vmstate.bin`、`/memfile`、`/metadata.json`。为既有规范，CLI 适配之。 |
+| **状态目录（home）** | `/var/lib/template-vm/sandboxes/<sandbox_id>/`：upper data/index、config.v1.json、snapfiles 挂载点、状态记录文件（pid、dev_id、挂载点）。持久，delete 时清理。 |
+| **运行目录（runtime）** | `/run/template-vm/sandboxes/<sandbox_id>/`：firecracker API socket、serial 日志。易失，宿主机重启即失效。 |
+| **kernel 解析** | metadata.json 的 `kernel_version` → 宿主机本地 vmlinux 路径（约定目录 + flag 覆盖）。kernel 不随镜像分发。 |
+| **凭证转写** | template.json 的 `auth.dockerAuth`（docker config json 字符串）→ overlaybd 全局凭证文件（默认 `/opt/overlaybd/cred.json`，`credentialFilePath`）。CLI 负责合入，否则按需拉块返回 401。 |
+| **既有网络体系** | metadata.json `network.host_dev_name`（形如 `cnid-*`）所属的网络栈。CLI 通过 NetworkProvider 抽象对接；接口规范待网络侧提供，MVP 支持 `--network=none` 跳过。 |


### PR DESCRIPTION

Design interview outcome for a standalone single-host data-plane CLI that restores a VM from a remote OCI-registry template (a pair of overlaybd images: ${repo}:${template_id}_rootfs / _snapfiles), with decisions:

- standalone binary cmd/template-vm, bypassing all control planes
- device creation via overlaybd-ublkd HTTP-over-uds API (/v1/add|del|list)
- oras-pulled manifests -> config.v1.json; dockerAuth merged into cred.json
- memfile as raw file mmap (Firecracker File backend); lazy loading still happens at the block layer via ublk + overlaybd range reads
- metadata.json authoritative for machine spec, flags may override; hypervisor_type dispatch (firecracker only for now)
- rootfs hybrid writable upper, discarded on delete (no commit-back yet)
- command surface: create / list / delete

Includes Chinese ADR, English ADR, and the glossary.